### PR TITLE
M4a: Target storage layout + lock/list/show/use/delete commands

### DIFF
--- a/cmd/archai/main.go
+++ b/cmd/archai/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kgatilin/archai/internal/adapter/golang"
 	yamlAdapter "github.com/kgatilin/archai/internal/adapter/yaml"
 	"github.com/kgatilin/archai/internal/service"
+	"github.com/kgatilin/archai/internal/target"
 	"github.com/spf13/cobra"
 )
 
@@ -117,6 +118,70 @@ Examples:
 	composeCmd.Flags().Bool("spec", false, "Use *-spec.d2 files instead of pub.d2")
 	_ = composeCmd.MarkFlagRequired("output")
 	diagramCmd.AddCommand(composeCmd)
+
+	// Target command group (M4a)
+	targetCmd := &cobra.Command{
+		Use:   "target",
+		Short: "Manage target architecture snapshots",
+		Long: `Lock, list, inspect, select and delete frozen target snapshots.
+
+A "target" is a frozen copy of the project's per-package .arch/*.yaml
+specifications plus the overlay (archai.yaml) at a point in time. Targets
+live under .arch/targets/<id>/ and the active target is tracked in
+.arch/targets/CURRENT.`,
+	}
+	rootCmd.AddCommand(targetCmd)
+
+	// target lock
+	targetLockCmd := &cobra.Command{
+		Use:   "lock <id>",
+		Short: "Freeze the current architecture as target <id>",
+		Long: `Regenerate per-package YAML specs (archai diagram generate --format yaml)
+and freeze them — along with archai.yaml — into .arch/targets/<id>/.`,
+		Args: cobra.ExactArgs(1),
+		RunE: runTargetLock,
+	}
+	targetLockCmd.Flags().String("description", "", "Optional description for this target")
+	targetLockCmd.Flags().Bool("skip-generate", false, "Skip regeneration; use existing .arch/*.yaml files")
+	targetLockCmd.Flags().StringSliceP("paths", "p", []string{"./..."}, "Package paths to regenerate (only used when generate is enabled)")
+	targetCmd.AddCommand(targetLockCmd)
+
+	// target list
+	targetListCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List locked targets",
+		Args:  cobra.NoArgs,
+		RunE:  runTargetList,
+	}
+	targetCmd.AddCommand(targetListCmd)
+
+	// target show
+	targetShowCmd := &cobra.Command{
+		Use:   "show <id>",
+		Short: "Show target metadata and package summary",
+		Args:  cobra.ExactArgs(1),
+		RunE:  runTargetShow,
+	}
+	targetCmd.AddCommand(targetShowCmd)
+
+	// target use
+	targetUseCmd := &cobra.Command{
+		Use:   "use <id>",
+		Short: "Mark <id> as the active (CURRENT) target",
+		Args:  cobra.ExactArgs(1),
+		RunE:  runTargetUse,
+	}
+	targetCmd.AddCommand(targetUseCmd)
+
+	// target delete
+	targetDeleteCmd := &cobra.Command{
+		Use:   "delete <id>",
+		Short: "Delete a locked target",
+		Args:  cobra.ExactArgs(1),
+		RunE:  runTargetDelete,
+	}
+	targetDeleteCmd.Flags().Bool("force", false, "Delete even if <id> is the current target")
+	targetCmd.AddCommand(targetDeleteCmd)
 
 	// Execute root command
 	if err := rootCmd.Execute(); err != nil {
@@ -338,5 +403,130 @@ func runCompose(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	return nil
+}
+
+// runTargetLock handles `archai target lock <id>`. It (optionally)
+// regenerates per-package YAML specs and then freezes them plus
+// archai.yaml into .arch/targets/<id>/.
+func runTargetLock(cmd *cobra.Command, args []string) error {
+	id := args[0]
+	description, _ := cmd.Flags().GetString("description")
+	skipGenerate, _ := cmd.Flags().GetBool("skip-generate")
+	paths, _ := cmd.Flags().GetStringSlice("paths")
+
+	projectRoot, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("resolving cwd: %w", err)
+	}
+
+	if !skipGenerate {
+		ctx := cmd.Context()
+		if ctx == nil {
+			ctx = context.Background()
+		}
+		goReader := golang.NewReader()
+		d2Reader := d2.NewReader()
+		yamlReader := yamlAdapter.NewReader()
+		yamlWriter := yamlAdapter.NewWriter()
+		svc := service.NewService(goReader, d2Reader, yamlWriter, service.WithYAML(yamlReader, yamlWriter))
+
+		opts := service.GenerateOptions{
+			Paths:         paths,
+			FileExtension: ".yaml",
+		}
+		results, err := svc.Generate(ctx, opts)
+		if err != nil {
+			return fmt.Errorf("regenerating specs: %w", err)
+		}
+		for _, r := range results {
+			if r.Error != nil {
+				fmt.Fprintf(os.Stderr, "WARN: %s: %v\n", r.PackagePath, r.Error)
+			}
+		}
+	}
+
+	if err := target.Lock(projectRoot, id, target.LockOptions{Description: description}); err != nil {
+		return err
+	}
+	fmt.Printf("Locked target %q\n", id)
+	return nil
+}
+
+// runTargetList handles `archai target list`.
+func runTargetList(cmd *cobra.Command, args []string) error {
+	projectRoot, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("resolving cwd: %w", err)
+	}
+	metas, err := target.List(projectRoot)
+	if err != nil {
+		return err
+	}
+	if len(metas) == 0 {
+		fmt.Println("No targets found.")
+		return nil
+	}
+	cur, _ := target.Current(projectRoot)
+	for _, m := range metas {
+		marker := "  "
+		if m.ID == cur {
+			marker = "* "
+		}
+		fmt.Printf("%s%s  %s  %s\n", marker, m.ID, m.CreatedAt, m.Description)
+	}
+	return nil
+}
+
+// runTargetShow handles `archai target show <id>`.
+func runTargetShow(cmd *cobra.Command, args []string) error {
+	id := args[0]
+	projectRoot, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("resolving cwd: %w", err)
+	}
+	meta, pkgs, err := target.Show(projectRoot, id)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("id:          %s\n", meta.ID)
+	fmt.Printf("created_at:  %s\n", meta.CreatedAt)
+	fmt.Printf("base_commit: %s\n", meta.BaseCommit)
+	if meta.Description != "" {
+		fmt.Printf("description: %s\n", meta.Description)
+	}
+	fmt.Printf("packages:    %d\n", len(pkgs))
+	for _, p := range pkgs {
+		fmt.Printf("  - %s\n", p)
+	}
+	return nil
+}
+
+// runTargetUse handles `archai target use <id>`.
+func runTargetUse(cmd *cobra.Command, args []string) error {
+	id := args[0]
+	projectRoot, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("resolving cwd: %w", err)
+	}
+	if err := target.Use(projectRoot, id); err != nil {
+		return err
+	}
+	fmt.Printf("Using target %q\n", id)
+	return nil
+}
+
+// runTargetDelete handles `archai target delete <id>`.
+func runTargetDelete(cmd *cobra.Command, args []string) error {
+	id := args[0]
+	force, _ := cmd.Flags().GetBool("force")
+	projectRoot, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("resolving cwd: %w", err)
+	}
+	if err := target.Delete(projectRoot, id, force); err != nil {
+		return err
+	}
+	fmt.Printf("Deleted target %q\n", id)
 	return nil
 }

