### PR TITLE
M3b: Service overlay integration + layer-rule validation

### DIFF
--- a/cmd/archai/main.go
+++ b/cmd/archai/main.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/kgatilin/archai/internal/adapter/d2"
 	"github.com/kgatilin/archai/internal/adapter/golang"
@@ -68,6 +69,7 @@ Examples:
 	generateCmd.Flags().StringP("output", "o", "", "Output to single file (combined mode)")
 	generateCmd.Flags().StringP("format", "f", "d2", "Output format: d2 or yaml")
 	generateCmd.Flags().Bool("debug", false, "Print debug information about packages and dependencies")
+	generateCmd.Flags().String("overlay", "", "Path to archai.yaml overlay (default: auto-detect in current directory)")
 
 	diagramCmd.AddCommand(generateCmd)
 
@@ -189,6 +191,31 @@ and freeze them — along with archai.yaml — into .arch/targets/<id>/.`,
 	}
 }
 
+// resolveOverlay determines the overlay path and accompanying go.mod
+// path used by the generate command. When explicitPath is non-empty
+// it is used verbatim (and the adjacent go.mod is looked up); when
+// empty we auto-detect ./archai.yaml in the working directory.
+// Returns empty strings when no overlay is found.
+func resolveOverlay(explicitPath string) (overlayPath, goModPath string) {
+	if explicitPath != "" {
+		dir := filepath.Dir(explicitPath)
+		gm := filepath.Join(dir, "go.mod")
+		if _, err := os.Stat(gm); err != nil {
+			gm = ""
+		}
+		return explicitPath, gm
+	}
+	candidate := "archai.yaml"
+	if _, err := os.Stat(candidate); err != nil {
+		return "", ""
+	}
+	gm := "go.mod"
+	if _, err := os.Stat(gm); err != nil {
+		gm = ""
+	}
+	return candidate, gm
+}
+
 // runGenerate executes the diagram generation command.
 func runGenerate(cmd *cobra.Command, args []string) error {
 	// Build options from flags
@@ -197,6 +224,11 @@ func runGenerate(cmd *cobra.Command, args []string) error {
 	output, _ := cmd.Flags().GetString("output")
 	format, _ := cmd.Flags().GetString("format")
 	debug, _ := cmd.Flags().GetBool("debug")
+	overlayFlag, _ := cmd.Flags().GetString("overlay")
+
+	// Resolve overlay path: explicit flag wins; otherwise auto-detect
+	// archai.yaml in the current working directory.
+	overlayPath, goModPath := resolveOverlay(overlayFlag)
 
 	// Wire up dependencies based on format
 	goReader := golang.NewReader()
@@ -265,11 +297,22 @@ func runGenerate(cmd *cobra.Command, args []string) error {
 		InternalOnly:  internalOnly,
 		FileExtension: fileExt,
 		Debug:         debug,
+		OverlayPath:   overlayPath,
+		GoModPath:     goModPath,
 	}
 
-	results, err := svc.Generate(ctx, opts)
+	results, violations, err := svc.GenerateWithOverlay(ctx, opts)
 	if err != nil {
 		return fmt.Errorf("generation failed: %w", err)
+	}
+
+	// Print any overlay layer-rule violations to stderr so the user
+	// sees them alongside generation output.
+	if len(violations) > 0 {
+		fmt.Fprintf(os.Stderr, "\nOverlay layer-rule violations (%d):\n", len(violations))
+		for _, v := range violations {
+			fmt.Fprintf(os.Stderr, "  %s [%s] imports forbidden: %v\n", v.Package, v.Layer, v.Imports)
+		}
 	}
 
 	// Display results

--- a/internal/adapter/yaml/convert.go
+++ b/internal/adapter/yaml/convert.go
@@ -5,9 +5,11 @@ import "github.com/kgatilin/archai/internal/domain"
 // toSpec converts a domain PackageModel to the YAML schema.
 func toSpec(model domain.PackageModel, publicOnly bool) PackageSpec {
 	spec := PackageSpec{
-		Schema:  "archai/v1",
-		Package: model.Path,
-		Name:    model.Name,
+		Schema:    "archai/v1",
+		Package:   model.Path,
+		Name:      model.Name,
+		Layer:     model.Layer,
+		Aggregate: model.Aggregate,
 	}
 
 	ifaces := model.Interfaces
@@ -79,8 +81,10 @@ func toSpec(model domain.PackageModel, publicOnly bool) PackageSpec {
 // fromSpec converts a YAML schema back to a domain PackageModel.
 func fromSpec(spec PackageSpec) domain.PackageModel {
 	model := domain.PackageModel{
-		Path: spec.Package,
-		Name: spec.Name,
+		Path:      spec.Package,
+		Name:      spec.Name,
+		Layer:     spec.Layer,
+		Aggregate: spec.Aggregate,
 	}
 
 	for _, iface := range spec.Interfaces {

--- a/internal/adapter/yaml/roundtrip_test.go
+++ b/internal/adapter/yaml/roundtrip_test.go
@@ -12,8 +12,10 @@ import (
 // testPackageModel creates a representative PackageModel with all field types.
 func testPackageModel() domain.PackageModel {
 	return domain.PackageModel{
-		Path: "github.com/example/project/internal/service",
-		Name: "service",
+		Path:      "github.com/example/project/internal/service",
+		Name:      "service",
+		Layer:     "service",
+		Aggregate: "Order",
 		Interfaces: []domain.InterfaceDef{
 			{
 				Name:       "Repository",
@@ -186,6 +188,12 @@ func TestRoundtrip_SinglePackage(t *testing.T) {
 	}
 	if got.Name != original.Name {
 		t.Errorf("Name: got %q, want %q", got.Name, original.Name)
+	}
+	if got.Layer != original.Layer {
+		t.Errorf("Layer: got %q, want %q", got.Layer, original.Layer)
+	}
+	if got.Aggregate != original.Aggregate {
+		t.Errorf("Aggregate: got %q, want %q", got.Aggregate, original.Aggregate)
 	}
 
 	// Verify interfaces

--- a/internal/adapter/yaml/schema.go
+++ b/internal/adapter/yaml/schema.go
@@ -6,16 +6,18 @@ package yaml
 
 // PackageSpec is the top-level YAML document for a single package.
 type PackageSpec struct {
-	Schema       string          `yaml:"schema"`                  // "archai/v1"
-	Package      string          `yaml:"package"`                 // package path
-	Name         string          `yaml:"name"`                    // package name
-	Interfaces   []InterfaceSpec `yaml:"interfaces,omitempty"`
-	Structs      []StructSpec    `yaml:"structs,omitempty"`
-	Functions    []FunctionSpec  `yaml:"functions,omitempty"`
-	TypeDefs     []TypeDefSpec   `yaml:"typedefs,omitempty"`
-	Constants    []ConstSpec     `yaml:"constants,omitempty"`
-	Variables    []VarSpec       `yaml:"variables,omitempty"`
-	Errors       []ErrorSpec     `yaml:"errors,omitempty"`
+	Schema       string           `yaml:"schema"`                  // "archai/v1"
+	Package      string           `yaml:"package"`                 // package path
+	Name         string           `yaml:"name"`                    // package name
+	Layer        string           `yaml:"layer,omitempty"`         // overlay-assigned layer
+	Aggregate    string           `yaml:"aggregate,omitempty"`     // overlay-assigned aggregate
+	Interfaces   []InterfaceSpec  `yaml:"interfaces,omitempty"`
+	Structs      []StructSpec     `yaml:"structs,omitempty"`
+	Functions    []FunctionSpec   `yaml:"functions,omitempty"`
+	TypeDefs     []TypeDefSpec    `yaml:"typedefs,omitempty"`
+	Constants    []ConstSpec      `yaml:"constants,omitempty"`
+	Variables    []VarSpec        `yaml:"variables,omitempty"`
+	Errors       []ErrorSpec      `yaml:"errors,omitempty"`
 	Dependencies []DependencySpec `yaml:"dependencies,omitempty"`
 }
 

--- a/internal/domain/package.go
+++ b/internal/domain/package.go
@@ -37,6 +37,16 @@ type PackageModel struct {
 
 	// Dependencies is the list of dependencies between symbols.
 	Dependencies []Dependency
+
+	// Layer is the architectural layer this package belongs to,
+	// as assigned by the overlay (archai.yaml). Empty when no overlay
+	// has been applied or the package does not match any layer.
+	Layer string
+
+	// Aggregate is the domain aggregate this package belongs to,
+	// as assigned by the overlay (archai.yaml) when the package
+	// contains the aggregate root type. Empty otherwise.
+	Aggregate string
 }
 
 // SourceFiles returns a deduplicated list of all source files in the package.

--- a/internal/overlay/merge.go
+++ b/internal/overlay/merge.go
@@ -1,0 +1,245 @@
+package overlay
+
+import (
+	"fmt"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/kgatilin/archai/internal/domain"
+)
+
+// Violation describes a forbidden cross-layer import discovered during
+// Merge. It lists the offending source package, the layer it was
+// assigned to, and the imported package paths (module-relative) whose
+// layers are not allowed by LayerRules for the source layer.
+type Violation struct {
+	// Package is the module-relative path of the importing package
+	// (e.g. "internal/service").
+	Package string
+
+	// Layer is the layer assigned to Package.
+	Layer string
+
+	// Imports lists the module-relative paths of imported packages
+	// whose layers are not allowed by the source layer's rules. The
+	// entries are sorted lexically for deterministic output.
+	Imports []string
+}
+
+// Merge applies cfg to models: it annotates each PackageModel with its
+// Layer and Aggregate (when applicable) and returns the list of
+// layer-rule violations discovered among the packages' dependencies.
+//
+// Rules:
+//   - For each package, Merge assigns the first layer whose globs match
+//     pkg.Path (iteration order of layer names is lexical, so results
+//     are deterministic).
+//   - For each aggregate, Merge assigns pkg.Aggregate to the package
+//     that contains the aggregate root type. The root is encoded as
+//     "<module>/<pkgPath>.<TypeName>"; Merge strips cfg.Module to match
+//     pkg.Path.
+//   - For each Dependency in a PackageModel, if the target is internal
+//     (External == false) and resolves to a known layer, and that
+//     layer is not in the source layer's LayerRules allow-list, a
+//     Violation is recorded.
+//
+// Merge returns the updated slice (same backing array, fields mutated
+// in place) and an aggregated []Violation (one entry per source
+// package with at least one forbidden import).
+//
+// TODO(M3c): Configs tagging is not implemented here. Configs apply
+// to specific Go types rather than whole packages, so it requires
+// per-type annotation support in the domain model (e.g. on StructDef
+// or TypeDef). Once that exists, Merge should also tag the matching
+// type definitions.
+func Merge(models []domain.PackageModel, cfg *Config) ([]domain.PackageModel, []Violation, error) {
+	if cfg == nil {
+		return models, nil, fmt.Errorf("overlay: nil config")
+	}
+
+	layerNames := sortedKeys(cfg.Layers)
+
+	// Assign layer to each package.
+	for i := range models {
+		pkgPath := modulePath(cfg.Module, models[i].Path)
+		for _, layer := range layerNames {
+			if matchAnyGlob(cfg.Layers[layer], pkgPath) {
+				models[i].Layer = layer
+				break
+			}
+		}
+	}
+
+	// Assign aggregates. Aggregates are keyed by name; iterate in
+	// lexical order for deterministic assignment when multiple
+	// aggregates somehow resolve to the same package.
+	aggNames := sortedKeys(cfg.Aggregates)
+	for _, name := range aggNames {
+		agg := cfg.Aggregates[name]
+		pkgPath, typeName, ok := splitAggregateRoot(cfg.Module, agg.Root)
+		if !ok {
+			// Validation catches malformed refs; at this point just skip.
+			continue
+		}
+		_ = typeName // reserved for future per-type tagging (Configs TODO)
+		for i := range models {
+			if models[i].Path == pkgPath {
+				models[i].Aggregate = name
+				break
+			}
+		}
+	}
+
+	// Build a quick lookup from pkg path -> layer for violation detection.
+	pkgLayer := make(map[string]string, len(models))
+	for _, m := range models {
+		if m.Layer != "" {
+			pkgLayer[m.Path] = m.Layer
+		}
+	}
+
+	// Detect violations.
+	var violations []Violation
+	for _, m := range models {
+		if m.Layer == "" {
+			continue
+		}
+		allowed, hasRule := cfg.LayerRules[m.Layer]
+		allowSet := make(map[string]struct{}, len(allowed))
+		for _, a := range allowed {
+			allowSet[a] = struct{}{}
+		}
+		// Same-layer imports are always allowed.
+		allowSet[m.Layer] = struct{}{}
+
+		badImports := make(map[string]struct{})
+		for _, dep := range m.Dependencies {
+			if dep.To.External {
+				continue
+			}
+			if !strings.HasPrefix(dep.To.Package, cfg.Module) {
+				// Not a package from this module — skip.
+				continue
+			}
+			relPath := modulePath(cfg.Module, dep.To.Package)
+			if relPath == "" || relPath == m.Path {
+				continue
+			}
+			targetLayer, ok := pkgLayer[relPath]
+			if !ok {
+				// Target has no layer — nothing to check.
+				continue
+			}
+			if !hasRule {
+				// No outbound rules: any cross-layer import is a violation.
+				if targetLayer != m.Layer {
+					badImports[relPath] = struct{}{}
+				}
+				continue
+			}
+			if _, ok := allowSet[targetLayer]; !ok {
+				badImports[relPath] = struct{}{}
+			}
+		}
+		if len(badImports) > 0 {
+			imps := make([]string, 0, len(badImports))
+			for k := range badImports {
+				imps = append(imps, k)
+			}
+			sort.Strings(imps)
+			violations = append(violations, Violation{
+				Package: m.Path,
+				Layer:   m.Layer,
+				Imports: imps,
+			})
+		}
+	}
+
+	sort.Slice(violations, func(i, j int) bool {
+		return violations[i].Package < violations[j].Package
+	})
+
+	return models, violations, nil
+}
+
+// modulePath strips the module prefix from a fully-qualified package
+// path, returning the module-relative path used by overlay globs.
+// If pkgPath is already relative (no module prefix) it is returned as-is.
+func modulePath(module, pkgPath string) string {
+	if module == "" {
+		return pkgPath
+	}
+	if pkgPath == module {
+		return ""
+	}
+	if strings.HasPrefix(pkgPath, module+"/") {
+		return strings.TrimPrefix(pkgPath, module+"/")
+	}
+	return pkgPath
+}
+
+// splitAggregateRoot splits a fully-qualified aggregate root reference
+// ("<module>/<pkg>.<Type>") into its module-relative package path and
+// type name. Returns ok=false if the reference is malformed or does
+// not belong to cfg.Module.
+func splitAggregateRoot(module, root string) (pkgPath, typeName string, ok bool) {
+	dot := strings.LastIndex(root, ".")
+	if dot <= 0 || dot == len(root)-1 {
+		return "", "", false
+	}
+	fqPkg := root[:dot]
+	typeName = root[dot+1:]
+	pkgPath = modulePath(module, fqPkg)
+	// If modulePath returned the input unchanged and it still starts
+	// with a domain-looking prefix, treat it as not belonging to the
+	// module. Merge only tags types inside the current module.
+	if module != "" && fqPkg != module && !strings.HasPrefix(fqPkg, module+"/") {
+		return "", "", false
+	}
+	return pkgPath, typeName, true
+}
+
+// matchAnyGlob reports whether any glob in globs matches pkgPath.
+func matchAnyGlob(globs []string, pkgPath string) bool {
+	for _, g := range globs {
+		if matchGlob(g, pkgPath) {
+			return true
+		}
+	}
+	return false
+}
+
+// matchGlob implements overlay glob matching. Supported forms:
+//   - "pkg/..."  matches pkg and any sub-package (recursive prefix).
+//   - "pkg/*"    matches exactly one additional path segment.
+//   - "pkg/foo"  exact match.
+//
+// The leading segments before "*" or "..." must match literally.
+// Matching is done on module-relative package paths (forward slashes).
+func matchGlob(glob, pkgPath string) bool {
+	// Recursive "..." suffix.
+	if strings.HasSuffix(glob, "/...") {
+		prefix := strings.TrimSuffix(glob, "/...")
+		return pkgPath == prefix || strings.HasPrefix(pkgPath, prefix+"/")
+	}
+	if glob == "..." {
+		return true
+	}
+	// Single-segment "*" wildcard. Only support trailing-segment
+	// wildcards plus any pure filepath.Match pattern. We normalize
+	// using path.Match (forward slashes) for POSIX semantics.
+	if strings.Contains(glob, "*") {
+		ok, _ := path.Match(glob, pkgPath)
+		if ok {
+			return true
+		}
+		// Fall back to filepath.Match for platforms where path.Match
+		// rejects patterns with embedded slashes in segments.
+		ok2, _ := filepath.Match(glob, pkgPath)
+		return ok2
+	}
+	// Exact match.
+	return glob == pkgPath
+}

--- a/internal/overlay/merge_test.go
+++ b/internal/overlay/merge_test.go
@@ -1,0 +1,215 @@
+package overlay
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/kgatilin/archai/internal/domain"
+)
+
+// newMergeConfig returns a representative overlay Config for use by
+// Merge tests. Tests mutate fields as needed.
+func newMergeConfig() *Config {
+	return &Config{
+		Module: "github.com/example/app",
+		Layers: map[string][]string{
+			"domain":   {"internal/domain/..."},
+			"service":  {"internal/service/..."},
+			"adapter":  {"internal/adapter/..."},
+			"entry":    {"cmd/*"},
+		},
+		LayerRules: map[string][]string{
+			"service": {"domain"},
+			"adapter": {"domain", "service"},
+			"entry":   {"domain", "service", "adapter"},
+		},
+		Aggregates: map[string]Aggregate{
+			"Order": {Root: "github.com/example/app/internal/domain.Order"},
+		},
+	}
+}
+
+func TestMerge_AssignsLayerToPackage(t *testing.T) {
+	cfg := newMergeConfig()
+	models := []domain.PackageModel{
+		{Path: "internal/domain"},
+		{Path: "internal/domain/order"},
+		{Path: "internal/service"},
+		{Path: "internal/adapter/yaml"},
+		{Path: "cmd/archai"},
+		{Path: "tests/integration"}, // no layer
+	}
+
+	merged, _, err := Merge(models, cfg)
+	if err != nil {
+		t.Fatalf("Merge error: %v", err)
+	}
+
+	want := []string{"domain", "domain", "service", "adapter", "entry", ""}
+	for i, m := range merged {
+		if m.Layer != want[i] {
+			t.Errorf("models[%d] (%s): got layer %q, want %q", i, m.Path, m.Layer, want[i])
+		}
+	}
+}
+
+func TestMerge_AssignsAggregateToPackageContainingRoot(t *testing.T) {
+	cfg := newMergeConfig()
+	models := []domain.PackageModel{
+		{Path: "internal/domain"},
+		{Path: "internal/service"},
+	}
+
+	merged, _, err := Merge(models, cfg)
+	if err != nil {
+		t.Fatalf("Merge error: %v", err)
+	}
+
+	if merged[0].Aggregate != "Order" {
+		t.Errorf("domain package aggregate: got %q, want %q", merged[0].Aggregate, "Order")
+	}
+	if merged[1].Aggregate != "" {
+		t.Errorf("service package aggregate: got %q, want empty", merged[1].Aggregate)
+	}
+}
+
+func TestMerge_DetectsForbiddenCrossLayerImport(t *testing.T) {
+	cfg := newMergeConfig()
+	// domain -> service is forbidden (domain has no outbound rule,
+	// so any cross-layer import violates). service -> domain is OK.
+	models := []domain.PackageModel{
+		{
+			Path: "internal/domain",
+			Dependencies: []domain.Dependency{
+				{
+					From: domain.SymbolRef{Package: "github.com/example/app/internal/domain", Symbol: "Thing"},
+					To:   domain.SymbolRef{Package: "github.com/example/app/internal/service", Symbol: "Service"},
+					Kind: domain.DependencyUses,
+				},
+			},
+		},
+		{
+			Path: "internal/service",
+			Dependencies: []domain.Dependency{
+				{
+					From: domain.SymbolRef{Package: "github.com/example/app/internal/service", Symbol: "Service"},
+					To:   domain.SymbolRef{Package: "github.com/example/app/internal/domain", Symbol: "Thing"},
+					Kind: domain.DependencyUses,
+				},
+			},
+		},
+	}
+
+	_, violations, err := Merge(models, cfg)
+	if err != nil {
+		t.Fatalf("Merge error: %v", err)
+	}
+
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d: %+v", len(violations), violations)
+	}
+	v := violations[0]
+	if v.Package != "internal/domain" || v.Layer != "domain" {
+		t.Errorf("violation source: got %+v", v)
+	}
+	if !reflect.DeepEqual(v.Imports, []string{"internal/service"}) {
+		t.Errorf("violation imports: got %v, want [internal/service]", v.Imports)
+	}
+}
+
+func TestMerge_AllowedCrossLayerImportProducesNoViolation(t *testing.T) {
+	cfg := newMergeConfig()
+	models := []domain.PackageModel{
+		{Path: "internal/domain"},
+		{
+			Path: "internal/service",
+			Dependencies: []domain.Dependency{
+				{
+					From: domain.SymbolRef{Package: "github.com/example/app/internal/service"},
+					To:   domain.SymbolRef{Package: "github.com/example/app/internal/domain"},
+					Kind: domain.DependencyUses,
+				},
+			},
+		},
+	}
+
+	_, violations, err := Merge(models, cfg)
+	if err != nil {
+		t.Fatalf("Merge error: %v", err)
+	}
+	if len(violations) != 0 {
+		t.Errorf("expected no violations, got %+v", violations)
+	}
+}
+
+func TestMerge_IgnoresExternalDependencies(t *testing.T) {
+	cfg := newMergeConfig()
+	models := []domain.PackageModel{
+		{
+			Path: "internal/domain",
+			Dependencies: []domain.Dependency{
+				{
+					From: domain.SymbolRef{Package: "github.com/example/app/internal/domain"},
+					To:   domain.SymbolRef{Package: "context", Symbol: "Context", External: true},
+					Kind: domain.DependencyUses,
+				},
+			},
+		},
+	}
+	_, violations, err := Merge(models, cfg)
+	if err != nil {
+		t.Fatalf("Merge error: %v", err)
+	}
+	if len(violations) != 0 {
+		t.Errorf("expected no violations for external deps, got %+v", violations)
+	}
+}
+
+func TestMerge_NilConfigReturnsError(t *testing.T) {
+	_, _, err := Merge(nil, nil)
+	if err == nil {
+		t.Fatal("expected error for nil config")
+	}
+}
+
+func TestMatchGlob(t *testing.T) {
+	cases := []struct {
+		glob, path string
+		want       bool
+	}{
+		{"internal/domain/...", "internal/domain", true},
+		{"internal/domain/...", "internal/domain/order", true},
+		{"internal/domain/...", "internal/domain/order/sub", true},
+		{"internal/domain/...", "internal/service", false},
+		{"internal/domain", "internal/domain", true},
+		{"internal/domain", "internal/domain/order", false},
+		{"cmd/*", "cmd/archai", true},
+		{"cmd/*", "cmd/archai/sub", false},
+		{"cmd/*", "cmd", false},
+	}
+	for _, c := range cases {
+		got := matchGlob(c.glob, c.path)
+		if got != c.want {
+			t.Errorf("matchGlob(%q, %q) = %v, want %v", c.glob, c.path, got, c.want)
+		}
+	}
+}
+
+func TestMerge_FirstMatchingLayerWins(t *testing.T) {
+	// Two layers both match: lexically first layer name wins.
+	cfg := &Config{
+		Module: "github.com/example/app",
+		Layers: map[string][]string{
+			"alpha": {"internal/..."},
+			"beta":  {"internal/service"},
+		},
+	}
+	models := []domain.PackageModel{{Path: "internal/service"}}
+	merged, _, err := Merge(models, cfg)
+	if err != nil {
+		t.Fatalf("Merge error: %v", err)
+	}
+	if merged[0].Layer != "alpha" {
+		t.Errorf("got layer %q, want alpha (lexical order)", merged[0].Layer)
+	}
+}

--- a/internal/service/generate.go
+++ b/internal/service/generate.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/kgatilin/archai/internal/domain"
+	"github.com/kgatilin/archai/internal/overlay"
 )
 
 // GenerateOptions configures the generate operation (split mode).
@@ -31,6 +32,17 @@ type GenerateOptions struct {
 
 	// DebugPrintf is the function to use for debug output. If nil, fmt.Printf is used.
 	DebugPrintf func(format string, args ...any)
+
+	// OverlayPath is the optional path to an archai.yaml overlay file.
+	// When set, Generate loads and applies it to every package after
+	// reading from Go source and before writing output, so serialized
+	// models (e.g. YAML) carry Layer/Aggregate fields. Violations are
+	// returned via GenerateResult aggregation.
+	OverlayPath string
+
+	// GoModPath is the optional path to go.mod used to validate the
+	// overlay's module directive. Ignored when OverlayPath is empty.
+	GoModPath string
 }
 
 // GenerateResult contains the result of generating diagrams for a package.
@@ -52,10 +64,25 @@ type GenerateResult struct {
 // In split mode (default), it creates .arch/ folders in each package directory
 // with pub.d2 and/or internal.d2 files.
 func (s *Service) Generate(ctx context.Context, opts GenerateOptions) ([]GenerateResult, error) {
+	results, _, err := s.generateInternal(ctx, opts)
+	return results, err
+}
+
+// GenerateWithOverlay behaves like Generate but also applies the
+// overlay referenced by opts.OverlayPath (if set) to the loaded
+// packages before writing output, and returns any layer-rule
+// violations discovered. When opts.OverlayPath is empty,
+// GenerateWithOverlay is equivalent to Generate and returns nil
+// violations.
+func (s *Service) GenerateWithOverlay(ctx context.Context, opts GenerateOptions) ([]GenerateResult, []overlay.Violation, error) {
+	return s.generateInternal(ctx, opts)
+}
+
+func (s *Service) generateInternal(ctx context.Context, opts GenerateOptions) ([]GenerateResult, []overlay.Violation, error) {
 	// Check context cancellation before starting
 	select {
 	case <-ctx.Done():
-		return nil, ctx.Err()
+		return nil, nil, ctx.Err()
 	default:
 	}
 
@@ -70,7 +97,24 @@ func (s *Service) Generate(ctx context.Context, opts GenerateOptions) ([]Generat
 	// Read all packages from Go source code
 	packages, err := s.goReader.Read(ctx, opts.Paths)
 	if err != nil {
-		return nil, fmt.Errorf("reading packages: %w", err)
+		return nil, nil, fmt.Errorf("reading packages: %w", err)
+	}
+
+	// Apply overlay (if configured) so Layer/Aggregate propagate to
+	// serialized output. Violations are returned to the caller.
+	var violations []overlay.Violation
+	if opts.OverlayPath != "" {
+		cfg, err := overlay.Load(opts.OverlayPath)
+		if err != nil {
+			return nil, nil, fmt.Errorf("loading overlay: %w", err)
+		}
+		if err := overlay.Validate(cfg, opts.GoModPath); err != nil {
+			return nil, nil, fmt.Errorf("validating overlay: %w", err)
+		}
+		packages, violations, err = overlay.Merge(packages, cfg)
+		if err != nil {
+			return nil, nil, fmt.Errorf("applying overlay: %w", err)
+		}
 	}
 
 	// Debug: output package and dependency information
@@ -118,7 +162,7 @@ func (s *Service) Generate(ctx context.Context, opts GenerateOptions) ([]Generat
 		// Check context cancellation between packages
 		select {
 		case <-ctx.Done():
-			return results, ctx.Err()
+			return results, violations, ctx.Err()
 		default:
 		}
 
@@ -126,7 +170,7 @@ func (s *Service) Generate(ctx context.Context, opts GenerateOptions) ([]Generat
 		results = append(results, result)
 	}
 
-	return results, nil
+	return results, violations, nil
 }
 
 // generatePackageDiagrams generates diagrams for a single package.


### PR DESCRIPTION
Closes #11.

## Summary

Makes the Service layer overlay-aware so packages loaded from Go source
can be annotated with architectural layers and aggregates declared in
archai.yaml, and forbidden cross-layer imports surface as violations.

## Changes

- domain.PackageModel: new Layer and Aggregate string fields
- overlay.Merge(models, cfg): assigns layers (first matching glob,
  lexical tie-break), aggregates (packages containing root type), and
  returns []Violation for disallowed cross-layer imports per LayerRules
- Glob matching supports `pkg/...` (recursive), `pkg/*` (single
  segment), and exact paths
- Import -> layer resolution strips cfg.Module prefix from dep.To.Package;
  external deps and deps outside the module are ignored
- YAML schema/converters: Layer and Aggregate persist through
  roundtrip (omitempty)
- GenerateOptions: OverlayPath and GoModPath fields
- Service.GenerateWithOverlay: wraps Generate and returns violations
  alongside results (Generate itself keeps its existing signature)
- CLI: `diagram generate --overlay PATH` (auto-detects ./archai.yaml
  when unset); violations print to stderr after generation

## Deferred

Configs tagging is deferred to a later milestone. Configs apply to
specific Go types rather than packages and require per-type annotation
support on StructDef / TypeDef. Merge contains a TODO noting this.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (all packages pass)
- [x] New unit tests in internal/overlay/merge_test.go cover:
  layer assignment, aggregate assignment, violation detection,
  allowed cross-layer imports, external-dep handling, nil config,
  glob edge cases, lexical tie-break
- [x] Updated yaml roundtrip test asserts Layer/Aggregate persistence