### PR TITLE
M2a: Add ConstDef, VarDef, ErrorDef to domain + Go reader extraction

### DIFF
--- a/internal/adapter/d2/builder.go
+++ b/internal/adapter/d2/builder.go
@@ -64,6 +64,9 @@ type fileGroup struct {
 	structs    []domain.StructDef
 	functions  []domain.FunctionDef
 	typeDefs   []domain.TypeDef
+	constants  []domain.ConstDef
+	variables  []domain.VarDef
+	errors     []domain.ErrorDef
 }
 
 // groupByFile groups package symbols by their source file.
@@ -116,12 +119,40 @@ func (b *d2TextBuilder) groupByFile(pkg domain.PackageModel, publicOnly bool) []
 		fg.typeDefs = append(fg.typeDefs, td)
 	}
 
+	// Group constants
+	for _, c := range pkg.Constants {
+		if publicOnly && !c.IsExported {
+			continue
+		}
+		fg := getGroup(c.SourceFile)
+		fg.constants = append(fg.constants, c)
+	}
+
+	// Group variables
+	for _, v := range pkg.Variables {
+		if publicOnly && !v.IsExported {
+			continue
+		}
+		fg := getGroup(v.SourceFile)
+		fg.variables = append(fg.variables, v)
+	}
+
+	// Group errors
+	for _, e := range pkg.Errors {
+		if publicOnly && !e.IsExported {
+			continue
+		}
+		fg := getGroup(e.SourceFile)
+		fg.errors = append(fg.errors, e)
+	}
+
 	// Convert map to sorted slice
 	var result []fileGroup
 	for _, fg := range groups {
 		// Skip empty groups
 		if len(fg.interfaces) == 0 && len(fg.structs) == 0 &&
-			len(fg.functions) == 0 && len(fg.typeDefs) == 0 {
+			len(fg.functions) == 0 && len(fg.typeDefs) == 0 &&
+			len(fg.constants) == 0 && len(fg.variables) == 0 && len(fg.errors) == 0 {
 			continue
 		}
 		result = append(result, *fg)
@@ -175,8 +206,94 @@ func (b *d2TextBuilder) writeFileContainer(fg fileGroup, publicOnly bool) {
 		b.writeLine("")
 	}
 
+	// Write constants container (if any)
+	if len(fg.constants) > 0 {
+		b.writeConstantsBlock(fg.constants)
+		b.writeLine("")
+	}
+
+	// Write variables container (if any)
+	if len(fg.variables) > 0 {
+		b.writeVariablesBlock(fg.variables)
+		b.writeLine("")
+	}
+
+	// Write errors container (if any)
+	if len(fg.errors) > 0 {
+		b.writeErrorsBlock(fg.errors)
+		b.writeLine("")
+	}
+
 	b.indent--
 	b.writeLine("}")
+}
+
+// writeConstantsBlock renders a D2 class grouping all standalone constants
+// defined in the same source file.
+func (b *d2TextBuilder) writeConstantsBlock(consts []domain.ConstDef) {
+	b.writeLine("Constants: {")
+	b.indent++
+	b.writeLine("shape: class")
+	b.writeLine(`stereotype: "<<const>>"`)
+	b.writeLine("")
+	for _, c := range consts {
+		label := c.Type.String()
+		if label == "" {
+			label = "const"
+		}
+		if c.Value != "" {
+			label = fmt.Sprintf("%s = %s", label, c.Value)
+		}
+		b.writeLine(fmt.Sprintf(`"%s": "%s"`, c.Name, escapeD2(label)))
+	}
+	b.indent--
+	b.writeLine("}")
+}
+
+// writeVariablesBlock renders a D2 class grouping all package-level variables
+// defined in the same source file.
+func (b *d2TextBuilder) writeVariablesBlock(vars []domain.VarDef) {
+	b.writeLine("Variables: {")
+	b.indent++
+	b.writeLine("shape: class")
+	b.writeLine(`stereotype: "<<var>>"`)
+	b.writeLine("")
+	for _, v := range vars {
+		label := v.Type.String()
+		if label == "" {
+			label = "var"
+		}
+		b.writeLine(fmt.Sprintf(`"%s": "%s"`, v.Name, escapeD2(label)))
+	}
+	b.indent--
+	b.writeLine("}")
+}
+
+// writeErrorsBlock renders a D2 class grouping sentinel error variables
+// defined in the same source file.
+func (b *d2TextBuilder) writeErrorsBlock(errs []domain.ErrorDef) {
+	b.writeLine("Errors: {")
+	b.indent++
+	b.writeLine("shape: class")
+	b.writeLine(`stereotype: "<<error>>"`)
+	b.writeLine("")
+	for _, e := range errs {
+		label := e.Message
+		if label == "" {
+			label = "error"
+		}
+		b.writeLine(fmt.Sprintf(`"%s": "%s"`, e.Name, escapeD2(label)))
+	}
+	b.indent--
+	b.writeLine("}")
+}
+
+// escapeD2 escapes characters in a string so it can safely appear inside
+// a double-quoted D2 label.
+func escapeD2(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `"`, `\"`)
+	return s
 }
 
 // collectSymbolInfo collects stereotype information from all symbols in a file group.

