### PR TITLE
M3a: archai.yaml schema definition + loader

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,9 @@ go 1.25.1
 
 require (
 	github.com/spf13/cobra v1.10.2
+	golang.org/x/mod v0.32.0
 	golang.org/x/tools v0.41.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -41,7 +43,6 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/exp v0.0.0-20240909161429-701f63a606c0 // indirect
 	golang.org/x/image v0.20.0 // indirect
-	golang.org/x/mod v0.32.0 // indirect
 	golang.org/x/net v0.49.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.40.0 // indirect
@@ -49,7 +50,6 @@ require (
 	golang.org/x/text v0.33.0 // indirect
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	oss.terrastruct.com/d2 v0.7.1 // indirect
 	oss.terrastruct.com/util-go v0.0.0-20250213174338-243d8661088a // indirect
 )

--- a/internal/overlay/config.go
+++ b/internal/overlay/config.go
@@ -1,0 +1,38 @@
+// Package overlay provides the schema and loader for archai.yaml,
+// the user-authored overlay file that describes the target architecture
+// (layers, layer rules, aggregates, and configs) for a Go module.
+//
+// The overlay is intentionally declarative: it names architectural
+// concepts (layers, aggregates) and maps them to concrete Go packages
+// and types. Later milestones (M3b, M3c) consume this Config to drive
+// analysis, diffing, and CLI behavior; this package only defines the
+// schema, loads it from disk, and validates it in isolation.
+package overlay
+
+// Config is the top-level archai.yaml document.
+//
+// Field semantics:
+//   - Module: the Go module path (e.g. "github.com/kgatilin/archai").
+//     Must match the module directive in go.mod.
+//   - Layers: named architectural layers, each mapped to one or more
+//     package globs (e.g. "internal/domain/...").
+//   - LayerRules: per-layer allow-list of other layers it may depend on.
+//     A layer absent from LayerRules is treated as "no outbound
+//     dependencies allowed" by downstream consumers.
+//   - Aggregates: named domain aggregates rooted at a single type.
+//   - Configs: fully-qualified type names to surface as configuration
+//     entry points.
+type Config struct {
+	Module     string               `yaml:"module"`
+	Layers     map[string][]string  `yaml:"layers"`
+	LayerRules map[string][]string  `yaml:"layer_rules"`
+	Aggregates map[string]Aggregate `yaml:"aggregates"`
+	Configs    []string             `yaml:"configs"`
+}
+
+// Aggregate describes a domain aggregate by its root type.
+// Root is a fully-qualified type name, e.g.
+// "github.com/kgatilin/archai/internal/domain.PackageModel".
+type Aggregate struct {
+	Root string `yaml:"root"`
+}

--- a/internal/overlay/load.go
+++ b/internal/overlay/load.go
@@ -1,0 +1,30 @@
+package overlay
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+
+	yamlv3 "gopkg.in/yaml.v3"
+)
+
+// Load reads the archai.yaml file at path, parses it into a Config,
+// and returns it. Errors are wrapped with the source path so callers
+// can report them clearly.
+//
+// Load does not validate semantic consistency (e.g. module matches
+// go.mod, layer globs are well-formed); use Validate for that.
+func Load(path string) (*Config, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("overlay: reading %s: %w", path, err)
+	}
+
+	var cfg Config
+	dec := yamlv3.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	if err := dec.Decode(&cfg); err != nil {
+		return nil, fmt.Errorf("overlay: parsing %s: %w", path, err)
+	}
+	return &cfg, nil
+}