--- a/internal/target/meta.go
+++ b/internal/target/meta.go
@@ -1,0 +1,28 @@
+// Package target provides storage and management of "target" snapshots:
+// frozen copies of a project's per-package architecture specs (.arch/*.yaml)
+// plus the overlay (archai.yaml) at a specific point in time.
+//
+// A target is identified by a human-readable id and lives under
+// .arch/targets/<id>/. A single active target is tracked via
+// .arch/targets/CURRENT (a one-line file containing the target id).
+//
+// This package implements the storage layout and management operations
+// (lock/list/show/use/delete) for M4a. It does not implement diffing or
+// validation; those are handled by later milestones.
+package target
+
+// TargetMeta describes a single locked target.
+//
+// The YAML representation lives at .arch/targets/<id>/meta.yaml.
+// Fields:
+//   - ID: target identifier, matches the directory name under .arch/targets/.
+//   - BaseCommit: git commit hash captured at lock time (output of
+//     `git rev-parse HEAD`). Empty if the project is not a git repo.
+//   - CreatedAt: RFC3339 timestamp of when Lock was called.
+//   - Description: optional free-form description passed via --description.
+type TargetMeta struct {
+	ID          string `yaml:"id"`
+	BaseCommit  string `yaml:"base_commit"`
+	CreatedAt   string `yaml:"created_at"`
+	Description string `yaml:"description,omitempty"`
+}