--- a/internal/adapter/d2/combined_builder.go
+++ b/internal/adapter/d2/combined_builder.go
@@ -116,6 +116,20 @@ func (b *combinedBuilder) writePackageContainer(pkg domain.PackageModel, symbolI
 		b.writeLine("")
 	}
 
+	// Write exported constants, variables, and errors blocks
+	if exportedConsts := pkg.ExportedConstants(); len(exportedConsts) > 0 {
+		b.writeConstantsBlock(exportedConsts)
+		b.writeLine("")
+	}
+	if exportedVars := pkg.ExportedVariables(); len(exportedVars) > 0 {
+		b.writeVariablesBlock(exportedVars)
+		b.writeLine("")
+	}
+	if exportedErrs := pkg.ExportedErrors(); len(exportedErrs) > 0 {
+		b.writeErrorsBlock(exportedErrs)
+		b.writeLine("")
+	}
+
 	// Write intra-package dependencies
 	intraDeps := b.collectIntraPackageDeps(pkg, symbolIndex)
 	if len(intraDeps) > 0 {
@@ -258,6 +272,63 @@ func (b *combinedBuilder) writeTypeDef(td domain.TypeDef) {
 		}
 	}
 
+	b.indent--
+	b.writeLine("}")
+}
+
+// writeConstantsBlock renders exported constants as a grouped D2 class.
+func (b *combinedBuilder) writeConstantsBlock(consts []domain.ConstDef) {
+	b.writeLine("Constants: {")
+	b.indent++
+	b.writeLine("shape: class")
+	b.writeLine(`stereotype: "<<const>>"`)
+	b.writeLine("")
+	for _, c := range consts {
+		label := c.Type.String()
+		if label == "" {
+			label = "const"
+		}
+		if c.Value != "" {
+			label = fmt.Sprintf("%s = %s", label, c.Value)
+		}
+		b.writeLine(fmt.Sprintf(`"%s": "%s"`, c.Name, escapeD2(label)))
+	}
+	b.indent--
+	b.writeLine("}")
+}
+
+// writeVariablesBlock renders exported variables as a grouped D2 class.
+func (b *combinedBuilder) writeVariablesBlock(vars []domain.VarDef) {
+	b.writeLine("Variables: {")
+	b.indent++
+	b.writeLine("shape: class")
+	b.writeLine(`stereotype: "<<var>>"`)
+	b.writeLine("")
+	for _, v := range vars {
+		label := v.Type.String()
+		if label == "" {
+			label = "var"
+		}
+		b.writeLine(fmt.Sprintf(`"%s": "%s"`, v.Name, escapeD2(label)))
+	}
+	b.indent--
+	b.writeLine("}")
+}
+
+// writeErrorsBlock renders exported sentinel errors as a grouped D2 class.
+func (b *combinedBuilder) writeErrorsBlock(errs []domain.ErrorDef) {
+	b.writeLine("Errors: {")
+	b.indent++
+	b.writeLine("shape: class")
+	b.writeLine(`stereotype: "<<error>>"`)
+	b.writeLine("")
+	for _, e := range errs {
+		label := e.Message
+		if label == "" {
+			label = "error"
+		}
+		b.writeLine(fmt.Sprintf(`"%s": "%s"`, e.Name, escapeD2(label)))
+	}
 	b.indent--
 	b.writeLine("}")
 }

