### PR TITLE
M2b: Interface implementation resolution via go/types.Implements

### DIFF
--- a/internal/adapter/d2/builder.go
+++ b/internal/adapter/d2/builder.go
@@ -54,6 +54,16 @@ func (b *d2TextBuilder) Build(pkg domain.PackageModel, publicOnly bool) string {
 		b.writeDependency(dep)
 	}
 
+	// 6. Write implementation edges (dashed arrows from concrete -> interface)
+	impls := b.filterImplementations(pkg.Implementations, publicOnly, pkg)
+	if len(impls) > 0 {
+		b.writeLine("")
+		b.writeComment("Implementations")
+		for _, impl := range impls {
+			b.writeImplementation(impl)
+		}
+	}
+
 	return b.buf.String()
 }
 
@@ -631,6 +641,91 @@ func (b *d2TextBuilder) writeDependency(dep domain.Dependency) {
 	fromPath := b.toD2Path(dep.From)
 	toPath := b.toD2Path(dep.To)
 	b.writeLine(fmt.Sprintf(`%s -> %s: "%s"`, fromPath, toPath, dep.Kind))
+}
+
+// filterImplementations returns implementations that can be rendered within
+// this package's diagram. Only intra-package implementations (concrete and
+// interface both in this package) are rendered, since cross-package concrete
+// types are not represented as shapes in a single-package diagram.
+func (b *d2TextBuilder) filterImplementations(
+	impls []domain.Implementation,
+	publicOnly bool,
+	pkg domain.PackageModel,
+) []domain.Implementation {
+	// Build a set of visible struct and interface names (with source files).
+	visibleStructs := make(map[string]string) // name -> file
+	visibleIfaces := make(map[string]string)  // name -> file
+
+	for _, iface := range pkg.Interfaces {
+		if !publicOnly || iface.IsExported {
+			visibleIfaces[iface.Name] = iface.SourceFile
+		}
+	}
+	for _, s := range pkg.Structs {
+		if !publicOnly || s.IsExported {
+			visibleStructs[s.Name] = s.SourceFile
+		}
+	}
+
+	var result []domain.Implementation
+	seen := make(map[string]bool)
+
+	for _, impl := range impls {
+		// Interface must be in this package and visible.
+		if impl.Interface.Package != pkg.Path {
+			continue
+		}
+		ifaceFile, ok := visibleIfaces[impl.Interface.Symbol]
+		if !ok {
+			continue
+		}
+		// Concrete must also be in this package and visible as a struct.
+		if impl.Concrete.Package != pkg.Path {
+			continue
+		}
+		concreteFile, ok := visibleStructs[impl.Concrete.Symbol]
+		if !ok {
+			continue
+		}
+
+		// Fill in source files if empty.
+		if impl.Interface.File == "" {
+			impl.Interface.File = ifaceFile
+		}
+		if impl.Concrete.File == "" {
+			impl.Concrete.File = concreteFile
+		}
+
+		key := fmt.Sprintf("%s.%s->%s.%s",
+			b.fileContainerID(impl.Concrete.File), impl.Concrete.Symbol,
+			b.fileContainerID(impl.Interface.File), impl.Interface.Symbol)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		result = append(result, impl)
+	}
+
+	// Sort deterministically.
+	sort.Slice(result, func(i, j int) bool {
+		ki := fmt.Sprintf("%s.%s->%s.%s",
+			b.fileContainerID(result[i].Concrete.File), result[i].Concrete.Symbol,
+			b.fileContainerID(result[i].Interface.File), result[i].Interface.Symbol)
+		kj := fmt.Sprintf("%s.%s->%s.%s",
+			b.fileContainerID(result[j].Concrete.File), result[j].Concrete.Symbol,
+			b.fileContainerID(result[j].Interface.File), result[j].Interface.Symbol)
+		return ki < kj
+	})
+
+	return result
+}
+
+// writeImplementation writes a D2 dashed arrow from the concrete type to the interface.
+func (b *d2TextBuilder) writeImplementation(impl domain.Implementation) {
+	fromPath := b.toD2Path(impl.Concrete)
+	toPath := b.toD2Path(impl.Interface)
+	// Dashed arrow with "implements" label. Style block sets stroke-dash.
+	b.writeLine(fmt.Sprintf(`%s -> %s: "implements" {style.stroke-dash: 3}`, fromPath, toPath))
 }
 
 // toD2Path converts a SymbolRef to a D2 container path.

