### PR TITLE
M4b: Structured diff schema + 'archai diff' command

### DIFF
--- a/cmd/archai/main.go
+++ b/cmd/archai/main.go
@@ -3,13 +3,19 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 
 	"github.com/kgatilin/archai/internal/adapter/d2"
 	"github.com/kgatilin/archai/internal/adapter/golang"
 	yamlAdapter "github.com/kgatilin/archai/internal/adapter/yaml"
+	"github.com/kgatilin/archai/internal/diff"
+	"github.com/kgatilin/archai/internal/domain"
 	"github.com/kgatilin/archai/internal/service"
 	"github.com/kgatilin/archai/internal/target"
 	"github.com/spf13/cobra"
@@ -184,6 +190,24 @@ and freeze them — along with archai.yaml — into .arch/targets/<id>/.`,
 	}
 	targetDeleteCmd.Flags().Bool("force", false, "Delete even if <id> is the current target")
 	targetCmd.AddCommand(targetDeleteCmd)
+
+	// Diff command (M4b)
+	diffCmd := &cobra.Command{
+		Use:   "diff",
+		Short: "Show differences between current code and a locked target",
+		Long: `Compare the project's current architecture model (from .arch/*.yaml specs,
+or the Go source if no specs are present) against a locked target and print
+the structured differences.
+
+By default, the active target (.arch/targets/CURRENT) is used; override with
+--target <id>. Output format is plain text; use --format yaml or --format
+json for machine-readable output.`,
+		Args: cobra.NoArgs,
+		RunE: runDiff,
+	}
+	diffCmd.Flags().String("target", "", "Target id to compare against (defaults to CURRENT)")
+	diffCmd.Flags().StringP("format", "f", "text", "Output format: text, yaml, or json")
+	rootCmd.AddCommand(diffCmd)
 
 	// Execute root command
 	if err := rootCmd.Execute(); err != nil {
@@ -572,4 +596,172 @@ func runTargetDelete(cmd *cobra.Command, args []string) error {
 	}
 	fmt.Printf("Deleted target %q\n", id)
 	return nil
+}
+
+// runDiff handles `archai diff`. It loads the current model from the
+// project's per-package .arch/*.yaml files (falling back to parsing Go
+// sources if no specs are present) and the target model from
+// .arch/targets/<id>/model/, computes a structured diff and prints it in
+// the requested format.
+func runDiff(cmd *cobra.Command, args []string) error {
+	targetID, _ := cmd.Flags().GetString("target")
+	format, _ := cmd.Flags().GetString("format")
+
+	projectRoot, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("resolving cwd: %w", err)
+	}
+
+	// Resolve target id.
+	if targetID == "" {
+		cur, err := target.Current(projectRoot)
+		if err != nil {
+			return fmt.Errorf("reading CURRENT: %w", err)
+		}
+		if cur == "" {
+			return errors.New("no target specified and no CURRENT target set; use --target <id> or `archai target use <id>`")
+		}
+		targetID = cur
+	}
+
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	current, err := loadCurrentModel(ctx, projectRoot)
+	if err != nil {
+		return fmt.Errorf("loading current model: %w", err)
+	}
+
+	targetModel, err := loadTargetModel(ctx, projectRoot, targetID)
+	if err != nil {
+		return fmt.Errorf("loading target %q: %w", targetID, err)
+	}
+
+	d := diff.Compute(current, targetModel)
+
+	switch format {
+	case "", "text":
+		fmt.Print(diff.FormatText(d))
+	case "yaml":
+		out, err := diff.FormatYAML(d)
+		if err != nil {
+			return err
+		}
+		fmt.Print(out)
+	case "json":
+		out, err := diff.FormatJSON(d)
+		if err != nil {
+			return err
+		}
+		fmt.Print(out)
+	default:
+		return fmt.Errorf("unsupported format %q (use text, yaml, or json)", format)
+	}
+
+	return nil
+}
+
+// loadCurrentModel builds the "current" package model for diff. Preference
+// order:
+//  1. Per-package .arch/*.yaml specs found under projectRoot (excluding
+//     .arch/targets/).
+//  2. Fallback: parse Go sources under ./... via the Go reader.
+func loadCurrentModel(ctx context.Context, projectRoot string) ([]domain.PackageModel, error) {
+	files, err := findCurrentYAMLSpecs(projectRoot)
+	if err != nil {
+		return nil, err
+	}
+	if len(files) > 0 {
+		return yamlAdapter.NewReader().Read(ctx, files)
+	}
+
+	// Fallback to Go source parsing.
+	return golang.NewReader().Read(ctx, []string{"./..."})
+}
+
+// loadTargetModel loads the frozen model from .arch/targets/<id>/model/.
+func loadTargetModel(ctx context.Context, projectRoot, id string) ([]domain.PackageModel, error) {
+	targetDir := filepath.Join(projectRoot, ".arch", "targets", id)
+	if _, err := os.Stat(targetDir); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, fmt.Errorf("target %q not found", id)
+		}
+		return nil, err
+	}
+	modelDir := filepath.Join(targetDir, "model")
+	files, err := collectYAMLFiles(modelDir)
+	if err != nil {
+		return nil, err
+	}
+	if len(files) == 0 {
+		return nil, fmt.Errorf("target %q has no model files under %s", id, modelDir)
+	}
+	return yamlAdapter.NewReader().Read(ctx, files)
+}
+
+// findCurrentYAMLSpecs walks projectRoot for package-level .arch/*.yaml
+// files. The .arch/targets tree is skipped so locked targets don't leak
+// into the "current" model.
+func findCurrentYAMLSpecs(projectRoot string) ([]string, error) {
+	var out []string
+	targetsTree := filepath.Join(projectRoot, ".arch", "targets")
+
+	err := filepath.WalkDir(projectRoot, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			// Skip the targets tree entirely.
+			if path == targetsTree || strings.HasPrefix(path, targetsTree+string(os.PathSeparator)) {
+				return filepath.SkipDir
+			}
+			// Skip hidden directories except `.arch` itself.
+			name := d.Name()
+			if strings.HasPrefix(name, ".") && name != ".arch" && name != "." {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if filepath.Ext(path) != ".yaml" && filepath.Ext(path) != ".yml" {
+			return nil
+		}
+		// Only include files located directly inside a .arch directory.
+		if filepath.Base(filepath.Dir(path)) != ".arch" {
+			return nil
+		}
+		out = append(out, path)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+// collectYAMLFiles returns every *.yaml / *.yml file under root.
+func collectYAMLFiles(root string) ([]string, error) {
+	var out []string
+	if _, err := os.Stat(root); errors.Is(err, fs.ErrNotExist) {
+		return nil, nil
+	}
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if filepath.Ext(path) == ".yaml" || filepath.Ext(path) == ".yml" {
+			out = append(out, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(out)
+	return out, nil
 }

--- a/internal/diff/compute.go
+++ b/internal/diff/compute.go
@@ -1,0 +1,400 @@
+package diff
+
+import (
+	"reflect"
+	"sort"
+
+	"github.com/kgatilin/archai/internal/domain"
+)
+
+// Compute produces a structured Diff describing how the current model must
+// change to match the target model.
+//
+//   - OpAdd    — symbol exists in target but not in current (After populated).
+//   - OpRemove — symbol exists in current but not in target (Before populated).
+//   - OpChange — symbol exists on both sides but differs (Before+After).
+//
+// Matching is strictly name-based: packages by Path, symbols by Name within
+// a package, methods by (receiver, Name). Rename detection is intentionally
+// left out — a rename surfaces as OpRemove + OpAdd.
+func Compute(current, target []domain.PackageModel) *Diff {
+	d := &Diff{}
+
+	curByPath := indexPackages(current)
+	tgtByPath := indexPackages(target)
+
+	// Stable ordering: union of package paths, sorted.
+	paths := make([]string, 0, len(curByPath)+len(tgtByPath))
+	seen := make(map[string]struct{}, len(curByPath)+len(tgtByPath))
+	for p := range curByPath {
+		if _, ok := seen[p]; !ok {
+			seen[p] = struct{}{}
+			paths = append(paths, p)
+		}
+	}
+	for p := range tgtByPath {
+		if _, ok := seen[p]; !ok {
+			seen[p] = struct{}{}
+			paths = append(paths, p)
+		}
+	}
+	sort.Strings(paths)
+
+	for _, p := range paths {
+		cur, hasCur := curByPath[p]
+		tgt, hasTgt := tgtByPath[p]
+		switch {
+		case !hasCur && hasTgt:
+			d.Changes = append(d.Changes, Change{
+				Op:    OpAdd,
+				Kind:  KindPackage,
+				Path:  p,
+				After: packageSummary(tgt),
+			})
+		case hasCur && !hasTgt:
+			d.Changes = append(d.Changes, Change{
+				Op:     OpRemove,
+				Kind:   KindPackage,
+				Path:   p,
+				Before: packageSummary(cur),
+			})
+		default:
+			d.Changes = append(d.Changes, diffPackage(cur, tgt)...)
+		}
+	}
+
+	return d
+}
+
+func indexPackages(pkgs []domain.PackageModel) map[string]domain.PackageModel {
+	out := make(map[string]domain.PackageModel, len(pkgs))
+	for _, p := range pkgs {
+		out[p.Path] = p
+	}
+	return out
+}
+
+// diffPackage compares two matched packages and emits Changes for each
+// differing child symbol.
+func diffPackage(cur, tgt domain.PackageModel) []Change {
+	var changes []Change
+	changes = append(changes, diffInterfaces(cur.Path, cur.Interfaces, tgt.Interfaces)...)
+	changes = append(changes, diffStructs(cur.Path, cur.Structs, tgt.Structs)...)
+	changes = append(changes, diffFunctions(cur.Path, cur.Functions, tgt.Functions)...)
+	changes = append(changes, diffTypeDefs(cur.Path, cur.TypeDefs, tgt.TypeDefs)...)
+	changes = append(changes, diffConsts(cur.Path, cur.Constants, tgt.Constants)...)
+	changes = append(changes, diffVars(cur.Path, cur.Variables, tgt.Variables)...)
+	changes = append(changes, diffErrors(cur.Path, cur.Errors, tgt.Errors)...)
+	changes = append(changes, diffDependencies(cur.Path, cur.Dependencies, tgt.Dependencies)...)
+	return changes
+}
+
+// --- per-kind comparisons ---
+
+func diffInterfaces(pkg string, cur, tgt []domain.InterfaceDef) []Change {
+	curIdx := make(map[string]domain.InterfaceDef, len(cur))
+	for _, v := range cur {
+		curIdx[v.Name] = v
+	}
+	tgtIdx := make(map[string]domain.InterfaceDef, len(tgt))
+	for _, v := range tgt {
+		tgtIdx[v.Name] = v
+	}
+	names := unionNames(curIdx, tgtIdx)
+
+	var out []Change
+	for _, n := range names {
+		c, hasC := curIdx[n]
+		t, hasT := tgtIdx[n]
+		path := pkg + "." + n
+		switch {
+		case !hasC && hasT:
+			out = append(out, Change{Op: OpAdd, Kind: KindInterface, Path: path, After: t})
+		case hasC && !hasT:
+			out = append(out, Change{Op: OpRemove, Kind: KindInterface, Path: path, Before: c})
+		default:
+			if !reflect.DeepEqual(c, t) {
+				out = append(out, Change{Op: OpChange, Kind: KindInterface, Path: path, Before: c, After: t})
+			}
+		}
+	}
+	return out
+}
+
+func diffStructs(pkg string, cur, tgt []domain.StructDef) []Change {
+	curIdx := make(map[string]domain.StructDef, len(cur))
+	for _, v := range cur {
+		curIdx[v.Name] = v
+	}
+	tgtIdx := make(map[string]domain.StructDef, len(tgt))
+	for _, v := range tgt {
+		tgtIdx[v.Name] = v
+	}
+	names := unionNames(curIdx, tgtIdx)
+
+	var out []Change
+	for _, n := range names {
+		c, hasC := curIdx[n]
+		t, hasT := tgtIdx[n]
+		path := pkg + "." + n
+		switch {
+		case !hasC && hasT:
+			out = append(out, Change{Op: OpAdd, Kind: KindStruct, Path: path, After: t})
+		case hasC && !hasT:
+			out = append(out, Change{Op: OpRemove, Kind: KindStruct, Path: path, Before: c})
+		default:
+			if !reflect.DeepEqual(c, t) {
+				out = append(out, Change{Op: OpChange, Kind: KindStruct, Path: path, Before: c, After: t})
+			}
+		}
+	}
+	return out
+}
+
+func diffFunctions(pkg string, cur, tgt []domain.FunctionDef) []Change {
+	curIdx := make(map[string]domain.FunctionDef, len(cur))
+	for _, v := range cur {
+		curIdx[v.Name] = v
+	}
+	tgtIdx := make(map[string]domain.FunctionDef, len(tgt))
+	for _, v := range tgt {
+		tgtIdx[v.Name] = v
+	}
+	names := unionNames(curIdx, tgtIdx)
+
+	var out []Change
+	for _, n := range names {
+		c, hasC := curIdx[n]
+		t, hasT := tgtIdx[n]
+		path := pkg + "." + n
+		switch {
+		case !hasC && hasT:
+			out = append(out, Change{Op: OpAdd, Kind: KindFunction, Path: path, After: t})
+		case hasC && !hasT:
+			out = append(out, Change{Op: OpRemove, Kind: KindFunction, Path: path, Before: c})
+		default:
+			if !reflect.DeepEqual(c, t) {
+				out = append(out, Change{Op: OpChange, Kind: KindFunction, Path: path, Before: c, After: t})
+			}
+		}
+	}
+	return out
+}
+
+func diffTypeDefs(pkg string, cur, tgt []domain.TypeDef) []Change {
+	curIdx := make(map[string]domain.TypeDef, len(cur))
+	for _, v := range cur {
+		curIdx[v.Name] = v
+	}
+	tgtIdx := make(map[string]domain.TypeDef, len(tgt))
+	for _, v := range tgt {
+		tgtIdx[v.Name] = v
+	}
+	names := unionNames(curIdx, tgtIdx)
+
+	var out []Change
+	for _, n := range names {
+		c, hasC := curIdx[n]
+		t, hasT := tgtIdx[n]
+		path := pkg + "." + n
+		switch {
+		case !hasC && hasT:
+			out = append(out, Change{Op: OpAdd, Kind: KindTypeDef, Path: path, After: t})
+		case hasC && !hasT:
+			out = append(out, Change{Op: OpRemove, Kind: KindTypeDef, Path: path, Before: c})
+		default:
+			if !reflect.DeepEqual(c, t) {
+				out = append(out, Change{Op: OpChange, Kind: KindTypeDef, Path: path, Before: c, After: t})
+			}
+		}
+	}
+	return out
+}
+
+func diffConsts(pkg string, cur, tgt []domain.ConstDef) []Change {
+	curIdx := make(map[string]domain.ConstDef, len(cur))
+	for _, v := range cur {
+		curIdx[v.Name] = v
+	}
+	tgtIdx := make(map[string]domain.ConstDef, len(tgt))
+	for _, v := range tgt {
+		tgtIdx[v.Name] = v
+	}
+	names := unionNames(curIdx, tgtIdx)
+
+	var out []Change
+	for _, n := range names {
+		c, hasC := curIdx[n]
+		t, hasT := tgtIdx[n]
+		path := pkg + "." + n
+		switch {
+		case !hasC && hasT:
+			out = append(out, Change{Op: OpAdd, Kind: KindConst, Path: path, After: t})
+		case hasC && !hasT:
+			out = append(out, Change{Op: OpRemove, Kind: KindConst, Path: path, Before: c})
+		default:
+			if !reflect.DeepEqual(c, t) {
+				out = append(out, Change{Op: OpChange, Kind: KindConst, Path: path, Before: c, After: t})
+			}
+		}
+	}
+	return out
+}
+
+func diffVars(pkg string, cur, tgt []domain.VarDef) []Change {
+	curIdx := make(map[string]domain.VarDef, len(cur))
+	for _, v := range cur {
+		curIdx[v.Name] = v
+	}
+	tgtIdx := make(map[string]domain.VarDef, len(tgt))
+	for _, v := range tgt {
+		tgtIdx[v.Name] = v
+	}
+	names := unionNames(curIdx, tgtIdx)
+
+	var out []Change
+	for _, n := range names {
+		c, hasC := curIdx[n]
+		t, hasT := tgtIdx[n]
+		path := pkg + "." + n
+		switch {
+		case !hasC && hasT:
+			out = append(out, Change{Op: OpAdd, Kind: KindVar, Path: path, After: t})
+		case hasC && !hasT:
+			out = append(out, Change{Op: OpRemove, Kind: KindVar, Path: path, Before: c})
+		default:
+			if !reflect.DeepEqual(c, t) {
+				out = append(out, Change{Op: OpChange, Kind: KindVar, Path: path, Before: c, After: t})
+			}
+		}
+	}
+	return out
+}
+
+func diffErrors(pkg string, cur, tgt []domain.ErrorDef) []Change {
+	curIdx := make(map[string]domain.ErrorDef, len(cur))
+	for _, v := range cur {
+		curIdx[v.Name] = v
+	}
+	tgtIdx := make(map[string]domain.ErrorDef, len(tgt))
+	for _, v := range tgt {
+		tgtIdx[v.Name] = v
+	}
+	names := unionNames(curIdx, tgtIdx)
+
+	var out []Change
+	for _, n := range names {
+		c, hasC := curIdx[n]
+		t, hasT := tgtIdx[n]
+		path := pkg + "." + n
+		switch {
+		case !hasC && hasT:
+			out = append(out, Change{Op: OpAdd, Kind: KindError, Path: path, After: t})
+		case hasC && !hasT:
+			out = append(out, Change{Op: OpRemove, Kind: KindError, Path: path, Before: c})
+		default:
+			if !reflect.DeepEqual(c, t) {
+				out = append(out, Change{Op: OpChange, Kind: KindError, Path: path, Before: c, After: t})
+			}
+		}
+	}
+	return out
+}
+
+// diffDependencies compares dependency lists. Since Dependency does not have
+// a natural name, we use a string key built from From/To/Kind.
+func diffDependencies(pkg string, cur, tgt []domain.Dependency) []Change {
+	depKey := func(d domain.Dependency) string {
+		return d.From.String() + "->" + d.To.String() + ":" + string(d.Kind)
+	}
+	curIdx := make(map[string]domain.Dependency, len(cur))
+	for _, v := range cur {
+		curIdx[depKey(v)] = v
+	}
+	tgtIdx := make(map[string]domain.Dependency, len(tgt))
+	for _, v := range tgt {
+		tgtIdx[depKey(v)] = v
+	}
+
+	keys := make([]string, 0, len(curIdx)+len(tgtIdx))
+	seen := make(map[string]struct{}, len(curIdx)+len(tgtIdx))
+	for k := range curIdx {
+		if _, ok := seen[k]; !ok {
+			seen[k] = struct{}{}
+			keys = append(keys, k)
+		}
+	}
+	for k := range tgtIdx {
+		if _, ok := seen[k]; !ok {
+			seen[k] = struct{}{}
+			keys = append(keys, k)
+		}
+	}
+	sort.Strings(keys)
+
+	var out []Change
+	for _, k := range keys {
+		c, hasC := curIdx[k]
+		t, hasT := tgtIdx[k]
+		path := pkg + "#" + k
+		switch {
+		case !hasC && hasT:
+			out = append(out, Change{Op: OpAdd, Kind: KindDep, Path: path, After: t})
+		case hasC && !hasT:
+			out = append(out, Change{Op: OpRemove, Kind: KindDep, Path: path, Before: c})
+		default:
+			if !reflect.DeepEqual(c, t) {
+				out = append(out, Change{Op: OpChange, Kind: KindDep, Path: path, Before: c, After: t})
+			}
+		}
+	}
+	return out
+}
+
+// --- helpers ---
+
+// unionNames returns the sorted union of keys from two maps.
+func unionNames[V any](a, b map[string]V) []string {
+	seen := make(map[string]struct{}, len(a)+len(b))
+	names := make([]string, 0, len(a)+len(b))
+	for k := range a {
+		if _, ok := seen[k]; !ok {
+			seen[k] = struct{}{}
+			names = append(names, k)
+		}
+	}
+	for k := range b {
+		if _, ok := seen[k]; !ok {
+			seen[k] = struct{}{}
+			names = append(names, k)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+// packageSummary produces a compact, marshal-friendly snapshot of a package
+// used for the Before/After payload on add/remove-of-whole-package changes.
+func packageSummary(p domain.PackageModel) map[string]any {
+	return map[string]any{
+		"path":         p.Path,
+		"name":         p.Name,
+		"interfaces":   symbolNames(p.Interfaces, func(v domain.InterfaceDef) string { return v.Name }),
+		"structs":      symbolNames(p.Structs, func(v domain.StructDef) string { return v.Name }),
+		"functions":    symbolNames(p.Functions, func(v domain.FunctionDef) string { return v.Name }),
+		"typedefs":     symbolNames(p.TypeDefs, func(v domain.TypeDef) string { return v.Name }),
+		"constants":    symbolNames(p.Constants, func(v domain.ConstDef) string { return v.Name }),
+		"variables":    symbolNames(p.Variables, func(v domain.VarDef) string { return v.Name }),
+		"errors":       symbolNames(p.Errors, func(v domain.ErrorDef) string { return v.Name }),
+		"dependencies": len(p.Dependencies),
+	}
+}
+
+func symbolNames[T any](xs []T, name func(T) string) []string {
+	out := make([]string, 0, len(xs))
+	for _, x := range xs {
+		out = append(out, name(x))
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/diff/compute_test.go
+++ b/internal/diff/compute_test.go
@@ -1,0 +1,215 @@
+package diff
+
+import (
+	"testing"
+
+	"github.com/kgatilin/archai/internal/domain"
+)
+
+func pkg(path, name string) domain.PackageModel {
+	return domain.PackageModel{Path: path, Name: name}
+}
+
+func findChange(changes []Change, op Op, kind Kind, path string) *Change {
+	for i := range changes {
+		if changes[i].Op == op && changes[i].Kind == kind && changes[i].Path == path {
+			return &changes[i]
+		}
+	}
+	return nil
+}
+
+func TestCompute_NoDiff(t *testing.T) {
+	cur := []domain.PackageModel{pkg("internal/svc", "svc")}
+	tgt := []domain.PackageModel{pkg("internal/svc", "svc")}
+	d := Compute(cur, tgt)
+	if !d.IsEmpty() {
+		t.Fatalf("expected empty diff, got %d changes: %+v", len(d.Changes), d.Changes)
+	}
+}
+
+func TestCompute_AddedPackage(t *testing.T) {
+	cur := []domain.PackageModel{pkg("internal/svc", "svc")}
+	tgt := []domain.PackageModel{
+		pkg("internal/svc", "svc"),
+		pkg("internal/new", "new"),
+	}
+	d := Compute(cur, tgt)
+	if got := len(d.Changes); got != 1 {
+		t.Fatalf("expected 1 change, got %d: %+v", got, d.Changes)
+	}
+	c := d.Changes[0]
+	if c.Op != OpAdd || c.Kind != KindPackage || c.Path != "internal/new" {
+		t.Fatalf("unexpected change: %+v", c)
+	}
+	if c.After == nil {
+		t.Errorf("expected After populated for add, got nil")
+	}
+	if c.Before != nil {
+		t.Errorf("expected Before nil for add, got %+v", c.Before)
+	}
+}
+
+func TestCompute_RemovedPackage(t *testing.T) {
+	cur := []domain.PackageModel{
+		pkg("internal/svc", "svc"),
+		pkg("internal/gone", "gone"),
+	}
+	tgt := []domain.PackageModel{pkg("internal/svc", "svc")}
+	d := Compute(cur, tgt)
+	if got := len(d.Changes); got != 1 {
+		t.Fatalf("expected 1 change, got %d: %+v", got, d.Changes)
+	}
+	c := d.Changes[0]
+	if c.Op != OpRemove || c.Kind != KindPackage || c.Path != "internal/gone" {
+		t.Fatalf("unexpected change: %+v", c)
+	}
+	if c.Before == nil {
+		t.Errorf("expected Before populated for remove, got nil")
+	}
+}
+
+func TestCompute_AddedStruct(t *testing.T) {
+	cur := []domain.PackageModel{pkg("internal/svc", "svc")}
+	tgtPkg := pkg("internal/svc", "svc")
+	tgtPkg.Structs = []domain.StructDef{{Name: "Service", IsExported: true}}
+	tgt := []domain.PackageModel{tgtPkg}
+
+	d := Compute(cur, tgt)
+	c := findChange(d.Changes, OpAdd, KindStruct, "internal/svc.Service")
+	if c == nil {
+		t.Fatalf("expected added struct, got %+v", d.Changes)
+	}
+}
+
+func TestCompute_RemovedInterface(t *testing.T) {
+	curPkg := pkg("internal/svc", "svc")
+	curPkg.Interfaces = []domain.InterfaceDef{{Name: "Reader", IsExported: true}}
+	cur := []domain.PackageModel{curPkg}
+	tgt := []domain.PackageModel{pkg("internal/svc", "svc")}
+
+	d := Compute(cur, tgt)
+	c := findChange(d.Changes, OpRemove, KindInterface, "internal/svc.Reader")
+	if c == nil {
+		t.Fatalf("expected removed interface, got %+v", d.Changes)
+	}
+}
+
+func TestCompute_ChangedMethodSignature(t *testing.T) {
+	mk := func(params ...domain.ParamDef) domain.InterfaceDef {
+		return domain.InterfaceDef{
+			Name:       "Reader",
+			IsExported: true,
+			Methods: []domain.MethodDef{{
+				Name:       "Read",
+				IsExported: true,
+				Params:     params,
+			}},
+		}
+	}
+
+	curPkg := pkg("internal/svc", "svc")
+	curPkg.Interfaces = []domain.InterfaceDef{mk(
+		domain.ParamDef{Name: "ctx", Type: domain.TypeRef{Name: "Context", Package: "context"}},
+	)}
+	tgtPkg := pkg("internal/svc", "svc")
+	tgtPkg.Interfaces = []domain.InterfaceDef{mk(
+		domain.ParamDef{Name: "ctx", Type: domain.TypeRef{Name: "Context", Package: "context"}},
+		domain.ParamDef{Name: "id", Type: domain.TypeRef{Name: "string"}},
+	)}
+
+	d := Compute([]domain.PackageModel{curPkg}, []domain.PackageModel{tgtPkg})
+	c := findChange(d.Changes, OpChange, KindInterface, "internal/svc.Reader")
+	if c == nil {
+		t.Fatalf("expected changed interface, got %+v", d.Changes)
+	}
+	if c.Before == nil || c.After == nil {
+		t.Errorf("expected Before and After populated for change, got before=%v after=%v", c.Before, c.After)
+	}
+}
+
+func TestCompute_ChangedStructFields(t *testing.T) {
+	curPkg := pkg("internal/svc", "svc")
+	curPkg.Structs = []domain.StructDef{{
+		Name: "Config", IsExported: true,
+		Fields: []domain.FieldDef{{Name: "Host", IsExported: true, Type: domain.TypeRef{Name: "string"}}},
+	}}
+	tgtPkg := pkg("internal/svc", "svc")
+	tgtPkg.Structs = []domain.StructDef{{
+		Name: "Config", IsExported: true,
+		Fields: []domain.FieldDef{
+			{Name: "Host", IsExported: true, Type: domain.TypeRef{Name: "string"}},
+			{Name: "Port", IsExported: true, Type: domain.TypeRef{Name: "int"}},
+		},
+	}}
+
+	d := Compute([]domain.PackageModel{curPkg}, []domain.PackageModel{tgtPkg})
+	c := findChange(d.Changes, OpChange, KindStruct, "internal/svc.Config")
+	if c == nil {
+		t.Fatalf("expected changed struct, got %+v", d.Changes)
+	}
+}
+
+func TestCompute_ConstsVarsErrors(t *testing.T) {
+	curPkg := pkg("internal/svc", "svc")
+	curPkg.Constants = []domain.ConstDef{{Name: "Max", IsExported: true, Value: "10"}}
+	curPkg.Errors = []domain.ErrorDef{{Name: "ErrGone", IsExported: true, Message: "gone"}}
+	tgtPkg := pkg("internal/svc", "svc")
+	tgtPkg.Constants = []domain.ConstDef{{Name: "Max", IsExported: true, Value: "20"}}
+	tgtPkg.Variables = []domain.VarDef{{Name: "Default", IsExported: true, Type: domain.TypeRef{Name: "int"}}}
+
+	d := Compute([]domain.PackageModel{curPkg}, []domain.PackageModel{tgtPkg})
+	if findChange(d.Changes, OpChange, KindConst, "internal/svc.Max") == nil {
+		t.Errorf("expected const change, got %+v", d.Changes)
+	}
+	if findChange(d.Changes, OpRemove, KindError, "internal/svc.ErrGone") == nil {
+		t.Errorf("expected error removal, got %+v", d.Changes)
+	}
+	if findChange(d.Changes, OpAdd, KindVar, "internal/svc.Default") == nil {
+		t.Errorf("expected var add, got %+v", d.Changes)
+	}
+}
+
+func TestCompute_Dependencies(t *testing.T) {
+	dep := domain.Dependency{
+		From: domain.SymbolRef{Package: "internal/a", Symbol: "A"},
+		To:   domain.SymbolRef{Package: "internal/b", Symbol: "B"},
+		Kind: domain.DependencyUses,
+	}
+	curPkg := pkg("internal/a", "a")
+	tgtPkg := pkg("internal/a", "a")
+	tgtPkg.Dependencies = []domain.Dependency{dep}
+
+	d := Compute([]domain.PackageModel{curPkg}, []domain.PackageModel{tgtPkg})
+	var found bool
+	for _, c := range d.Changes {
+		if c.Op == OpAdd && c.Kind == KindDep {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected added dep, got %+v", d.Changes)
+	}
+}
+
+func TestCompute_StableOrderingByPath(t *testing.T) {
+	cur := []domain.PackageModel{
+		pkg("zeta", "zeta"),
+		pkg("alpha", "alpha"),
+	}
+	tgt := []domain.PackageModel{
+		pkg("beta", "beta"),
+	}
+	d := Compute(cur, tgt)
+	// Expect ordering: alpha (remove), beta (add), zeta (remove)
+	if len(d.Changes) != 3 {
+		t.Fatalf("expected 3 changes, got %d: %+v", len(d.Changes), d.Changes)
+	}
+	wantPaths := []string{"alpha", "beta", "zeta"}
+	for i, p := range wantPaths {
+		if d.Changes[i].Path != p {
+			t.Errorf("change[%d].Path = %q, want %q", i, d.Changes[i].Path, p)
+		}
+	}
+}

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -1,0 +1,71 @@
+// Package diff defines a structured, format-agnostic representation of the
+// differences between two snapshots of a project's architecture model
+// (typically the "current" code-derived model and a locked target).
+//
+// The types in this package are intentionally small and free of behavior so
+// that they can be marshalled to YAML/JSON or rendered to a terminal without
+// coupling to any particular output format.
+package diff
+
+// Op identifies the kind of change a Change entry describes.
+type Op string
+
+const (
+	// OpAdd indicates a symbol present in the target model but missing in
+	// the current model — i.e. something that still needs to be added to
+	// the codebase to match the target.
+	OpAdd Op = "add"
+
+	// OpRemove indicates a symbol present in the current model but missing
+	// in the target model — i.e. something in the code that the target
+	// wants gone.
+	OpRemove Op = "remove"
+
+	// OpChange indicates a symbol that exists on both sides but whose
+	// representation differs. The Change entry carries Before (current)
+	// and After (target) snapshots.
+	OpChange Op = "change"
+)
+
+// Kind identifies the architectural element a Change entry refers to.
+type Kind string
+
+const (
+	KindPackage   Kind = "package"
+	KindInterface Kind = "interface"
+	KindStruct    Kind = "struct"
+	KindFunction  Kind = "function"
+	KindMethod    Kind = "method"
+	KindField     Kind = "field"
+	KindConst     Kind = "const"
+	KindVar       Kind = "var"
+	KindError     Kind = "error"
+	KindDep       Kind = "dep"
+	KindLayerRule Kind = "layer-rule"
+	KindTypeDef   Kind = "typedef"
+)
+
+// Change describes a single difference between two models.
+//
+// Path is a dotted identifier that locates the element inside the model,
+// e.g. "internal/service" for a package, "internal/service.Service" for a
+// struct or interface, or "internal/service.Service.Handle" for a method.
+// Before/After are populated for OpChange; for OpAdd only After is set, for
+// OpRemove only Before is set.
+type Change struct {
+	Op     Op     `yaml:"op" json:"op"`
+	Kind   Kind   `yaml:"kind" json:"kind"`
+	Path   string `yaml:"path" json:"path"`
+	Before any    `yaml:"before,omitempty" json:"before,omitempty"`
+	After  any    `yaml:"after,omitempty" json:"after,omitempty"`
+}
+
+// Diff is the ordered list of Changes produced by Compute.
+type Diff struct {
+	Changes []Change `yaml:"changes" json:"changes"`
+}
+
+// IsEmpty reports whether d contains no changes.
+func (d *Diff) IsEmpty() bool {
+	return d == nil || len(d.Changes) == 0
+}

--- a/internal/diff/format.go
+++ b/internal/diff/format.go
@@ -1,0 +1,62 @@
+package diff
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	yamlv3 "gopkg.in/yaml.v3"
+)
+
+// FormatText renders a Diff as a plain, human-readable listing. Each change
+// is a single line prefixed with "+" for add, "-" for remove, "~" for change.
+// A trailing summary line counts per-op totals.
+func FormatText(d *Diff) string {
+	if d == nil || len(d.Changes) == 0 {
+		return "No changes.\n"
+	}
+
+	var sb strings.Builder
+	var added, removed, changed int
+	for _, c := range d.Changes {
+		switch c.Op {
+		case OpAdd:
+			fmt.Fprintf(&sb, "+ added %s %s\n", c.Kind, c.Path)
+			added++
+		case OpRemove:
+			fmt.Fprintf(&sb, "- removed %s %s\n", c.Kind, c.Path)
+			removed++
+		case OpChange:
+			fmt.Fprintf(&sb, "~ changed %s %s\n", c.Kind, c.Path)
+			changed++
+		default:
+			fmt.Fprintf(&sb, "? %s %s %s\n", c.Op, c.Kind, c.Path)
+		}
+	}
+	fmt.Fprintf(&sb, "\n%d added, %d removed, %d changed\n", added, removed, changed)
+	return sb.String()
+}
+
+// FormatYAML marshals the Diff to a YAML document.
+func FormatYAML(d *Diff) (string, error) {
+	if d == nil {
+		d = &Diff{}
+	}
+	out, err := yamlv3.Marshal(d)
+	if err != nil {
+		return "", fmt.Errorf("diff: marshal yaml: %w", err)
+	}
+	return string(out), nil
+}
+
+// FormatJSON marshals the Diff to indented JSON.
+func FormatJSON(d *Diff) (string, error) {
+	if d == nil {
+		d = &Diff{}
+	}
+	out, err := json.MarshalIndent(d, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("diff: marshal json: %w", err)
+	}
+	return string(out) + "\n", nil
+}

--- a/internal/diff/format_test.go
+++ b/internal/diff/format_test.go
@@ -1,0 +1,84 @@
+package diff
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	yamlv3 "gopkg.in/yaml.v3"
+)
+
+func TestFormatText_Empty(t *testing.T) {
+	got := FormatText(&Diff{})
+	if !strings.Contains(got, "No changes") {
+		t.Errorf("expected 'No changes' for empty diff, got %q", got)
+	}
+
+	gotNil := FormatText(nil)
+	if !strings.Contains(gotNil, "No changes") {
+		t.Errorf("expected 'No changes' for nil diff, got %q", gotNil)
+	}
+}
+
+func TestFormatText_Smoke(t *testing.T) {
+	d := &Diff{Changes: []Change{
+		{Op: OpAdd, Kind: KindStruct, Path: "pkg.Foo"},
+		{Op: OpRemove, Kind: KindInterface, Path: "pkg.Bar"},
+		{Op: OpChange, Kind: KindFunction, Path: "pkg.Baz"},
+	}}
+	got := FormatText(d)
+
+	checks := []string{
+		"+ added struct pkg.Foo",
+		"- removed interface pkg.Bar",
+		"~ changed function pkg.Baz",
+		"1 added, 1 removed, 1 changed",
+	}
+	for _, s := range checks {
+		if !strings.Contains(got, s) {
+			t.Errorf("expected output to contain %q, got:\n%s", s, got)
+		}
+	}
+}
+
+func TestFormatYAML_Roundtrip(t *testing.T) {
+	d := &Diff{Changes: []Change{
+		{Op: OpAdd, Kind: KindStruct, Path: "pkg.Foo", After: map[string]any{"name": "Foo"}},
+	}}
+	got, err := FormatYAML(d)
+	if err != nil {
+		t.Fatalf("FormatYAML error: %v", err)
+	}
+	if !strings.Contains(got, "op: add") {
+		t.Errorf("expected 'op: add' in yaml output, got:\n%s", got)
+	}
+
+	var parsed Diff
+	if err := yamlv3.Unmarshal([]byte(got), &parsed); err != nil {
+		t.Fatalf("roundtrip unmarshal: %v", err)
+	}
+	if len(parsed.Changes) != 1 || parsed.Changes[0].Op != OpAdd {
+		t.Errorf("roundtrip mismatch: %+v", parsed)
+	}
+}
+
+func TestFormatJSON_Roundtrip(t *testing.T) {
+	d := &Diff{Changes: []Change{
+		{Op: OpRemove, Kind: KindInterface, Path: "pkg.Bar", Before: map[string]any{"name": "Bar"}},
+	}}
+	got, err := FormatJSON(d)
+	if err != nil {
+		t.Fatalf("FormatJSON error: %v", err)
+	}
+	if !strings.Contains(got, `"op": "remove"`) {
+		t.Errorf("expected op=remove in json, got:\n%s", got)
+	}
+
+	var parsed Diff
+	if err := json.Unmarshal([]byte(got), &parsed); err != nil {
+		t.Fatalf("json roundtrip: %v", err)
+	}
+	if len(parsed.Changes) != 1 || parsed.Changes[0].Op != OpRemove {
+		t.Errorf("roundtrip mismatch: %+v", parsed)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `internal/diff` package with `Diff`/`Change` schema (Op, Kind, Path, Before, After) and `Compute(current, target)` that pairs packages by path and matches child symbols by name, emitting add/remove/change entries for interfaces, structs, functions, typedefs, consts, vars, errors and dependencies.
- Provides text, YAML, and JSON formatters.
- Wires up new `archai diff [--target <id>] [--format text|yaml|json]` CLI command. The current model is loaded from per-package `.arch/*.yaml` (falling back to parsing Go sources when no specs exist); the target model is loaded from `.arch/targets/<id>/model/`. When `--target` is omitted, `.arch/targets/CURRENT` is used.

Closes #14.

Does NOT implement `diff apply` or `validate` — those are M4c.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (all packages green, including new `internal/diff` tests covering no-diff, added/removed package, added struct, removed interface, changed method signature, changed struct fields, const/var/error shifts, dependency diff, and stable path ordering)
- [x] Manual smoke: `archai diff --target nonexistent` prints a clear error