--- a/internal/adapter/golang/reader.go
+++ b/internal/adapter/golang/reader.go
@@ -117,6 +117,12 @@ func (r *reader) convertPackage(pkg *packages.Package) (domain.PackageModel, err
 	// Extract type definitions
 	model.TypeDefs = r.extractTypeDefs(pkg, astFiles, constantsByType)
 
+	// Extract standalone constants (those not captured as TypeDef enum values).
+	model.Constants = r.extractConstants(pkg, astFiles)
+
+	// Extract package-level variables and sentinel errors.
+	model.Variables, model.Errors = r.extractVarsAndErrors(pkg, astFiles)
+
 	// Collect dependencies
 	model.Dependencies = r.collectDependencies(pkg, &model)
 
@@ -390,6 +396,210 @@ func (r *reader) extractTypeDefs(
 	}
 
 	return typeDefs
+}
+
+// extractConstants extracts standalone package-level constants.
+// Constants whose type is a named user-defined type are considered part of
+// a TypeDef (enum pattern) and are skipped here — they remain accessible
+// through TypeDef.Constants.
+func (r *reader) extractConstants(pkg *packages.Package, astFiles map[string]*ast.File) []domain.ConstDef {
+	var constants []domain.ConstDef
+
+	scope := pkg.Types.Scope()
+	for _, name := range scope.Names() {
+		obj := scope.Lookup(name)
+		cnst, ok := obj.(*types.Const)
+		if !ok {
+			continue
+		}
+
+		// Skip enum constants — those whose type is a named user-defined type
+		// and are captured via TypeDef.Constants.
+		if _, isNamed := cnst.Type().(*types.Named); isNamed {
+			continue
+		}
+
+		sourceFile := r.getSourceFile(pkg.Fset, cnst.Pos())
+		doc := r.getDocComment(astFiles, sourceFile, name)
+		value := r.getConstValueText(astFiles, sourceFile, name)
+		if value == "" {
+			value = cnst.Val().ExactString()
+		}
+
+		constants = append(constants, domain.ConstDef{
+			Name:       name,
+			Type:       r.convertTypeRef(cnst.Type()),
+			Value:      value,
+			IsExported: isExported(name),
+			SourceFile: sourceFile,
+			Doc:        doc,
+		})
+	}
+
+	return constants
+}
+
+// extractVarsAndErrors extracts package-level variables, separating sentinel
+// errors (errors.New(...) / fmt.Errorf(...)) into a dedicated slice.
+func (r *reader) extractVarsAndErrors(
+	pkg *packages.Package,
+	astFiles map[string]*ast.File,
+) ([]domain.VarDef, []domain.ErrorDef) {
+	var vars []domain.VarDef
+	var errs []domain.ErrorDef
+
+	scope := pkg.Types.Scope()
+	for _, name := range scope.Names() {
+		obj := scope.Lookup(name)
+		v, ok := obj.(*types.Var)
+		if !ok {
+			continue
+		}
+
+		// Skip fields and function params — only package-level vars.
+		if v.IsField() {
+			continue
+		}
+
+		sourceFile := r.getSourceFile(pkg.Fset, v.Pos())
+		doc := r.getDocComment(astFiles, sourceFile, name)
+
+		if msg, isErr := r.extractErrorMessage(astFiles, sourceFile, name); isErr {
+			errs = append(errs, domain.ErrorDef{
+				Name:       name,
+				Message:    msg,
+				IsExported: isExported(name),
+				SourceFile: sourceFile,
+				Doc:        doc,
+			})
+			continue
+		}
+
+		vars = append(vars, domain.VarDef{
+			Name:       name,
+			Type:       r.convertTypeRef(v.Type()),
+			IsExported: isExported(name),
+			SourceFile: sourceFile,
+			Doc:        doc,
+		})
+	}
+
+	return vars, errs
+}
+
+// getConstValueText returns the literal value source text for a constant.
+// Returns an empty string if the declaration cannot be located or the
+// value is not a basic literal.
+func (r *reader) getConstValueText(astFiles map[string]*ast.File, filename, name string) string {
+	for path, f := range astFiles {
+		if filepath.Base(path) != filename {
+			continue
+		}
+		for _, decl := range f.Decls {
+			gd, ok := decl.(*ast.GenDecl)
+			if !ok || gd.Tok != token.CONST {
+				continue
+			}
+			for _, spec := range gd.Specs {
+				vs, ok := spec.(*ast.ValueSpec)
+				if !ok {
+					continue
+				}
+				for i, n := range vs.Names {
+					if n.Name != name {
+						continue
+					}
+					if i < len(vs.Values) {
+						return exprText(vs.Values[i])
+					}
+					// No explicit value (e.g. grouped iota) — fall back later.
+					return ""
+				}
+			}
+		}
+	}
+	return ""
+}
+
+// extractErrorMessage inspects the var declaration for `name` in the given
+// source file and, if it is initialised with errors.New(...) or fmt.Errorf(...)
+// where the first argument is a string literal, returns the unquoted message.
+// The second return value reports whether the variable looked like a sentinel
+// error at all (even when we couldn't extract a literal message).
+func (r *reader) extractErrorMessage(astFiles map[string]*ast.File, filename, name string) (string, bool) {
+	for path, f := range astFiles {
+		if filepath.Base(path) != filename {
+			continue
+		}
+		for _, decl := range f.Decls {
+			gd, ok := decl.(*ast.GenDecl)
+			if !ok || gd.Tok != token.VAR {
+				continue
+			}
+			for _, spec := range gd.Specs {
+				vs, ok := spec.(*ast.ValueSpec)
+				if !ok {
+					continue
+				}
+				for i, n := range vs.Names {
+					if n.Name != name {
+						continue
+					}
+					if i >= len(vs.Values) {
+						return "", false
+					}
+					call, ok := vs.Values[i].(*ast.CallExpr)
+					if !ok {
+						return "", false
+					}
+					sel, ok := call.Fun.(*ast.SelectorExpr)
+					if !ok {
+						return "", false
+					}
+					pkgIdent, ok := sel.X.(*ast.Ident)
+					if !ok {
+						return "", false
+					}
+					isErrorCtor := (pkgIdent.Name == "errors" && sel.Sel.Name == "New") ||
+						(pkgIdent.Name == "fmt" && sel.Sel.Name == "Errorf")
+					if !isErrorCtor {
+						return "", false
+					}
+					if len(call.Args) == 0 {
+						return "", true
+					}
+					lit, ok := call.Args[0].(*ast.BasicLit)
+					if !ok || lit.Kind != token.STRING {
+						return "", true
+					}
+					// Strip quotes from the string literal.
+					unquoted := lit.Value
+					if len(unquoted) >= 2 {
+						unquoted = unquoted[1 : len(unquoted)-1]
+					}
+					return unquoted, true
+				}
+			}
+		}
+	}
+	return "", false
+}
+
+// exprText returns a best-effort textual representation of a simple expression.
+// Only basic literals and identifiers (for `iota` and similar) are supported;
+// more complex expressions yield an empty string.
+func exprText(e ast.Expr) string {
+	switch v := e.(type) {
+	case *ast.BasicLit:
+		return v.Value
+	case *ast.Ident:
+		return v.Name
+	case *ast.UnaryExpr:
+		if lit, ok := v.X.(*ast.BasicLit); ok {
+			return v.Op.String() + lit.Value
+		}
+	}
+	return ""
 }
 
 // convertMethod converts a types.Func to a domain.MethodDef.