--- a/internal/adapter/d2/builder_test.go
+++ b/internal/adapter/d2/builder_test.go
@@ -261,3 +261,61 @@ func TestD2TextBuilder_MethodSignatures(t *testing.T) {
 		})
 	}
 }
+
+func TestD2TextBuilder_RendersImplementations(t *testing.T) {
+	model := domain.PackageModel{
+		Name: "svc",
+		Path: "internal/svc",
+		Interfaces: []domain.InterfaceDef{
+			{Name: "Greeter", IsExported: true, SourceFile: "greeter.go"},
+		},
+		Structs: []domain.StructDef{
+			{Name: "Hello", IsExported: true, SourceFile: "hello.go"},
+		},
+		Implementations: []domain.Implementation{
+			{
+				Concrete:  domain.SymbolRef{Package: "internal/svc", File: "hello.go", Symbol: "Hello"},
+				Interface: domain.SymbolRef{Package: "internal/svc", File: "greeter.go", Symbol: "Greeter"},
+				IsPointer: false,
+			},
+		},
+	}
+
+	builder := newD2TextBuilder()
+	got := builder.Build(model, false)
+
+	wantParts := []string{
+		"# Implementations",
+		`hello.Hello -> greeter.Greeter: "implements"`,
+		"style.stroke-dash",
+	}
+	for _, want := range wantParts {
+		if !strings.Contains(got, want) {
+			t.Errorf("Build() output missing %q\n\nGot:\n%s", want, got)
+		}
+	}
+}
+
+func TestD2TextBuilder_SkipsCrossPackageImplementations(t *testing.T) {
+	model := domain.PackageModel{
+		Name: "api",
+		Path: "internal/api",
+		Interfaces: []domain.InterfaceDef{
+			{Name: "Service", IsExported: true, SourceFile: "api.go"},
+		},
+		Implementations: []domain.Implementation{
+			{
+				// Concrete from different package — can't be rendered here.
+				Concrete:  domain.SymbolRef{Package: "internal/impl", File: "impl.go", Symbol: "Worker"},
+				Interface: domain.SymbolRef{Package: "internal/api", File: "api.go", Symbol: "Service"},
+			},
+		},
+	}
+
+	builder := newD2TextBuilder()
+	got := builder.Build(model, false)
+
+	if strings.Contains(got, "# Implementations") {
+		t.Errorf("expected no Implementations section for cross-package impl\n\nGot:\n%s", got)
+	}
+}