--- a/internal/target/storage.go
+++ b/internal/target/storage.go
@@ -1,0 +1,386 @@
+package target
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	yamlv3 "gopkg.in/yaml.v3"
+)
+
+// Directory/file name constants used throughout the storage layout.
+const (
+	archDirName      = ".arch"
+	targetsDirName   = "targets"
+	currentFileName  = "CURRENT"
+	metaFileName     = "meta.yaml"
+	overlayFileName  = "overlay.yaml"
+	overlaySource    = "archai.yaml"
+	modelDirName     = "model"
+	pubYAMLFileName  = "pub.yaml"
+	intYAMLFileName  = "internal.yaml"
+)
+
+// LockOptions configures a Lock call.
+type LockOptions struct {
+	// Description is an optional human-readable description stored in meta.yaml.
+	Description string
+}
+
+// Lock freezes the current per-package .arch/*.yaml snapshots and the
+// project's archai.yaml into .arch/targets/<id>/.
+//
+// It does NOT run `archai diagram generate` — callers must ensure the
+// per-package .arch/*.yaml files are up to date (the CLI runs generate
+// before invoking Lock; tests populate .arch/ directly).
+//
+// The project layout after Lock looks like:
+//
+//	.arch/targets/<id>/meta.yaml
+//	.arch/targets/<id>/overlay.yaml              (copy of archai.yaml, optional)
+//	.arch/targets/<id>/model/<pkg>/pub.yaml
+//	.arch/targets/<id>/model/<pkg>/internal.yaml
+//
+// Returns an error if the target already exists or if the project
+// contains no .arch/*.yaml files to freeze.
+func Lock(projectRoot, id string, opts LockOptions) error {
+	if id == "" {
+		return errors.New("target: id must not be empty")
+	}
+	if strings.ContainsAny(id, "/\\") {
+		return fmt.Errorf("target: id %q must not contain path separators", id)
+	}
+
+	targetDir := filepath.Join(projectRoot, archDirName, targetsDirName, id)
+	if _, err := os.Stat(targetDir); err == nil {
+		return fmt.Errorf("target: target %q already exists", id)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("target: stat %s: %w", targetDir, err)
+	}
+
+	pkgs, err := findPackagesWithArchYAML(projectRoot)
+	if err != nil {
+		return err
+	}
+	if len(pkgs) == 0 {
+		return errors.New("target: no packages with .arch/*.yaml found — run `archai diagram generate --format yaml` first")
+	}
+
+	if err := os.MkdirAll(targetDir, 0o755); err != nil {
+		return fmt.Errorf("target: create %s: %w", targetDir, err)
+	}
+
+	// Freeze per-package model snapshots.
+	for _, rel := range pkgs {
+		srcArch := filepath.Join(projectRoot, rel, archDirName)
+		dstModel := filepath.Join(targetDir, modelDirName, rel)
+		if err := os.MkdirAll(dstModel, 0o755); err != nil {
+			return fmt.Errorf("target: create %s: %w", dstModel, err)
+		}
+		for _, fn := range []string{pubYAMLFileName, intYAMLFileName} {
+			src := filepath.Join(srcArch, fn)
+			if _, err := os.Stat(src); errors.Is(err, os.ErrNotExist) {
+				continue
+			} else if err != nil {
+				return fmt.Errorf("target: stat %s: %w", src, err)
+			}
+			dst := filepath.Join(dstModel, fn)
+			if err := copyFile(src, dst); err != nil {
+				return err
+			}
+		}
+	}
+
+	// Freeze overlay (archai.yaml) if present.
+	overlaySrc := filepath.Join(projectRoot, overlaySource)
+	if _, err := os.Stat(overlaySrc); err == nil {
+		if err := copyFile(overlaySrc, filepath.Join(targetDir, overlayFileName)); err != nil {
+			return err
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("target: stat %s: %w", overlaySrc, err)
+	}
+
+	meta := TargetMeta{
+		ID:          id,
+		BaseCommit:  gitHead(projectRoot),
+		CreatedAt:   time.Now().UTC().Format(time.RFC3339),
+		Description: opts.Description,
+	}
+	if err := writeMeta(filepath.Join(targetDir, metaFileName), meta); err != nil {
+		return err
+	}
+	return nil
+}
+
+// List returns metadata for every locked target under .arch/targets/,
+// sorted by ID. Entries without a readable meta.yaml are skipped.
+func List(projectRoot string) ([]TargetMeta, error) {
+	dir := filepath.Join(projectRoot, archDirName, targetsDirName)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("target: read %s: %w", dir, err)
+	}
+
+	var out []TargetMeta
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		metaPath := filepath.Join(dir, e.Name(), metaFileName)
+		meta, err := readMeta(metaPath)
+		if err != nil {
+			// Skip malformed entries; they're not valid targets.
+			continue
+		}
+		out = append(out, meta)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out, nil
+}
+
+// Show returns the meta.yaml for <id> together with the list of package
+// paths (relative to projectRoot) contained in its model/ directory.
+func Show(projectRoot, id string) (*TargetMeta, []string, error) {
+	targetDir := filepath.Join(projectRoot, archDirName, targetsDirName, id)
+	if _, err := os.Stat(targetDir); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil, fmt.Errorf("target: target %q not found", id)
+		}
+		return nil, nil, fmt.Errorf("target: stat %s: %w", targetDir, err)
+	}
+
+	meta, err := readMeta(filepath.Join(targetDir, metaFileName))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	pkgs, err := collectModelPackages(filepath.Join(targetDir, modelDirName))
+	if err != nil {
+		return nil, nil, err
+	}
+	return &meta, pkgs, nil
+}
+
+// Use marks <id> as the active target by writing it to .arch/targets/CURRENT.
+// It errors if the target directory does not exist.
+func Use(projectRoot, id string) error {
+	targetDir := filepath.Join(projectRoot, archDirName, targetsDirName, id)
+	if _, err := os.Stat(targetDir); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("target: target %q not found", id)
+		}
+		return fmt.Errorf("target: stat %s: %w", targetDir, err)
+	}
+
+	currentPath := filepath.Join(projectRoot, archDirName, targetsDirName, currentFileName)
+	if err := os.MkdirAll(filepath.Dir(currentPath), 0o755); err != nil {
+		return fmt.Errorf("target: create targets dir: %w", err)
+	}
+	if err := os.WriteFile(currentPath, []byte(id), 0o644); err != nil {
+		return fmt.Errorf("target: write CURRENT: %w", err)
+	}
+	return nil
+}
+
+// Delete removes .arch/targets/<id>/. If <id> is the active target (CURRENT),
+// Delete fails unless force is true; when forced, CURRENT is also removed.
+func Delete(projectRoot, id string, force bool) error {
+	targetDir := filepath.Join(projectRoot, archDirName, targetsDirName, id)
+	if _, err := os.Stat(targetDir); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("target: target %q not found", id)
+		}
+		return fmt.Errorf("target: stat %s: %w", targetDir, err)
+	}
+
+	cur, _ := Current(projectRoot)
+	if cur == id && !force {
+		return fmt.Errorf("target: %q is the current target; re-run with --force to delete", id)
+	}
+	if err := os.RemoveAll(targetDir); err != nil {
+		return fmt.Errorf("target: remove %s: %w", targetDir, err)
+	}
+	if cur == id {
+		_ = os.Remove(filepath.Join(projectRoot, archDirName, targetsDirName, currentFileName))
+	}
+	return nil
+}
+
+// Current returns the active target id from .arch/targets/CURRENT,
+// or an empty string if no CURRENT file exists.
+func Current(projectRoot string) (string, error) {
+	path := filepath.Join(projectRoot, archDirName, targetsDirName, currentFileName)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", nil
+		}
+		return "", fmt.Errorf("target: read CURRENT: %w", err)
+	}
+	return strings.TrimSpace(string(data)), nil
+}
+
+// --- helpers ---
+
+// findPackagesWithArchYAML walks projectRoot looking for directories
+// containing a .arch/ subdirectory with at least one of pub.yaml or
+// internal.yaml. Returns relative paths (relative to projectRoot) of
+// the parent (package) directories, e.g. "internal/service".
+// The .arch/targets/ tree itself is skipped.
+func findPackagesWithArchYAML(projectRoot string) ([]string, error) {
+	var out []string
+	targetsTree := filepath.Join(projectRoot, archDirName, targetsDirName)
+	err := filepath.WalkDir(projectRoot, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() {
+			return nil
+		}
+		// Skip the targets tree so nested .arch/targets/*/model/.arch dirs
+		// (if any) don't get picked up.
+		if path == targetsTree || strings.HasPrefix(path, targetsTree+string(os.PathSeparator)) {
+			return filepath.SkipDir
+		}
+		if filepath.Base(path) != archDirName {
+			return nil
+		}
+		// Found a .arch directory — check for yaml specs.
+		hasPub := fileExists(filepath.Join(path, pubYAMLFileName))
+		hasInt := fileExists(filepath.Join(path, intYAMLFileName))
+		if !hasPub && !hasInt {
+			return filepath.SkipDir
+		}
+		rel, err := filepath.Rel(projectRoot, filepath.Dir(path))
+		if err != nil {
+			return err
+		}
+		if rel == "." {
+			rel = ""
+		}
+		out = append(out, rel)
+		return filepath.SkipDir // don't descend into .arch/
+	})
+	if err != nil {
+		return nil, fmt.Errorf("target: walk %s: %w", projectRoot, err)
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+// collectModelPackages walks a target's model/ directory and returns
+// the relative package paths that contain at least one YAML spec.
+func collectModelPackages(modelDir string) ([]string, error) {
+	if _, err := os.Stat(modelDir); errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	var out []string
+	err := filepath.WalkDir(modelDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		name := d.Name()
+		if name != pubYAMLFileName && name != intYAMLFileName {
+			return nil
+		}
+		rel, err := filepath.Rel(modelDir, filepath.Dir(path))
+		if err != nil {
+			return err
+		}
+		out = append(out, rel)
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("target: walk %s: %w", modelDir, err)
+	}
+	// Deduplicate and sort.
+	seen := make(map[string]struct{}, len(out))
+	uniq := out[:0]
+	for _, p := range out {
+		if _, ok := seen[p]; ok {
+			continue
+		}
+		seen[p] = struct{}{}
+		uniq = append(uniq, p)
+	}
+	sort.Strings(uniq)
+	return uniq, nil
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("target: open %s: %w", src, err)
+	}
+	defer in.Close()
+
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return fmt.Errorf("target: mkdir for %s: %w", dst, err)
+	}
+	out, err := os.Create(dst)
+	if err != nil {
+		return fmt.Errorf("target: create %s: %w", dst, err)
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		return fmt.Errorf("target: copy %s -> %s: %w", src, dst, err)
+	}
+	if err := out.Close(); err != nil {
+		return fmt.Errorf("target: close %s: %w", dst, err)
+	}
+	return nil
+}
+
+func writeMeta(path string, meta TargetMeta) error {
+	data, err := yamlv3.Marshal(meta)
+	if err != nil {
+		return fmt.Errorf("target: marshal meta: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("target: write %s: %w", path, err)
+	}
+	return nil
+}
+
+func readMeta(path string) (TargetMeta, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return TargetMeta{}, fmt.Errorf("target: read %s: %w", path, err)
+	}
+	var m TargetMeta
+	if err := yamlv3.Unmarshal(data, &m); err != nil {
+		return TargetMeta{}, fmt.Errorf("target: parse %s: %w", path, err)
+	}
+	return m, nil
+}
+
+// gitHead returns the current git HEAD hash for projectRoot. If git is
+// unavailable or the directory is not a git repo, it returns an empty
+// string — the lack of a commit id is not fatal for locking a target.
+func gitHead(projectRoot string) string {
+	cmd := exec.Command("git", "rev-parse", "HEAD")
+	cmd.Dir = projectRoot
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}