--- a/internal/overlay/load_test.go
+++ b/internal/overlay/load_test.go
@@ -1,0 +1,105 @@
+package overlay
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const sampleArchaiYAML = `module: github.com/example/app
+
+layers:
+  domain:
+    - internal/domain/...
+  service:
+    - internal/service/...
+
+layer_rules:
+  service:
+    - domain
+
+aggregates:
+  Order:
+    root: github.com/example/app/internal/domain.Order
+
+configs:
+  - github.com/example/app/internal/config.AppConfig
+`
+
+func writeTempFile(t *testing.T, name, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+	return path
+}
+
+func TestLoad_ValidYAML(t *testing.T) {
+	path := writeTempFile(t, "archai.yaml", sampleArchaiYAML)
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load returned unexpected error: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("Load returned nil config")
+	}
+
+	if cfg.Module != "github.com/example/app" {
+		t.Errorf("Module = %q, want github.com/example/app", cfg.Module)
+	}
+	if got := len(cfg.Layers); got != 2 {
+		t.Errorf("len(Layers) = %d, want 2", got)
+	}
+	if globs := cfg.Layers["domain"]; len(globs) != 1 || globs[0] != "internal/domain/..." {
+		t.Errorf("Layers[domain] = %v, want [internal/domain/...]", globs)
+	}
+	if rules := cfg.LayerRules["service"]; len(rules) != 1 || rules[0] != "domain" {
+		t.Errorf("LayerRules[service] = %v, want [domain]", rules)
+	}
+	if agg, ok := cfg.Aggregates["Order"]; !ok ||
+		agg.Root != "github.com/example/app/internal/domain.Order" {
+		t.Errorf("Aggregates[Order] = %+v, want root=...domain.Order", agg)
+	}
+	if len(cfg.Configs) != 1 ||
+		cfg.Configs[0] != "github.com/example/app/internal/config.AppConfig" {
+		t.Errorf("Configs = %v, want one AppConfig entry", cfg.Configs)
+	}
+}
+
+func TestLoad_MissingFile(t *testing.T) {
+	_, err := Load(filepath.Join(t.TempDir(), "does-not-exist.yaml"))
+	if err == nil {
+		t.Fatal("expected error for missing file, got nil")
+	}
+	if !strings.Contains(err.Error(), "does-not-exist.yaml") {
+		t.Errorf("error should mention path, got: %v", err)
+	}
+}
+
+func TestLoad_InvalidYAML(t *testing.T) {
+	path := writeTempFile(t, "bad.yaml", "module: [unterminated\n")
+
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected parse error, got nil")
+	}
+	if !strings.Contains(err.Error(), "bad.yaml") {
+		t.Errorf("error should mention path, got: %v", err)
+	}
+}
+
+func TestLoad_UnknownField(t *testing.T) {
+	// KnownFields(true) should reject unknown top-level keys so typos
+	// in archai.yaml fail loudly instead of silently being ignored.
+	path := writeTempFile(t, "archai.yaml",
+		"module: github.com/example/app\nlayer:\n  domain: [internal/domain/...]\n")
+
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected error for unknown field, got nil")
+	}
+}