--- a/internal/adapter/golang/implementations_test.go
+++ b/internal/adapter/golang/implementations_test.go
@@ -1,0 +1,186 @@
+package golang
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kgatilin/archai/internal/domain"
+)
+
+// writeTestModule creates a temporary Go module with given files and returns the module root.
+func writeTestModule(t *testing.T, modPath string, files map[string]string) string {
+	t.Helper()
+	tmpDir := t.TempDir()
+	goMod := "module " + modPath + "\n\ngo 1.21\n"
+	if err := os.WriteFile(filepath.Join(tmpDir, "go.mod"), []byte(goMod), 0644); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+	for rel, content := range files {
+		full := filepath.Join(tmpDir, rel)
+		if err := os.MkdirAll(filepath.Dir(full), 0755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0644); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+	return tmpDir
+}
+
+// findImpl locates an implementation by concrete symbol name within a model.
+func findImpl(impls []domain.Implementation, concrete, iface string) *domain.Implementation {
+	for i := range impls {
+		if impls[i].Concrete.Symbol == concrete && impls[i].Interface.Symbol == iface {
+			return &impls[i]
+		}
+	}
+	return nil
+}
+
+func TestImplementations_ValueReceiver(t *testing.T) {
+	code := `package impls
+
+type Greeter interface {
+	Greet() string
+}
+
+type Hello struct{}
+
+func (h Hello) Greet() string { return "hi" }
+`
+	dir := writeTestModule(t, "test.example/impls", map[string]string{"impls.go": code})
+
+	oldDir, _ := os.Getwd()
+	defer os.Chdir(oldDir)
+	os.Chdir(dir)
+
+	models, err := NewReader().Read(context.Background(), []string{"."})
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if len(models) != 1 {
+		t.Fatalf("expected 1 model, got %d", len(models))
+	}
+	impls := models[0].Implementations
+	got := findImpl(impls, "Hello", "Greeter")
+	if got == nil {
+		t.Fatalf("expected Hello -> Greeter implementation, got %+v", impls)
+	}
+	if got.IsPointer {
+		t.Errorf("expected IsPointer=false for value-receiver impl, got true")
+	}
+}
+
+func TestImplementations_PointerReceiverOnly(t *testing.T) {
+	code := `package impls
+
+type Writer interface {
+	Write(p []byte) (int, error)
+}
+
+type Buffer struct{ data []byte }
+
+func (b *Buffer) Write(p []byte) (int, error) {
+	b.data = append(b.data, p...)
+	return len(p), nil
+}
+`
+	dir := writeTestModule(t, "test.example/ptr", map[string]string{"ptr.go": code})
+	oldDir, _ := os.Getwd()
+	defer os.Chdir(oldDir)
+	os.Chdir(dir)
+
+	models, err := NewReader().Read(context.Background(), []string{"."})
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	got := findImpl(models[0].Implementations, "Buffer", "Writer")
+	if got == nil {
+		t.Fatalf("expected Buffer -> Writer implementation, got %+v", models[0].Implementations)
+	}
+	if !got.IsPointer {
+		t.Errorf("expected IsPointer=true for pointer-only receiver, got false")
+	}
+}
+
+func TestImplementations_CrossPackage(t *testing.T) {
+	// Interface in package "api", concrete in package "impl".
+	files := map[string]string{
+		"api/api.go": `package api
+
+type Service interface {
+	Do() error
+}
+`,
+		"impl/impl.go": `package impl
+
+type Worker struct{}
+
+func (w Worker) Do() error { return nil }
+`,
+	}
+	dir := writeTestModule(t, "test.example/cross", files)
+	oldDir, _ := os.Getwd()
+	defer os.Chdir(oldDir)
+	os.Chdir(dir)
+
+	models, err := NewReader().Read(context.Background(), []string{"./..."})
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+
+	// The implementation should be stored in the interface's owning package ("api").
+	var apiModel *domain.PackageModel
+	for i := range models {
+		if models[i].Name == "api" {
+			apiModel = &models[i]
+			break
+		}
+	}
+	if apiModel == nil {
+		t.Fatalf("api model not found; got %d models", len(models))
+	}
+
+	got := findImpl(apiModel.Implementations, "Worker", "Service")
+	if got == nil {
+		t.Fatalf("expected Worker -> Service implementation in api model, got %+v", apiModel.Implementations)
+	}
+	if got.Concrete.Package != "impl" {
+		t.Errorf("expected concrete package 'impl', got %q", got.Concrete.Package)
+	}
+	if got.Interface.Package != "api" {
+		t.Errorf("expected interface package 'api', got %q", got.Interface.Package)
+	}
+}
+
+func TestImplementations_SkipEmptyAndUnexported(t *testing.T) {
+	code := `package skip
+
+// Empty interface - should be skipped.
+type Any interface{}
+
+// unexported interface - should be skipped.
+type helper interface {
+	help()
+}
+
+type T struct{}
+
+func (t T) help() {}
+`
+	dir := writeTestModule(t, "test.example/skip", map[string]string{"skip.go": code})
+	oldDir, _ := os.Getwd()
+	defer os.Chdir(oldDir)
+	os.Chdir(dir)
+
+	models, err := NewReader().Read(context.Background(), []string{"."})
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	// Should have no implementations recorded (empty iface skipped, unexported iface skipped).
+	if len(models[0].Implementations) != 0 {
+		t.Errorf("expected no implementations, got %+v", models[0].Implementations)
+	}
+}

--- a/internal/adapter/golang/reader.go
+++ b/internal/adapter/golang/reader.go
@@ -82,6 +82,11 @@ func (r *reader) Read(ctx context.Context, paths []string) ([]domain.PackageMode
 		models = append(models, model)
 	}
 
+	// Compute interface implementations across all loaded packages.
+	// This must run after all packages are loaded because implementations
+	// may cross package boundaries.
+	r.computeImplementations(pkgs, models)
+
 	return models, nil
 }
 