--- a/internal/adapter/golang/reader_test.go
+++ b/internal/adapter/golang/reader_test.go
@@ -398,3 +398,178 @@ func privateFunc() {}
 		t.Errorf("Expected 1 PublicFunc, got %d", publicFuncCount)
 	}
 }
+
+// loadSingleModelFromSources writes the given files into a fresh Go module
+// under a temp directory and loads the resulting package. It returns the
+// single extracted PackageModel.
+func loadSingleModelFromSources(t *testing.T, sources map[string]string) domain.PackageModel {
+	t.Helper()
+	tmpDir := t.TempDir()
+
+	goMod := "module test.example/m2a\n\ngo 1.21\n"
+	if err := os.WriteFile(filepath.Join(tmpDir, "go.mod"), []byte(goMod), 0644); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+	for name, content := range sources {
+		if err := os.WriteFile(filepath.Join(tmpDir, name), []byte(content), 0644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	oldDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	defer os.Chdir(oldDir)
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	r := NewReader()
+	models, err := r.Read(context.Background(), []string{"."})
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if len(models) != 1 {
+		t.Fatalf("want 1 model, got %d", len(models))
+	}
+	return models[0]
+}
+
+// TestReader_ExtractsStandaloneConstants verifies that plain package-level
+// constants surface in PackageModel.Constants and that enum constants are
+// left on their owning TypeDef rather than duplicated.
+func TestReader_ExtractsStandaloneConstants(t *testing.T) {
+	model := loadSingleModelFromSources(t, map[string]string{
+		"p.go": `package p
+
+// MaxRetries caps the number of retries.
+const MaxRetries = 5
+
+// DefaultName is the default name.
+const DefaultName = "bob"
+
+// Pi is an untyped float const.
+const Pi = 3.14
+
+// internalConst is unexported.
+const internalConst = 42
+
+// Status is an enum-like type.
+type Status string
+
+const (
+	StatusActive   Status = "active"
+	StatusInactive Status = "inactive"
+)
+`,
+	})
+
+	got := make(map[string]domain.ConstDef)
+	for _, c := range model.Constants {
+		got[c.Name] = c
+	}
+
+	for _, want := range []string{"MaxRetries", "DefaultName", "Pi", "internalConst"} {
+		if _, ok := got[want]; !ok {
+			t.Errorf("expected const %q in Constants, have %v", want, keys(got))
+		}
+	}
+	for _, excl := range []string{"StatusActive", "StatusInactive"} {
+		if _, ok := got[excl]; ok {
+			t.Errorf("enum const %q must not appear in Constants", excl)
+		}
+	}
+
+	if c := got["MaxRetries"]; c.Value != "5" || !c.IsExported {
+		t.Errorf("MaxRetries: %+v", c)
+	}
+	if c := got["DefaultName"]; c.Value != `"bob"` {
+		t.Errorf("DefaultName value: got %q, want %q", c.Value, `"bob"`)
+	}
+	if c := got["internalConst"]; c.IsExported {
+		t.Errorf("internalConst should not be exported")
+	}
+
+	// TypeDef should still carry its enum constants.
+	var status *domain.TypeDef
+	for i := range model.TypeDefs {
+		if model.TypeDefs[i].Name == "Status" {
+			status = &model.TypeDefs[i]
+			break
+		}
+	}
+	if status == nil {
+		t.Fatalf("Status TypeDef missing")
+	}
+	if len(status.Constants) != 2 {
+		t.Errorf("Status enum constants: got %v, want 2", status.Constants)
+	}
+}
+
+// TestReader_SplitsVarsAndErrors verifies that sentinel-error variables land
+// in Errors while plain package-level vars land in Variables.
+func TestReader_SplitsVarsAndErrors(t *testing.T) {
+	model := loadSingleModelFromSources(t, map[string]string{
+		"p.go": `package p
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrNotFound indicates a missing record.
+var ErrNotFound = errors.New("not found")
+
+// ErrBadArg is another sentinel error.
+var ErrBadArg = fmt.Errorf("bad argument")
+
+// Version is a plain string variable.
+var Version = "1.2.3"
+
+// Counter is a zero-valued int var.
+var Counter int
+
+// errInternal is an unexported sentinel error.
+var errInternal = errors.New("internal")
+`,
+	})
+
+	errs := make(map[string]string)
+	for _, e := range model.Errors {
+		errs[e.Name] = e.Message
+	}
+	if errs["ErrNotFound"] != "not found" {
+		t.Errorf("ErrNotFound: got %q, want %q", errs["ErrNotFound"], "not found")
+	}
+	if errs["ErrBadArg"] != "bad argument" {
+		t.Errorf("ErrBadArg: got %q, want %q", errs["ErrBadArg"], "bad argument")
+	}
+	if _, ok := errs["errInternal"]; !ok {
+		t.Errorf("errInternal missing from Errors: %v", errs)
+	}
+
+	vars := make(map[string]bool)
+	for _, v := range model.Variables {
+		vars[v.Name] = true
+	}
+	for _, want := range []string{"Version", "Counter"} {
+		if !vars[want] {
+			t.Errorf("expected var %q in Variables, have %v", want, keys(vars))
+		}
+	}
+	for _, excl := range []string{"ErrNotFound", "ErrBadArg", "errInternal"} {
+		if vars[excl] {
+			t.Errorf("sentinel error %q must not appear in Variables", excl)
+		}
+	}
+}
+
+// keys returns the sorted key set of a map[string]X for diagnostic output.
+func keys[V any](m map[string]V) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/adapter/yaml/convert.go
+++ b/internal/adapter/yaml/convert.go
@@ -42,6 +42,30 @@ func toSpec(model domain.PackageModel, publicOnly bool) PackageSpec {
 		spec.TypeDefs = append(spec.TypeDefs, toTypeDefSpec(td))
 	}
 
+	consts := model.Constants
+	if publicOnly {
+		consts = model.ExportedConstants()
+	}
+	for _, c := range consts {
+		spec.Constants = append(spec.Constants, toConstSpec(c))
+	}
+
+	vars := model.Variables
+	if publicOnly {
+		vars = model.ExportedVariables()
+	}
+	for _, v := range vars {
+		spec.Variables = append(spec.Variables, toVarSpec(v))
+	}
+
+	errs := model.Errors
+	if publicOnly {
+		errs = model.ExportedErrors()
+	}
+	for _, e := range errs {
+		spec.Errors = append(spec.Errors, toErrorSpec(e))
+	}
+
 	for _, dep := range model.Dependencies {
 		if publicOnly && !dep.ThroughExported {
 			continue
@@ -70,6 +94,15 @@ func fromSpec(spec PackageSpec) domain.PackageModel {
 	}
 	for _, td := range spec.TypeDefs {
 		model.TypeDefs = append(model.TypeDefs, fromTypeDefSpec(td))
+	}
+	for _, c := range spec.Constants {
+		model.Constants = append(model.Constants, fromConstSpec(c))
+	}
+	for _, v := range spec.Variables {
+		model.Variables = append(model.Variables, fromVarSpec(v))
+	}
+	for _, e := range spec.Errors {
+		model.Errors = append(model.Errors, fromErrorSpec(e))
 	}
 	for _, dep := range spec.Dependencies {
 		model.Dependencies = append(model.Dependencies, fromDependencySpec(dep))
@@ -137,6 +170,37 @@ func toTypeDefSpec(t domain.TypeDef) TypeDefSpec {
 		SourceFile:     t.SourceFile,
 		Doc:            t.Doc,
 		Stereotype:     string(t.Stereotype),
+	}
+}
+
+func toConstSpec(c domain.ConstDef) ConstSpec {
+	return ConstSpec{
+		Name:       c.Name,
+		Type:       toTypeRefSpec(c.Type),
+		Value:      c.Value,
+		Exported:   c.IsExported,
+		SourceFile: c.SourceFile,
+		Doc:        c.Doc,
+	}
+}
+
+func toVarSpec(v domain.VarDef) VarSpec {
+	return VarSpec{
+		Name:       v.Name,
+		Type:       toTypeRefSpec(v.Type),
+		Exported:   v.IsExported,
+		SourceFile: v.SourceFile,
+		Doc:        v.Doc,
+	}
+}
+
+func toErrorSpec(e domain.ErrorDef) ErrorSpec {
+	return ErrorSpec{
+		Name:       e.Name,
+		Message:    e.Message,
+		Exported:   e.IsExported,
+		SourceFile: e.SourceFile,
+		Doc:        e.Doc,
 	}
 }
 
@@ -266,6 +330,37 @@ func fromTypeDefSpec(s TypeDefSpec) domain.TypeDef {
 		SourceFile:     s.SourceFile,
 		Doc:            s.Doc,
 		Stereotype:     domain.Stereotype(s.Stereotype),
+	}
+}
+
+func fromConstSpec(s ConstSpec) domain.ConstDef {
+	return domain.ConstDef{
+		Name:       s.Name,
+		Type:       fromTypeRefSpec(s.Type),
+		Value:      s.Value,
+		IsExported: s.Exported,
+		SourceFile: s.SourceFile,
+		Doc:        s.Doc,
+	}
+}
+
+func fromVarSpec(s VarSpec) domain.VarDef {
+	return domain.VarDef{
+		Name:       s.Name,
+		Type:       fromTypeRefSpec(s.Type),
+		IsExported: s.Exported,
+		SourceFile: s.SourceFile,
+		Doc:        s.Doc,
+	}
+}
+
+func fromErrorSpec(s ErrorSpec) domain.ErrorDef {
+	return domain.ErrorDef{
+		Name:       s.Name,
+		Message:    s.Message,
+		IsExported: s.Exported,
+		SourceFile: s.SourceFile,
+		Doc:        s.Doc,
 	}
 }
 

--- a/internal/adapter/yaml/roundtrip_test.go
+++ b/internal/adapter/yaml/roundtrip_test.go
@@ -89,6 +89,34 @@ func testPackageModel() domain.PackageModel {
 				Stereotype:     domain.StereotypeEnum,
 			},
 		},
+		Constants: []domain.ConstDef{
+			{
+				Name:       "MaxRetries",
+				Type:       domain.TypeRef{Name: "int"},
+				Value:      "5",
+				IsExported: true,
+				SourceFile: "config.go",
+				Doc:        "MaxRetries caps retries.",
+			},
+		},
+		Variables: []domain.VarDef{
+			{
+				Name:       "Version",
+				Type:       domain.TypeRef{Name: "string"},
+				IsExported: true,
+				SourceFile: "version.go",
+				Doc:        "Version is the build version.",
+			},
+		},
+		Errors: []domain.ErrorDef{
+			{
+				Name:       "ErrNotFound",
+				Message:    "not found",
+				IsExported: true,
+				SourceFile: "errors.go",
+				Doc:        "ErrNotFound is returned when a lookup fails.",
+			},
+		},
 		Dependencies: []domain.Dependency{
 			{
 				From: domain.SymbolRef{
@@ -206,6 +234,33 @@ func TestRoundtrip_SinglePackage(t *testing.T) {
 	td := got.TypeDefs[0]
 	if td.Name != "Status" || len(td.Constants) != 3 {
 		t.Errorf("TypeDef mismatch: name=%s constants=%v", td.Name, td.Constants)
+	}
+
+	// Verify constants
+	if len(got.Constants) != len(original.Constants) {
+		t.Fatalf("Constants count: got %d, want %d", len(got.Constants), len(original.Constants))
+	}
+	c := got.Constants[0]
+	if c.Name != "MaxRetries" || c.Value != "5" || c.Type.Name != "int" || !c.IsExported {
+		t.Errorf("Constant mismatch: %+v", c)
+	}
+
+	// Verify variables
+	if len(got.Variables) != len(original.Variables) {
+		t.Fatalf("Variables count: got %d, want %d", len(got.Variables), len(original.Variables))
+	}
+	v := got.Variables[0]
+	if v.Name != "Version" || v.Type.Name != "string" {
+		t.Errorf("Variable mismatch: %+v", v)
+	}
+
+	// Verify errors
+	if len(got.Errors) != len(original.Errors) {
+		t.Fatalf("Errors count: got %d, want %d", len(got.Errors), len(original.Errors))
+	}
+	e := got.Errors[0]
+	if e.Name != "ErrNotFound" || e.Message != "not found" {
+		t.Errorf("Error mismatch: %+v", e)
 	}
 
 	// Verify dependencies

--- a/internal/adapter/yaml/schema.go
+++ b/internal/adapter/yaml/schema.go
@@ -13,7 +13,38 @@ type PackageSpec struct {
 	Structs      []StructSpec    `yaml:"structs,omitempty"`
 	Functions    []FunctionSpec  `yaml:"functions,omitempty"`
 	TypeDefs     []TypeDefSpec   `yaml:"typedefs,omitempty"`
+	Constants    []ConstSpec     `yaml:"constants,omitempty"`
+	Variables    []VarSpec       `yaml:"variables,omitempty"`
+	Errors       []ErrorSpec     `yaml:"errors,omitempty"`
 	Dependencies []DependencySpec `yaml:"dependencies,omitempty"`
+}
+
+// ConstSpec represents a package-level constant declaration.
+type ConstSpec struct {
+	Name       string      `yaml:"name"`
+	Type       TypeRefSpec `yaml:"type,omitempty"`
+	Value      string      `yaml:"value,omitempty"`
+	Exported   bool        `yaml:"exported"`
+	SourceFile string      `yaml:"source_file,omitempty"`
+	Doc        string      `yaml:"doc,omitempty"`
+}
+
+// VarSpec represents a package-level variable declaration.
+type VarSpec struct {
+	Name       string      `yaml:"name"`
+	Type       TypeRefSpec `yaml:"type,omitempty"`
+	Exported   bool        `yaml:"exported"`
+	SourceFile string      `yaml:"source_file,omitempty"`
+	Doc        string      `yaml:"doc,omitempty"`
+}
+
+// ErrorSpec represents a sentinel error declaration.
+type ErrorSpec struct {
+	Name       string `yaml:"name"`
+	Message    string `yaml:"message,omitempty"`
+	Exported   bool   `yaml:"exported"`
+	SourceFile string `yaml:"source_file,omitempty"`
+	Doc        string `yaml:"doc,omitempty"`
 }
 
 // InterfaceSpec represents an interface definition.

--- a/internal/domain/const.go
+++ b/internal/domain/const.go
@@ -1,0 +1,28 @@
+package domain
+
+// ConstDef represents a package-level constant declaration.
+// This captures standalone constants that are not associated with an
+// enum-like TypeDef. Enum constants continue to live on their owning
+// TypeDef.Constants slice.
+type ConstDef struct {
+	// Name is the constant name, e.g., "MaxRetries".
+	Name string
+
+	// Type is the declared type of the constant. May be a zero-value
+	// TypeRef for untyped constants (e.g., `const Pi = 3.14`).
+	Type TypeRef
+
+	// Value is the literal value as it appears in source, e.g., `"hello"`,
+	// "42", or "iota". Empty if the value cannot be represented as a
+	// simple literal.
+	Value string
+
+	// IsExported indicates if this constant is exported (starts with uppercase).
+	IsExported bool
+
+	// SourceFile is the filename where this constant is defined.
+	SourceFile string
+
+	// Doc is the documentation comment for this constant.
+	Doc string
+}

--- a/internal/domain/error.go
+++ b/internal/domain/error.go
@@ -1,0 +1,23 @@
+package domain
+
+// ErrorDef represents a sentinel error declaration such as
+// `var ErrNotFound = errors.New("not found")` or
+// `var ErrBadArg = fmt.Errorf("bad argument: %w", ErrInput)`.
+type ErrorDef struct {
+	// Name is the error variable name, e.g., "ErrNotFound".
+	Name string
+
+	// Message is the error message string extracted from the constructor
+	// call (errors.New or fmt.Errorf). Empty if the message is not a
+	// simple string literal.
+	Message string
+
+	// IsExported indicates if this error is exported (starts with uppercase).
+	IsExported bool
+
+	// SourceFile is the filename where this error is defined.
+	SourceFile string
+
+	// Doc is the documentation comment for this error.
+	Doc string
+}

--- a/internal/domain/package.go
+++ b/internal/domain/package.go
@@ -1,8 +1,9 @@
 package domain
 
 // PackageModel is the aggregate root representing a Go package's structure.
-// It contains all the symbols (interfaces, structs, functions, type definitions)
-// found in the package, along with their dependencies.
+// It contains all the symbols (interfaces, structs, functions, type definitions,
+// constants, variables, errors) found in the package, along with their
+// dependencies.
 type PackageModel struct {
 	// Path is the package path relative to the module root, e.g., "internal/service".
 	Path string
@@ -21,6 +22,18 @@ type PackageModel struct {
 
 	// TypeDefs is the list of type definitions (type aliases) in this package.
 	TypeDefs []TypeDef
+
+	// Constants is the list of standalone package-level constants. Constants
+	// that belong to an enum-like TypeDef are not duplicated here.
+	Constants []ConstDef
+
+	// Variables is the list of package-level variables (excluding sentinel
+	// errors, which are captured in Errors).
+	Variables []VarDef
+
+	// Errors is the list of sentinel error variables (e.g. declarations of
+	// the form `var ErrFoo = errors.New(...)`).
+	Errors []ErrorDef
 
 	// Dependencies is the list of dependencies between symbols.
 	Dependencies []Dependency
@@ -49,6 +62,15 @@ func (p PackageModel) SourceFiles() []string {
 	}
 	for _, td := range p.TypeDefs {
 		addFile(td.SourceFile)
+	}
+	for _, c := range p.Constants {
+		addFile(c.SourceFile)
+	}
+	for _, v := range p.Variables {
+		addFile(v.SourceFile)
+	}
+	for _, e := range p.Errors {
+		addFile(e.SourceFile)
 	}
 
 	return files
@@ -98,6 +120,39 @@ func (p PackageModel) ExportedTypeDefs() []TypeDef {
 	return result
 }
 
+// ExportedConstants returns only the exported constants.
+func (p PackageModel) ExportedConstants() []ConstDef {
+	var result []ConstDef
+	for _, c := range p.Constants {
+		if c.IsExported {
+			result = append(result, c)
+		}
+	}
+	return result
+}
+
+// ExportedVariables returns only the exported variables.
+func (p PackageModel) ExportedVariables() []VarDef {
+	var result []VarDef
+	for _, v := range p.Variables {
+		if v.IsExported {
+			result = append(result, v)
+		}
+	}
+	return result
+}
+
+// ExportedErrors returns only the exported sentinel errors.
+func (p PackageModel) ExportedErrors() []ErrorDef {
+	var result []ErrorDef
+	for _, e := range p.Errors {
+		if e.IsExported {
+			result = append(result, e)
+		}
+	}
+	return result
+}
+
 // HasExportedSymbols returns true if the package has any exported symbols.
 func (p PackageModel) HasExportedSymbols() bool {
 	for _, iface := range p.Interfaces {
@@ -117,6 +172,21 @@ func (p PackageModel) HasExportedSymbols() bool {
 	}
 	for _, td := range p.TypeDefs {
 		if td.IsExported {
+			return true
+		}
+	}
+	for _, c := range p.Constants {
+		if c.IsExported {
+			return true
+		}
+	}
+	for _, v := range p.Variables {
+		if v.IsExported {
+			return true
+		}
+	}
+	for _, e := range p.Errors {
+		if e.IsExported {
 			return true
 		}
 	}

--- a/internal/domain/variable.go
+++ b/internal/domain/variable.go
@@ -1,0 +1,22 @@
+package domain
+
+// VarDef represents a package-level variable declaration.
+// Sentinel error variables (e.g. `var ErrNotFound = errors.New(...)`) are
+// captured separately as ErrorDef rather than as VarDef.
+type VarDef struct {
+	// Name is the variable name.
+	Name string
+
+	// Type is the declared type of the variable. May be a zero-value
+	// TypeRef if the type is inferred and cannot be resolved statically.
+	Type TypeRef
+
+	// IsExported indicates if this variable is exported (starts with uppercase).
+	IsExported bool
+
+	// SourceFile is the filename where this variable is defined.
+	SourceFile string
+
+	// Doc is the documentation comment for this variable.
+	Doc string
+}


### PR DESCRIPTION
## Summary
- Add `ConstDef`, `VarDef`, `ErrorDef` domain types to `internal/domain/`
- Extend `PackageModel` with `Constants`, `Variables`, `Errors` slices + `ExportedConstants/Variables/Errors` filter methods
- Go reader extracts exported constants (excluding enum values already captured by TypeDefs), variables, and sentinel errors (`errors.New`, `fmt.Errorf`)
- YAML schema/converters handle new fields; roundtrip preserved
- D2 writer renders constants/vars/errors as list items inside package containers

Closes #8

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./...` — all 8 packages pass
- [x] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)