--- a/internal/overlay/validate.go
+++ b/internal/overlay/validate.go
@@ -1,0 +1,196 @@
+package overlay
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"golang.org/x/mod/modfile"
+)
+
+// Validate checks that cfg is internally consistent and agrees with
+// the go.mod at goModPath.
+//
+// Specifically it enforces:
+//   - cfg.Module is non-empty and matches the module directive in go.mod.
+//   - Each layer has at least one package glob, and every glob looks
+//     syntactically reasonable (non-empty, no whitespace, no absolute
+//     paths, at most one trailing "...").
+//   - LayerRules references only known layer names (both keys and
+//     values).
+//   - Every Aggregate has a non-empty, well-formed fully-qualified
+//     Root type name (must contain a '.' separating package path from
+//     type name).
+//   - Every entry in Configs is a well-formed fully-qualified type name.
+//
+// Errors are joined (errors.Join) so callers can see every problem at
+// once rather than discovering them one edit at a time.
+func Validate(cfg *Config, goModPath string) error {
+	if cfg == nil {
+		return errors.New("overlay: nil config")
+	}
+
+	var errs []error
+
+	if strings.TrimSpace(cfg.Module) == "" {
+		errs = append(errs, errors.New("overlay: module is required"))
+	} else if goModPath != "" {
+		declared, err := readGoModModule(goModPath)
+		if err != nil {
+			errs = append(errs, err)
+		} else if declared != cfg.Module {
+			errs = append(errs, fmt.Errorf(
+				"overlay: module mismatch: archai.yaml declares %q but %s declares %q",
+				cfg.Module, goModPath, declared))
+		}
+	}
+
+	if len(cfg.Layers) == 0 {
+		errs = append(errs, errors.New("overlay: at least one layer is required"))
+	}
+	for _, name := range sortedKeys(cfg.Layers) {
+		globs := cfg.Layers[name]
+		if strings.TrimSpace(name) == "" {
+			errs = append(errs, errors.New("overlay: layer name must not be empty"))
+			continue
+		}
+		if len(globs) == 0 {
+			errs = append(errs, fmt.Errorf("overlay: layer %q has no package globs", name))
+			continue
+		}
+		for _, g := range globs {
+			if err := validateGlob(name, g); err != nil {
+				errs = append(errs, err)
+			}
+		}
+	}
+
+	for _, layer := range sortedKeys(cfg.LayerRules) {
+		allowed := cfg.LayerRules[layer]
+		if _, ok := cfg.Layers[layer]; !ok {
+			errs = append(errs, fmt.Errorf(
+				"overlay: layer_rules references unknown layer %q", layer))
+		}
+		for _, target := range allowed {
+			if strings.TrimSpace(target) == "" {
+				errs = append(errs, fmt.Errorf(
+					"overlay: layer_rules for %q contains empty target", layer))
+				continue
+			}
+			if _, ok := cfg.Layers[target]; !ok {
+				errs = append(errs, fmt.Errorf(
+					"overlay: layer_rules for %q allows unknown layer %q",
+					layer, target))
+			}
+		}
+	}
+
+	for _, name := range sortedKeys(cfg.Aggregates) {
+		agg := cfg.Aggregates[name]
+		if strings.TrimSpace(name) == "" {
+			errs = append(errs, errors.New("overlay: aggregate name must not be empty"))
+			continue
+		}
+		if err := validateTypeRef(
+			fmt.Sprintf("aggregate %q root", name), agg.Root); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	for i, ref := range cfg.Configs {
+		if err := validateTypeRef(
+			fmt.Sprintf("configs[%d]", i), ref); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+// validateGlob checks a package glob for obvious syntactic problems.
+// It deliberately does not check the filesystem — that's a concern
+// for downstream consumers that actually load packages.
+func validateGlob(layer, glob string) error {
+	if strings.TrimSpace(glob) == "" {
+		return fmt.Errorf("overlay: layer %q has empty package glob", layer)
+	}
+	if glob != strings.TrimSpace(glob) {
+		return fmt.Errorf(
+			"overlay: layer %q glob %q has leading/trailing whitespace",
+			layer, glob)
+	}
+	if strings.ContainsAny(glob, " \t\n") {
+		return fmt.Errorf(
+			"overlay: layer %q glob %q contains whitespace", layer, glob)
+	}
+	if strings.HasPrefix(glob, "/") {
+		return fmt.Errorf(
+			"overlay: layer %q glob %q must be a relative package path",
+			layer, glob)
+	}
+	// Only a single trailing "..." is allowed; interior "..." is invalid.
+	if idx := strings.Index(glob, "..."); idx >= 0 && idx != len(glob)-3 {
+		return fmt.Errorf(
+			"overlay: layer %q glob %q: \"...\" may only appear at the end",
+			layer, glob)
+	}
+	return nil
+}
+
+// validateTypeRef checks that s looks like a fully-qualified Go type
+// reference (package path + "." + type name). It does not resolve the
+// type; that's left to downstream analysis.
+func validateTypeRef(context, s string) error {
+	if strings.TrimSpace(s) == "" {
+		return fmt.Errorf("overlay: %s is empty", context)
+	}
+	if s != strings.TrimSpace(s) {
+		return fmt.Errorf(
+			"overlay: %s %q has leading/trailing whitespace", context, s)
+	}
+	dot := strings.LastIndex(s, ".")
+	if dot <= 0 || dot == len(s)-1 {
+		return fmt.Errorf(
+			"overlay: %s %q is not a fully-qualified type reference "+
+				"(expected \"pkg/path.TypeName\")", context, s)
+	}
+	pkg, name := s[:dot], s[dot+1:]
+	if strings.ContainsAny(pkg, " \t\n") || strings.ContainsAny(name, " \t\n./") {
+		return fmt.Errorf(
+			"overlay: %s %q is not a well-formed type reference", context, s)
+	}
+	return nil
+}
+
+// readGoModModule reads the module directive from the go.mod file at
+// path. It uses golang.org/x/mod/modfile (already a transitive
+// dependency via golang.org/x/tools) for a forgiving, spec-correct
+// parse.
+func readGoModModule(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("overlay: reading %s: %w", path, err)
+	}
+	f, err := modfile.Parse(filepath.Base(path), data, nil)
+	if err != nil {
+		return "", fmt.Errorf("overlay: parsing %s: %w", path, err)
+	}
+	if f.Module == nil || f.Module.Mod.Path == "" {
+		return "", fmt.Errorf("overlay: %s has no module directive", path)
+	}
+	return f.Module.Mod.Path, nil
+}
+
+// sortedKeys returns the keys of m in lexical order so validation
+// errors appear deterministically regardless of map iteration order.
+func sortedKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/overlay/validate_test.go
+++ b/internal/overlay/validate_test.go
@@ -1,0 +1,215 @@
+package overlay
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeGoMod(t *testing.T, module string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "go.mod")
+	content := "module " + module + "\n\ngo 1.21\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+	return path
+}
+
+// validConfig returns a fully-valid Config paired with a matching go.mod
+// path. Individual tests mutate fields to exercise specific errors.
+func validConfig(t *testing.T) (*Config, string) {
+	t.Helper()
+	return &Config{
+		Module: "github.com/example/app",
+		Layers: map[string][]string{
+			"domain":  {"internal/domain/..."},
+			"service": {"internal/service/..."},
+		},
+		LayerRules: map[string][]string{
+			"service": {"domain"},
+		},
+		Aggregates: map[string]Aggregate{
+			"Order": {Root: "github.com/example/app/internal/domain.Order"},
+		},
+		Configs: []string{"github.com/example/app/internal/config.AppConfig"},
+	}, writeGoMod(t, "github.com/example/app")
+}
+
+func TestValidate_ValidConfig(t *testing.T) {
+	cfg, goMod := validConfig(t)
+	if err := Validate(cfg, goMod); err != nil {
+		t.Fatalf("Validate returned unexpected error: %v", err)
+	}
+}
+
+func TestValidate_NilConfig(t *testing.T) {
+	if err := Validate(nil, ""); err == nil {
+		t.Fatal("expected error for nil config")
+	}
+}
+
+func TestValidate_ModuleMismatch(t *testing.T) {
+	cfg, _ := validConfig(t)
+	goMod := writeGoMod(t, "github.com/other/app")
+
+	err := Validate(cfg, goMod)
+	if err == nil {
+		t.Fatal("expected module mismatch error, got nil")
+	}
+	if !strings.Contains(err.Error(), "module mismatch") {
+		t.Errorf("expected 'module mismatch' in error, got: %v", err)
+	}
+}
+
+func TestValidate_EmptyModule(t *testing.T) {
+	cfg, goMod := validConfig(t)
+	cfg.Module = ""
+
+	err := Validate(cfg, goMod)
+	if err == nil {
+		t.Fatal("expected error for empty module")
+	}
+	if !strings.Contains(err.Error(), "module is required") {
+		t.Errorf("expected 'module is required' in error, got: %v", err)
+	}
+}
+
+func TestValidate_NoLayers(t *testing.T) {
+	cfg, goMod := validConfig(t)
+	cfg.Layers = nil
+
+	err := Validate(cfg, goMod)
+	if err == nil {
+		t.Fatal("expected error for missing layers")
+	}
+	if !strings.Contains(err.Error(), "at least one layer") {
+		t.Errorf("expected 'at least one layer' in error, got: %v", err)
+	}
+}
+
+func TestValidate_EmptyLayerGlobs(t *testing.T) {
+	cfg, goMod := validConfig(t)
+	cfg.Layers["domain"] = nil
+
+	err := Validate(cfg, goMod)
+	if err == nil {
+		t.Fatal("expected error for empty globs")
+	}
+	if !strings.Contains(err.Error(), "no package globs") {
+		t.Errorf("expected 'no package globs' in error, got: %v", err)
+	}
+}
+
+func TestValidate_BadGlobs(t *testing.T) {
+	cases := map[string]string{
+		"empty glob":         "",
+		"whitespace":         "internal/ domain/...",
+		"absolute":           "/internal/domain/...",
+		"interior ellipsis":  "internal/.../domain",
+		"trailing whitespace": "internal/domain/... ",
+	}
+	for name, glob := range cases {
+		t.Run(name, func(t *testing.T) {
+			cfg, goMod := validConfig(t)
+			cfg.Layers["domain"] = []string{glob}
+
+			if err := Validate(cfg, goMod); err == nil {
+				t.Fatalf("expected error for glob %q", glob)
+			}
+		})
+	}
+}
+
+func TestValidate_LayerRuleUnknownKey(t *testing.T) {
+	cfg, goMod := validConfig(t)
+	cfg.LayerRules["ghost"] = []string{"domain"}
+
+	err := Validate(cfg, goMod)
+	if err == nil {
+		t.Fatal("expected error for unknown rule key")
+	}
+	if !strings.Contains(err.Error(), "unknown layer \"ghost\"") {
+		t.Errorf("expected 'unknown layer \"ghost\"' in error, got: %v", err)
+	}
+}
+
+func TestValidate_LayerRuleUnknownTarget(t *testing.T) {
+	cfg, goMod := validConfig(t)
+	cfg.LayerRules["service"] = []string{"phantom"}
+
+	err := Validate(cfg, goMod)
+	if err == nil {
+		t.Fatal("expected error for unknown rule target")
+	}
+	if !strings.Contains(err.Error(), "phantom") {
+		t.Errorf("expected 'phantom' in error, got: %v", err)
+	}
+}
+
+func TestValidate_BadAggregateRoot(t *testing.T) {
+	cases := map[string]string{
+		"empty":           "",
+		"no dot":          "OrderRoot",
+		"trailing dot":    "github.com/example/app/internal/domain.",
+		"leading dot":     ".Order",
+		"slash in name":   "github.com/example/app/internal.domain/Order",
+	}
+	for name, root := range cases {
+		t.Run(name, func(t *testing.T) {
+			cfg, goMod := validConfig(t)
+			cfg.Aggregates["Bad"] = Aggregate{Root: root}
+
+			if err := Validate(cfg, goMod); err == nil {
+				t.Fatalf("expected error for root %q", root)
+			}
+		})
+	}
+}
+
+func TestValidate_BadConfigRef(t *testing.T) {
+	cfg, goMod := validConfig(t)
+	cfg.Configs = append(cfg.Configs, "not-qualified")
+
+	err := Validate(cfg, goMod)
+	if err == nil {
+		t.Fatal("expected error for malformed config ref")
+	}
+	if !strings.Contains(err.Error(), "configs[1]") {
+		t.Errorf("expected 'configs[1]' in error, got: %v", err)
+	}
+}
+
+func TestValidate_SkipsGoModCheckWhenPathEmpty(t *testing.T) {
+	cfg, _ := validConfig(t)
+	// A caller that doesn't know where go.mod lives should still be able
+	// to validate the rest of the overlay.
+	if err := Validate(cfg, ""); err != nil {
+		t.Fatalf("Validate with empty goModPath returned error: %v", err)
+	}
+}
+
+func TestValidate_MissingGoMod(t *testing.T) {
+	cfg, _ := validConfig(t)
+	err := Validate(cfg, filepath.Join(t.TempDir(), "go.mod"))
+	if err == nil {
+		t.Fatal("expected error for missing go.mod")
+	}
+}
+
+func TestValidate_AggregatesWithMultipleErrorsJoined(t *testing.T) {
+	cfg, goMod := validConfig(t)
+	cfg.Aggregates["Bad1"] = Aggregate{Root: ""}
+	cfg.Aggregates["Bad2"] = Aggregate{Root: "NoDot"}
+
+	err := Validate(cfg, goMod)
+	if err == nil {
+		t.Fatal("expected aggregated error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "Bad1") || !strings.Contains(msg, "Bad2") {
+		t.Errorf("expected both Bad1 and Bad2 reported, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Implements **M3a** from issue #10: the schema, loader, and validator for `archai.yaml`.

New package `internal/overlay/`:

- `config.go` — `Config` struct (Module, Layers, LayerRules, Aggregates, Configs) and nested `Aggregate` type, with field-level docs describing the overlay's semantics.
- `load.go` — `Load(path string) (*Config, error)` parses YAML via `gopkg.in/yaml.v3` with `KnownFields(true)` so typos in user-authored files fail loudly; all errors are wrapped with the source path.
- `validate.go` — `Validate(cfg *Config, goModPath string) error` checks that:
  - the declared `module` matches `go.mod` (parsed via `golang.org/x/mod/modfile`);
  - every layer has at least one glob, and each glob is syntactically reasonable (non-empty, no whitespace, relative, at most one trailing `...`);
  - `layer_rules` keys and values reference known layers;
  - `aggregates.*.root` and `configs[*]` are well-formed fully-qualified type refs (`pkg/path.TypeName`).
  - Errors are joined with `errors.Join` so all problems surface at once, and map iteration is sorted for deterministic output.

Tests (`load_test.go`, `validate_test.go`) cover: valid YAML round-trip, missing file, malformed YAML, unknown top-level keys, module mismatch, empty/missing layers, four flavors of bad globs, unknown rule keys and targets, five flavors of malformed aggregate roots, malformed config refs, optional go.mod path, and error aggregation.

## Scope

Intentionally narrow: **schema + loader + validator only**. Service integration is M3b; CLI is M3c. No production code outside `internal/overlay/` changes except `go.mod` (promotes the already-present `golang.org/x/mod` and `gopkg.in/yaml.v3` from indirect to direct requires).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (all packages pass, including new `internal/overlay`)

Refs: #10