@@ -1001,6 +1006,169 @@ func (r *reader) applyStereotypes(model *domain.PackageModel) {
 
 	for i := range model.TypeDefs {
 		model.TypeDefs[i].Stereotype = detectTypeDefStereotype(model.TypeDefs[i])
+	}
+}
+
+// computeImplementations computes interface implementations via go/types.Implements.
+// For each exported interface defined in the loaded packages, it iterates over all
+// named types across loaded packages and records which concrete types (T or *T)
+// implement it. Results are stored in the owning interface's PackageModel.
+func (r *reader) computeImplementations(pkgs []*packages.Package, models []domain.PackageModel) {
+	// Collect all interfaces (from loaded packages only) that are exported.
+	type ifaceEntry struct {
+		pkg       *packages.Package
+		name      string
+		iface     *types.Interface
+		modelIdx  int    // index into models slice
+		sourceFile string
+	}
+
+	// Map model.Path -> model index for quick lookup.
+	modelIdxByPath := make(map[string]int, len(models))
+	for i, m := range models {
+		modelIdxByPath[m.Path] = i
+	}
+
+	var ifaceEntries []ifaceEntry
+	for _, pkg := range pkgs {
+		if pkg.Types == nil {
+			continue
+		}
+		scope := pkg.Types.Scope()
+		relPath := r.relativePath(pkg.PkgPath)
+		modelIdx, ok := modelIdxByPath[relPath]
+		if !ok {
+			continue
+		}
+		for _, name := range scope.Names() {
+			obj := scope.Lookup(name)
+			typeName, ok := obj.(*types.TypeName)
+			if !ok {
+				continue
+			}
+			if !typeName.Exported() {
+				continue
+			}
+			iface, ok := typeName.Type().Underlying().(*types.Interface)
+			if !ok {
+				continue
+			}
+			// Skip empty interfaces (any/interface{}): every type satisfies them.
+			if iface.Empty() {
+				continue
+			}
+			ifaceEntries = append(ifaceEntries, ifaceEntry{
+				pkg:        pkg,
+				name:       name,
+				iface:      iface,
+				modelIdx:   modelIdx,
+				sourceFile: r.getSourceFile(pkg.Fset, typeName.Pos()),
+			})
+		}
+	}
+
+	if len(ifaceEntries) == 0 {
+		return
+	}
+
+	// Collect all named concrete types (non-interfaces) across loaded packages.
+	type concreteEntry struct {
+		pkg       *packages.Package
+		name      string
+		named     *types.Named
+		sourceFile string
+	}
+	var concretes []concreteEntry
+	for _, pkg := range pkgs {
+		if pkg.Types == nil {
+			continue
+		}
+		scope := pkg.Types.Scope()
+		for _, name := range scope.Names() {
+			obj := scope.Lookup(name)
+			typeName, ok := obj.(*types.TypeName)
+			if !ok {
+				continue
+			}
+			named, ok := typeName.Type().(*types.Named)
+			if !ok {
+				continue
+			}
+			// Skip interfaces — we only care about concrete types as implementers.
+			if _, isIface := named.Underlying().(*types.Interface); isIface {
+				continue
+			}
+			concretes = append(concretes, concreteEntry{
+				pkg:        pkg,
+				name:       name,
+				named:      named,
+				sourceFile: r.getSourceFile(pkg.Fset, typeName.Pos()),
+			})
+		}
+	}
+
+	// Deduplicate implementations per owning package.
+	seen := make(map[string]bool)
+
+	for _, ie := range ifaceEntries {
+		ifaceRelPath := r.relativePath(ie.pkg.PkgPath)
+		ifaceRef := domain.SymbolRef{
+			Package: ifaceRelPath,
+			File:    ie.sourceFile,
+			Symbol:  ie.name,
+		}
+
+		for _, c := range concretes {
+			concreteRelPath := r.relativePath(c.pkg.PkgPath)
+			// Skip if concrete type is identical to the interface type itself.
+			if c.pkg == ie.pkg && c.name == ie.name {
+				continue
+			}
+
+			concreteRef := domain.SymbolRef{
+				Package: concreteRelPath,
+				File:    c.sourceFile,
+				Symbol:  c.name,
+			}
+
+			// Check value type first.
+			if types.Implements(c.named, ie.iface) {
+				key := fmt.Sprintf("%s.%s->%s.%s|v",
+					concreteRef.Package, concreteRef.Symbol,
+					ifaceRef.Package, ifaceRef.Symbol)
+				if !seen[key] {
+					seen[key] = true
+					models[ie.modelIdx].Implementations = append(
+						models[ie.modelIdx].Implementations,
+						domain.Implementation{
+							Concrete:  concreteRef,
+							Interface: ifaceRef,
+							IsPointer: false,
+						},
+					)
+				}
+				continue
+			}
+
+			// Check pointer type only if value type does not implement.
+			ptr := types.NewPointer(c.named)
+			if types.Implements(ptr, ie.iface) {
+				key := fmt.Sprintf("%s.%s->%s.%s|p",
+					concreteRef.Package, concreteRef.Symbol,
+					ifaceRef.Package, ifaceRef.Symbol)
+				if !seen[key] {
+					seen[key] = true
+					models[ie.modelIdx].Implementations = append(
+						models[ie.modelIdx].Implementations,
+						domain.Implementation{
+							Concrete:  concreteRef,
+							Interface: ifaceRef,
+							IsPointer: true,
+						},
+					)
+				}
+			}
+		}
 	}
 }
 