--- a/internal/target/storage_test.go
+++ b/internal/target/storage_test.go
@@ -1,0 +1,320 @@
+package target
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	yamlv3 "gopkg.in/yaml.v3"
+)
+
+// setupProject creates a temporary project directory with a handful of
+// packages that each already contain a .arch/ folder with pub.yaml and
+// internal.yaml files. It mirrors what `archai diagram generate --format
+// yaml` would produce — Lock then just has to freeze these files.
+func setupProject(t *testing.T, withOverlay bool) string {
+	t.Helper()
+	root := t.TempDir()
+
+	pkgs := []string{
+		"internal/domain",
+		"internal/service",
+		"cmd/archai",
+	}
+	for _, p := range pkgs {
+		archDir := filepath.Join(root, p, ".arch")
+		if err := os.MkdirAll(archDir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", archDir, err)
+		}
+		if err := os.WriteFile(filepath.Join(archDir, "pub.yaml"), []byte("package: "+p+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(archDir, "internal.yaml"), []byte("package: "+p+"\ninternal: true\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if withOverlay {
+		if err := os.WriteFile(filepath.Join(root, "archai.yaml"), []byte("module: example.com/foo\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}
+
+func TestLock_CreatesLayout(t *testing.T) {
+	root := setupProject(t, true)
+
+	if err := Lock(root, "v1", LockOptions{Description: "first snapshot"}); err != nil {
+		t.Fatalf("Lock: %v", err)
+	}
+
+	targetDir := filepath.Join(root, ".arch", "targets", "v1")
+
+	// meta.yaml should exist and parse.
+	metaPath := filepath.Join(targetDir, "meta.yaml")
+	data, err := os.ReadFile(metaPath)
+	if err != nil {
+		t.Fatalf("read meta.yaml: %v", err)
+	}
+	var meta TargetMeta
+	if err := yamlv3.Unmarshal(data, &meta); err != nil {
+		t.Fatalf("unmarshal meta: %v", err)
+	}
+	if meta.ID != "v1" {
+		t.Errorf("meta.ID = %q, want v1", meta.ID)
+	}
+	if meta.Description != "first snapshot" {
+		t.Errorf("meta.Description = %q, want %q", meta.Description, "first snapshot")
+	}
+	if meta.CreatedAt == "" {
+		t.Error("meta.CreatedAt is empty")
+	}
+
+	// overlay.yaml should be copied.
+	overlayData, err := os.ReadFile(filepath.Join(targetDir, "overlay.yaml"))
+	if err != nil {
+		t.Fatalf("read overlay.yaml: %v", err)
+	}
+	if !strings.Contains(string(overlayData), "module: example.com/foo") {
+		t.Errorf("overlay.yaml content unexpected: %q", string(overlayData))
+	}
+
+	// Per-package model files should be copied.
+	for _, pkg := range []string{"internal/domain", "internal/service", "cmd/archai"} {
+		for _, fn := range []string{"pub.yaml", "internal.yaml"} {
+			p := filepath.Join(targetDir, "model", pkg, fn)
+			if _, err := os.Stat(p); err != nil {
+				t.Errorf("expected %s to exist: %v", p, err)
+			}
+		}
+	}
+}
+
+func TestLock_NoOverlay(t *testing.T) {
+	root := setupProject(t, false)
+	if err := Lock(root, "v1", LockOptions{}); err != nil {
+		t.Fatalf("Lock: %v", err)
+	}
+	overlayPath := filepath.Join(root, ".arch", "targets", "v1", "overlay.yaml")
+	if _, err := os.Stat(overlayPath); !os.IsNotExist(err) {
+		t.Errorf("expected overlay.yaml absent when archai.yaml missing, got err=%v", err)
+	}
+}
+
+func TestLock_DuplicateFails(t *testing.T) {
+	root := setupProject(t, false)
+	if err := Lock(root, "v1", LockOptions{}); err != nil {
+		t.Fatalf("first Lock: %v", err)
+	}
+	if err := Lock(root, "v1", LockOptions{}); err == nil {
+		t.Fatal("expected error locking existing target, got nil")
+	}
+}
+
+func TestLock_NoPackagesFails(t *testing.T) {
+	root := t.TempDir()
+	if err := Lock(root, "v1", LockOptions{}); err == nil {
+		t.Fatal("expected error when no packages present, got nil")
+	}
+}
+
+func TestLock_InvalidID(t *testing.T) {
+	root := setupProject(t, false)
+	cases := []string{"", "foo/bar", "a\\b"}
+	for _, id := range cases {
+		if err := Lock(root, id, LockOptions{}); err == nil {
+			t.Errorf("Lock(%q): expected error, got nil", id)
+		}
+	}
+}
+
+func TestList_ReturnsAllTargets(t *testing.T) {
+	root := setupProject(t, false)
+
+	for _, id := range []string{"v1", "v3", "v2"} {
+		if err := Lock(root, id, LockOptions{Description: "desc-" + id}); err != nil {
+			t.Fatalf("Lock %s: %v", id, err)
+		}
+	}
+
+	metas, err := List(root)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(metas) != 3 {
+		t.Fatalf("got %d metas, want 3", len(metas))
+	}
+	// List must be sorted by id.
+	for i, want := range []string{"v1", "v2", "v3"} {
+		if metas[i].ID != want {
+			t.Errorf("metas[%d].ID = %q, want %q", i, metas[i].ID, want)
+		}
+	}
+}
+
+func TestList_NoTargetsDir(t *testing.T) {
+	root := t.TempDir()
+	metas, err := List(root)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(metas) != 0 {
+		t.Errorf("expected empty list, got %d", len(metas))
+	}
+}
+
+func TestShow_ReadsMetaAndPackages(t *testing.T) {
+	root := setupProject(t, true)
+	if err := Lock(root, "v1", LockOptions{Description: "desc"}); err != nil {
+		t.Fatalf("Lock: %v", err)
+	}
+
+	meta, pkgs, err := Show(root, "v1")
+	if err != nil {
+		t.Fatalf("Show: %v", err)
+	}
+	if meta.ID != "v1" || meta.Description != "desc" {
+		t.Errorf("unexpected meta: %+v", meta)
+	}
+	wantPkgs := map[string]bool{
+		"internal/domain":  false,
+		"internal/service": false,
+		"cmd/archai":       false,
+	}
+	for _, p := range pkgs {
+		// Normalize to forward slashes for cross-platform comparison.
+		normalized := filepath.ToSlash(p)
+		if _, ok := wantPkgs[normalized]; !ok {
+			t.Errorf("unexpected package in show: %q", normalized)
+			continue
+		}
+		wantPkgs[normalized] = true
+	}
+	for p, seen := range wantPkgs {
+		if !seen {
+			t.Errorf("missing package in show: %q", p)
+		}
+	}
+}
+
+func TestShow_NotFound(t *testing.T) {
+	root := setupProject(t, false)
+	if _, _, err := Show(root, "missing"); err == nil {
+		t.Fatal("expected error for missing target, got nil")
+	}
+}
+
+func TestUse_WritesCURRENT(t *testing.T) {
+	root := setupProject(t, false)
+	if err := Lock(root, "v1", LockOptions{}); err != nil {
+		t.Fatalf("Lock: %v", err)
+	}
+
+	if err := Use(root, "v1"); err != nil {
+		t.Fatalf("Use: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(root, ".arch", "targets", "CURRENT"))
+	if err != nil {
+		t.Fatalf("read CURRENT: %v", err)
+	}
+	if strings.TrimSpace(string(data)) != "v1" {
+		t.Errorf("CURRENT = %q, want v1", string(data))
+	}
+
+	cur, err := Current(root)
+	if err != nil {
+		t.Fatalf("Current: %v", err)
+	}
+	if cur != "v1" {
+		t.Errorf("Current() = %q, want v1", cur)
+	}
+}
+
+func TestUse_NonExistentTarget(t *testing.T) {
+	root := setupProject(t, false)
+	if err := Use(root, "ghost"); err == nil {
+		t.Fatal("expected error using missing target, got nil")
+	}
+}
+
+func TestCurrent_MissingReturnsEmpty(t *testing.T) {
+	root := setupProject(t, false)
+	cur, err := Current(root)
+	if err != nil {
+		t.Fatalf("Current: %v", err)
+	}
+	if cur != "" {
+		t.Errorf("Current() = %q, want empty", cur)
+	}
+}
+
+func TestDelete_RemovesTarget(t *testing.T) {
+	root := setupProject(t, false)
+	if err := Lock(root, "v1", LockOptions{}); err != nil {
+		t.Fatalf("Lock: %v", err)
+	}
+	if err := Delete(root, "v1", false); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, ".arch", "targets", "v1")); !os.IsNotExist(err) {
+		t.Errorf("expected target dir removed, got err=%v", err)
+	}
+}
+
+func TestDelete_CurrentRequiresForce(t *testing.T) {
+	root := setupProject(t, false)
+	if err := Lock(root, "v1", LockOptions{}); err != nil {
+		t.Fatalf("Lock: %v", err)
+	}
+	if err := Use(root, "v1"); err != nil {
+		t.Fatalf("Use: %v", err)
+	}
+
+	if err := Delete(root, "v1", false); err == nil {
+		t.Fatal("expected error deleting current target without force")
+	}
+
+	if err := Delete(root, "v1", true); err != nil {
+		t.Fatalf("Delete with force: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, ".arch", "targets", "v1")); !os.IsNotExist(err) {
+		t.Errorf("expected target dir removed, got err=%v", err)
+	}
+	// CURRENT file should also be cleared.
+	if _, err := os.Stat(filepath.Join(root, ".arch", "targets", "CURRENT")); !os.IsNotExist(err) {
+		t.Errorf("expected CURRENT cleared, got err=%v", err)
+	}
+}
+
+func TestDelete_NotFound(t *testing.T) {
+	root := setupProject(t, false)
+	if err := Delete(root, "ghost", false); err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestLock_SkipsTargetsTree(t *testing.T) {
+	// After a Lock, a second Lock should not pick up copies nested inside
+	// .arch/targets/<prev>/model/<pkg>/.arch — we don't actually create
+	// a nested .arch under model/, but we guard against it anyway.
+	root := setupProject(t, false)
+	if err := Lock(root, "v1", LockOptions{}); err != nil {
+		t.Fatalf("first Lock: %v", err)
+	}
+	// Lock a second target; should still work and only reference the
+	// real packages, not anything inside .arch/targets.
+	if err := Lock(root, "v2", LockOptions{}); err != nil {
+		t.Fatalf("second Lock: %v", err)
+	}
+	_, pkgs, err := Show(root, "v2")
+	if err != nil {
+		t.Fatalf("Show: %v", err)
+	}
+	for _, p := range pkgs {
+		if strings.Contains(filepath.ToSlash(p), ".arch/targets") {
+			t.Errorf("target leaked into model/ packages: %q", p)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Implements issue #13 (M4a). Adds a new `internal/target` package and `archai target` CLI group for freezing and managing target architecture snapshots.

### Storage layout

```
.arch/targets/<id>/
  meta.yaml                      # id, base_commit, created_at, description
  overlay.yaml                   # frozen archai.yaml (optional)
  model/<package>/pub.yaml
  model/<package>/internal.yaml
.arch/targets/CURRENT            # single-line active target id
```

### CLI commands

- `archai target lock <id> [--description ...] [--skip-generate] [-p paths]` — regenerates YAML specs (unless `--skip-generate`), then freezes `.arch/*.yaml` files from every package plus `archai.yaml` into `.arch/targets/<id>/`.
- `archai target list` — prints all locked targets with an `*` marker on the CURRENT one.
- `archai target show <id>` — prints meta fields + package list.
- `archai target use <id>` — writes id to `.arch/targets/CURRENT`.
- `archai target delete <id> [--force]` — removes target; requires `--force` if it is CURRENT.

### Notes

- `base_commit` is captured via `git rev-parse HEAD`; non-git trees get an empty string (not fatal).
- Missing `archai.yaml` is handled gracefully — `overlay.yaml` is simply omitted.
- The target tree itself is skipped during package discovery to prevent recursion.
- Does NOT implement diff (M4b) or validate (M4c).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` — all packages green, including new `internal/target` tests covering Lock layout, List ordering, Show meta+packages, Use CURRENT, Delete (with/without --force), invalid ids, and nested-targets guard.

Closes #13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)