--- a/internal/adapter/yaml/convert.go
+++ b/internal/adapter/yaml/convert.go
@@ -75,6 +75,10 @@ func toSpec(model domain.PackageModel, publicOnly bool) PackageSpec {
 		spec.Dependencies = append(spec.Dependencies, toDependencySpec(dep))
 	}
 
+	for _, impl := range model.Implementations {
+		spec.Implementations = append(spec.Implementations, toImplementationSpec(impl))
+	}
+
 	return spec
 }
 
@@ -110,6 +114,9 @@ func fromSpec(spec PackageSpec) domain.PackageModel {
 	}
 	for _, dep := range spec.Dependencies {
 		model.Dependencies = append(model.Dependencies, fromDependencySpec(dep))
+	}
+	for _, impl := range spec.Implementations {
+		model.Implementations = append(model.Implementations, fromImplementationSpec(impl))
 	}
 
 	return model
@@ -263,6 +270,22 @@ func toDependencySpec(d domain.Dependency) DependencySpec {
 		To:              toSymbolRefSpec(d.To),
 		Kind:            string(d.Kind),
 		ThroughExported: d.ThroughExported,
+	}
+}
+
+func toImplementationSpec(i domain.Implementation) ImplementationSpec {
+	return ImplementationSpec{
+		Concrete:  toSymbolRefSpec(i.Concrete),
+		Interface: toSymbolRefSpec(i.Interface),
+		Pointer:   i.IsPointer,
+	}
+}
+
+func fromImplementationSpec(s ImplementationSpec) domain.Implementation {
+	return domain.Implementation{
+		Concrete:  fromSymbolRefSpec(s.Concrete),
+		Interface: fromSymbolRefSpec(s.Interface),
+		IsPointer: s.Pointer,
 	}
 }
 

--- a/internal/adapter/yaml/roundtrip_test.go
+++ b/internal/adapter/yaml/roundtrip_test.go
@@ -119,6 +119,21 @@ func testPackageModel() domain.PackageModel {
 				Doc:        "ErrNotFound is returned when a lookup fails.",
 			},
 		},
+		Implementations: []domain.Implementation{
+			{
+				Concrete: domain.SymbolRef{
+					Package: "github.com/example/project/internal/service",
+					File:    "handler.go",
+					Symbol:  "Handler",
+				},
+				Interface: domain.SymbolRef{
+					Package: "github.com/example/project/internal/service",
+					File:    "repository.go",
+					Symbol:  "Repository",
+				},
+				IsPointer: true,
+			},
+		},
 		Dependencies: []domain.Dependency{
 			{
 				From: domain.SymbolRef{
@@ -282,6 +297,18 @@ func TestRoundtrip_SinglePackage(t *testing.T) {
 	dep2 := got.Dependencies[1]
 	if !dep2.To.External {
 		t.Errorf("Expected external dependency, got: %+v", dep2.To)
+	}
+
+	// Verify implementations
+	if len(got.Implementations) != len(original.Implementations) {
+		t.Fatalf("Implementations count: got %d, want %d", len(got.Implementations), len(original.Implementations))
+	}
+	impl := got.Implementations[0]
+	if impl.Concrete.Symbol != "Handler" || impl.Interface.Symbol != "Repository" {
+		t.Errorf("Implementation symbols mismatch: %+v", impl)
+	}
+	if !impl.IsPointer {
+		t.Errorf("Implementation IsPointer: got false, want true")
 	}
 }
 

--- a/internal/adapter/yaml/schema.go
+++ b/internal/adapter/yaml/schema.go
@@ -19,6 +19,14 @@ type PackageSpec struct {
 	Variables    []VarSpec        `yaml:"variables,omitempty"`
 	Errors       []ErrorSpec      `yaml:"errors,omitempty"`
 	Dependencies []DependencySpec `yaml:"dependencies,omitempty"`
+	Implementations []ImplementationSpec `yaml:"implementations,omitempty"`
+}
+
+// ImplementationSpec represents an interface implementation relationship.
+type ImplementationSpec struct {
+	Concrete  SymbolRefSpec `yaml:"concrete"`
+	Interface SymbolRefSpec `yaml:"interface"`
+	Pointer   bool          `yaml:"pointer,omitempty"`
 }
 
 // ConstSpec represents a package-level constant declaration.

--- a/internal/domain/implementation.go
+++ b/internal/domain/implementation.go
@@ -1,0 +1,17 @@
+package domain
+
+// Implementation represents a concrete type implementing an interface.
+// It records that a named concrete type (possibly via its pointer) satisfies
+// the interface's method set.
+type Implementation struct {
+	// Concrete is the concrete type that implements the interface.
+	// This may be from a different package than the interface.
+	Concrete SymbolRef
+
+	// Interface is the interface being implemented.
+	Interface SymbolRef
+
+	// IsPointer is true when the pointer type *T implements the interface
+	// but the value type T does not (i.e., pointer-receiver methods).
+	IsPointer bool
+}

--- a/internal/domain/package.go
+++ b/internal/domain/package.go
@@ -47,6 +47,11 @@ type PackageModel struct {
 	// as assigned by the overlay (archai.yaml) when the package
 	// contains the aggregate root type. Empty otherwise.
 	Aggregate string
+
+	// Implementations is the list of interface implementation relationships
+	// where the interface is defined in this package. Concrete types may be
+	// from other packages.
+	Implementations []Implementation
 }
 
 // SourceFiles returns a deduplicated list of all source files in the package.


### PR DESCRIPTION
## Summary

Implements #9 — compute which concrete types implement which interfaces using `go/types.Implements()`, across all loaded packages.

- Add `domain.Implementation` (`Concrete`, `Interface`, `IsPointer`)
- Add `PackageModel.Implementations` field, stored in the interface's owning package
- Go reader: new `computeImplementations` pass iterates exported interfaces defined in loaded packages and checks every named concrete type `T` and `*T` via `types.Implements`. Empty and unexported interfaces are skipped to keep output manageable.
- YAML adapter: `ImplementationSpec` schema + convert + roundtrip test
- D2 writer: render intra-package implementations as dashed `implements` edges from concrete struct → interface (cross-package implementations are captured in the YAML model but not rendered in single-package diagrams, since the concrete type's shape lives elsewhere)

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] Value-receiver: `T` implements `I`
- [x] Pointer-only receiver: `*T` implements `I` but `T` does not
- [x] Cross-package: concrete in package A, interface in package B → recorded in B's model
- [x] Skip rules: empty interfaces (`any`) and unexported interfaces produce no entries
- [x] YAML roundtrip preserves `Implementations` including `IsPointer`
- [x] D2 writer renders `implements` edges with `stroke-dash` style

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)