### PR TITLE
M5a: Daemon skeleton + in-memory model + fsnotify watcher

### DIFF
--- a/cmd/archai/main.go
+++ b/cmd/archai/main.go
@@ -8,9 +8,11 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"sort"
 	"strings"
+	"syscall"
 
 	"github.com/kgatilin/archai/internal/adapter/d2"
 	"github.com/kgatilin/archai/internal/adapter/golang"
@@ -19,6 +21,7 @@ import (
 	"github.com/kgatilin/archai/internal/diff"
 	"github.com/kgatilin/archai/internal/domain"
 	"github.com/kgatilin/archai/internal/overlay"
+	"github.com/kgatilin/archai/internal/serve"
 	"github.com/kgatilin/archai/internal/service"
 	"github.com/kgatilin/archai/internal/target"
 	"github.com/spf13/cobra"
@@ -279,10 +282,59 @@ Examples:
 	overlayCheckCmd.Flags().String("overlay", "", "Path to archai.yaml overlay (default: ./archai.yaml)")
 	overlayCmd.AddCommand(overlayCheckCmd)
 
+	// Serve command (M5a) — long-running daemon holding an in-memory
+	// model kept current via fsnotify. Transports for MCP stdio (M5b)
+	// and HTTP (M7a) are wired as stubs; they log a notice and the
+	// daemon still runs so the watcher loop can be exercised.
+	serveCmd := &cobra.Command{
+		Use:   "serve",
+		Short: "Run archai as a long-running daemon with an in-memory model",
+		Long: `Run archai as a long-running daemon.
+
+Loads the Go model, the archai.yaml overlay (if present), and the active
+target id into memory, then watches the project root with fsnotify and
+incrementally refreshes the model on change.
+
+The MCP stdio (--mcp-stdio) and HTTP (--http) transports are stubs in
+this milestone; they will be filled in by M5b and M7a. With no
+transport flag, the daemon runs as a silent model-keeper useful for
+manual verification and as a base for future features.`,
+		Args: cobra.NoArgs,
+		RunE: runServe,
+	}
+	serveCmd.Flags().String("root", ".", "Project root directory")
+	serveCmd.Flags().Bool("mcp-stdio", false, "Enable MCP stdio transport (stub in M5a)")
+	serveCmd.Flags().String("http", "", "HTTP transport address, e.g. :8080 (stub in M5a)")
+	serveCmd.Flags().Bool("debug", false, "Verbose per-event logging")
+	rootCmd.AddCommand(serveCmd)
+
 	// Execute root command
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
 	}
+}
+
+// runServe handles `archai serve`. It wires SIGINT/SIGTERM into a
+// cancellable context and delegates the rest to the serve package.
+func runServe(cmd *cobra.Command, args []string) error {
+	root, _ := cmd.Flags().GetString("root")
+	mcpStdio, _ := cmd.Flags().GetBool("mcp-stdio")
+	httpAddr, _ := cmd.Flags().GetString("http")
+	debug, _ := cmd.Flags().GetBool("debug")
+
+	parent := cmd.Context()
+	if parent == nil {
+		parent = context.Background()
+	}
+	ctx, stop := signal.NotifyContext(parent, os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	return serve.Serve(ctx, serve.Options{
+		Root:     root,
+		MCPStdio: mcpStdio,
+		HTTPAddr: httpAddr,
+		Debug:    debug,
+	})
 }
 
 // runOverlayCheck executes `archai overlay check`. It loads the overlay,

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/dsoprea/go-png-image-structure/v2 v2.0.0-20210512210324-29b889a6093d // indirect
 	github.com/dsoprea/go-utility/v2 v2.0.0-20221003172846-a3e1774ef349 // indirect
 	github.com/ericpauley/go-quantize v0.0.0-20200331213906-ae555eb2afa4 // indirect
-	github.com/fsnotify/fsnotify v1.7.1-0.20240403050945-7086bea086b7 // indirect
+	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/go-errors/errors v1.5.1 // indirect
 	github.com/go-jose/go-jose/v3 v3.0.3 // indirect
 	github.com/go-sourcemap/sourcemap v2.1.4+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,8 @@ github.com/ericpauley/go-quantize v0.0.0-20200331213906-ae555eb2afa4 h1:BBade+Jl
 github.com/ericpauley/go-quantize v0.0.0-20200331213906-ae555eb2afa4/go.mod h1:H7chHJglrhPPzetLdzBleF8d22WYOv7UM/lEKYiwlKM=
 github.com/fsnotify/fsnotify v1.7.1-0.20240403050945-7086bea086b7 h1:5ZeiG5gIjLqPKLl+f5zv++9ZO2oxA6hmZ3e7G0mMW1M=
 github.com/fsnotify/fsnotify v1.7.1-0.20240403050945-7086bea086b7/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
+github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
+github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
 github.com/go-errors/errors v1.0.2/go.mod h1:psDX2osz5VnTOnFWbDeWwS7yejl+uV3FEWEp4lssFEs=
 github.com/go-errors/errors v1.1.1/go.mod h1:psDX2osz5VnTOnFWbDeWwS7yejl+uV3FEWEp4lssFEs=

--- a/internal/serve/daemon.go
+++ b/internal/serve/daemon.go
@@ -1,0 +1,180 @@
+package serve
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// Options configures the Serve entry point.
+type Options struct {
+	// Root is the project root directory. Defaults to cwd when empty.
+	Root string
+
+	// MCPStdio enables the MCP stdio transport. Currently a stub
+	// (M5a only wires the flag so M5b can implement it).
+	MCPStdio bool
+
+	// HTTPAddr enables the HTTP transport on the given address
+	// (e.g. ":8080"). Empty disables HTTP. Stub until M7a.
+	HTTPAddr string
+
+	// Debug enables verbose per-event logging.
+	Debug bool
+
+	// LogOut is the writer for human-readable daemon output. Defaults
+	// to os.Stderr when nil.
+	LogOut io.Writer
+
+	// Debounce overrides the event coalescing window. Zero uses the
+	// default (200ms). Exposed mainly for tests.
+	Debounce time.Duration
+}
+
+// Serve runs the daemon: it builds the in-memory model, starts the
+// fsnotify watcher, wires stub transports, and blocks until ctx is
+// cancelled. Callers are expected to bridge SIGINT/SIGTERM into ctx.
+func Serve(ctx context.Context, opts Options) error {
+	root := opts.Root
+	if root == "" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("serve: resolving cwd: %w", err)
+		}
+		root = cwd
+	}
+
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return fmt.Errorf("serve: resolving root %s: %w", root, err)
+	}
+
+	logOut := opts.LogOut
+	if logOut == nil {
+		logOut = os.Stderr
+	}
+
+	fmt.Fprintf(logOut, "serve: loading model from %s\n", absRoot)
+	state := NewState(absRoot)
+	if err := state.Load(ctx); err != nil {
+		return err
+	}
+	snap := state.Snapshot()
+	fmt.Fprintf(logOut, "serve: loaded %d package(s), overlay=%v, target=%q\n",
+		len(snap.Packages), snap.Overlay != nil, snap.CurrentTarget)
+
+	// Transport stubs. M5b / M7a will replace these with real
+	// implementations; for now we log so operators know they were
+	// requested.
+	if opts.MCPStdio {
+		fmt.Fprintln(logOut, "serve: MCP stdio transport requested — not implemented yet (stub)")
+	}
+	if opts.HTTPAddr != "" {
+		fmt.Fprintf(logOut, "serve: HTTP transport requested on %s — not implemented yet (stub)\n", opts.HTTPAddr)
+	}
+
+	watcher, err := NewWatcher(absRoot, opts.Debounce)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = watcher.Close() }()
+
+	handler := buildHandler(ctx, state, logOut, opts.Debug)
+
+	fmt.Fprintln(logOut, "serve: watching for changes (Ctrl-C to stop)")
+	if err := watcher.Run(ctx, handler); err != nil {
+		if errors.Is(err, context.Canceled) {
+			return nil
+		}
+		return err
+	}
+	fmt.Fprintln(logOut, "serve: shutdown complete")
+	return nil
+}
+
+// buildHandler returns the EventHandler closure that dispatches a
+// debounced batch of file events into the appropriate state reloads.
+func buildHandler(ctx context.Context, state *State, logOut io.Writer, debug bool) EventHandler {
+	root := state.Root()
+
+	return func(paths []string) {
+		if debug {
+			fmt.Fprintf(logOut, "serve: batch %d event(s)\n", len(paths))
+		}
+
+		// Deduplicate owning-package reloads within a batch.
+		pkgReloads := make(map[string]struct{})
+		overlayDirty := false
+		currentDirty := false
+
+		for _, p := range paths {
+			abs := p
+			if !filepath.IsAbs(abs) {
+				abs = filepath.Join(root, p)
+			}
+			rel, err := filepath.Rel(root, abs)
+			if err != nil {
+				rel = abs
+			}
+			rel = filepath.ToSlash(rel)
+
+			switch {
+			case rel == "archai.yaml":
+				overlayDirty = true
+			case rel == ".arch/targets/CURRENT":
+				currentDirty = true
+			case strings.HasSuffix(abs, ".go"):
+				if pkg := state.FindOwningPackage(abs); pkg != "" {
+					pkgReloads[pkg] = struct{}{}
+				}
+			}
+		}
+
+		for pkg := range pkgReloads {
+			if err := state.ReloadPackage(ctx, pkg); err != nil {
+				fmt.Fprintf(logOut, "serve: reload %s: %v\n", pkg, err)
+				continue
+			}
+			if debug {
+				fmt.Fprintf(logOut, "serve: reloaded package %s\n", pkg)
+			}
+		}
+
+		if overlayDirty {
+			if err := state.ReloadOverlay(ctx); err != nil {
+				fmt.Fprintf(logOut, "serve: reload overlay: %v\n", err)
+			} else if debug {
+				fmt.Fprintln(logOut, "serve: reloaded overlay")
+			}
+		}
+
+		if currentDirty {
+			id, err := readCurrent(filepath.Join(root, ".arch", "targets", "CURRENT"))
+			if err != nil {
+				fmt.Fprintf(logOut, "serve: read CURRENT: %v\n", err)
+			} else if err := state.SwitchTarget(id); err != nil {
+				fmt.Fprintf(logOut, "serve: switch target: %v\n", err)
+			} else if debug {
+				fmt.Fprintf(logOut, "serve: active target = %q\n", id)
+			}
+		}
+	}
+}
+
+// readCurrent reads the single-line CURRENT pointer. Missing file is
+// treated as an empty id (no active target).
+func readCurrent(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", nil
+		}
+		return "", err
+	}
+	return strings.TrimSpace(string(data)), nil
+}

--- a/internal/serve/state.go
+++ b/internal/serve/state.go
@@ -1,0 +1,297 @@
+// Package serve implements the long-running `archai serve` daemon: an
+// in-memory model of the project (extracted Go packages + overlay config +
+// active target id) kept current via an fsnotify watcher.
+//
+// The daemon is the backbone for future MCP stdio (M5b) and HTTP (M7a)
+// transports; those transports read from the shared State via Snapshot()
+// and are wired through Serve() in daemon.go.
+package serve
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/kgatilin/archai/internal/adapter/golang"
+	"github.com/kgatilin/archai/internal/domain"
+	"github.com/kgatilin/archai/internal/overlay"
+	"github.com/kgatilin/archai/internal/service"
+	"github.com/kgatilin/archai/internal/target"
+)
+
+// State holds the in-memory model consumed by the daemon's transports.
+// All reads go through Snapshot(); mutations go through the Reload*/Switch
+// methods which take an exclusive lock. State is safe for concurrent use.
+type State struct {
+	mu sync.RWMutex
+
+	// root is the project root directory (absolute path).
+	root string
+
+	// reader is the Go model reader. Stored so incremental reloads can
+	// re-use the same concrete reader (and its cached module path).
+	reader service.ModelReader
+
+	// packages is the current extracted model, keyed by PackageModel.Path.
+	packages map[string]domain.PackageModel
+
+	// overlayCfg is the parsed archai.yaml (may be nil if absent).
+	overlayCfg *overlay.Config
+
+	// overlayPath is the on-disk archai.yaml location used for reloads.
+	// Empty when no overlay was found on Load.
+	overlayPath string
+
+	// goModPath is the adjacent go.mod used for overlay validation.
+	goModPath string
+
+	// currentTarget is the active target id (may be empty).
+	currentTarget string
+}
+
+// NewState returns an empty State rooted at root. Callers must invoke
+// Load before querying the state.
+func NewState(root string) *State {
+	return &State{
+		root:     root,
+		reader:   golang.NewReader(),
+		packages: make(map[string]domain.PackageModel),
+	}
+}
+
+// Snapshot is a read-only view of the State. All slices/maps are
+// independent of the live State and safe to retain.
+type Snapshot struct {
+	Root          string
+	Packages      []domain.PackageModel
+	Overlay       *overlay.Config
+	CurrentTarget string
+}
+
+// Snapshot returns a consistent read-only copy of the state.
+func (s *State) Snapshot() Snapshot {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	pkgs := make([]domain.PackageModel, 0, len(s.packages))
+	for _, p := range s.packages {
+		pkgs = append(pkgs, p)
+	}
+
+	var cfgCopy *overlay.Config
+	if s.overlayCfg != nil {
+		cp := *s.overlayCfg
+		cfgCopy = &cp
+	}
+
+	return Snapshot{
+		Root:          s.root,
+		Packages:      pkgs,
+		Overlay:       cfgCopy,
+		CurrentTarget: s.currentTarget,
+	}
+}
+
+// Root returns the project root directory.
+func (s *State) Root() string {
+	return s.root
+}
+
+// Load performs the initial full extraction: Go packages under ./...,
+// archai.yaml overlay (if present), and the active target id
+// (.arch/targets/CURRENT). Errors extracting packages are returned; a
+// missing overlay or CURRENT file is not an error.
+func (s *State) Load(ctx context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	models, err := s.readAll(ctx)
+	if err != nil {
+		return fmt.Errorf("serve: loading packages: %w", err)
+	}
+
+	s.packages = make(map[string]domain.PackageModel, len(models))
+	for _, m := range models {
+		s.packages[m.Path] = m
+	}
+
+	// Overlay: best-effort. Missing file → leave nil.
+	if err := s.reloadOverlayLocked(); err != nil {
+		return fmt.Errorf("serve: loading overlay: %w", err)
+	}
+
+	// CURRENT target: best-effort.
+	cur, err := target.Current(s.root)
+	if err != nil {
+		return fmt.Errorf("serve: reading CURRENT: %w", err)
+	}
+	s.currentTarget = cur
+
+	return nil
+}
+
+// ReloadPackage re-extracts the single package identified by its
+// module-relative path (e.g. "internal/serve") and splices the result
+// into the in-memory model. A package that no longer exists is removed.
+func (s *State) ReloadPackage(ctx context.Context, pkgPath string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if pkgPath == "" {
+		return fmt.Errorf("serve: empty package path")
+	}
+
+	pattern := "./" + strings.TrimPrefix(pkgPath, "./")
+	if pkgPath == "." {
+		pattern = "./"
+	}
+
+	// The Go reader resolves relative patterns against cwd; scope the
+	// change to this call so caller-visible cwd is untouched.
+	prevCwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("serve: resolving cwd: %w", err)
+	}
+	if err := os.Chdir(s.root); err != nil {
+		return fmt.Errorf("serve: chdir %s: %w", s.root, err)
+	}
+	defer func() { _ = os.Chdir(prevCwd) }()
+
+	models, err := s.reader.Read(ctx, []string{pattern})
+	if err != nil {
+		// Package may have been removed; drop it and return no error so
+		// the watcher loop stays alive.
+		delete(s.packages, pkgPath)
+		return nil
+	}
+
+	// Remove the old entry so stale data cannot leak if the reader
+	// returned zero packages (deleted/empty dir).
+	delete(s.packages, pkgPath)
+	for _, m := range models {
+		s.packages[m.Path] = m
+	}
+	return nil
+}
+
+// ReloadOverlay re-reads archai.yaml from disk and updates the cached
+// config. Missing files clear the cached config without returning an
+// error (the daemon can run without an overlay).
+func (s *State) ReloadOverlay(ctx context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.reloadOverlayLocked()
+}
+
+// SwitchTarget updates the active target id. An empty id clears it
+// (equivalent to removing .arch/targets/CURRENT).
+func (s *State) SwitchTarget(id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.currentTarget = id
+	return nil
+}
+
+// readAll runs the Go reader over the whole project. Extracted into a
+// helper so Load can be kept readable.
+func (s *State) readAll(ctx context.Context) ([]domain.PackageModel, error) {
+	// We resolve paths relative to the configured root by temporarily
+	// changing working directory. go/packages loads relative patterns
+	// based on cwd; the project may be anywhere on disk.
+	prevCwd, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+	if err := os.Chdir(s.root); err != nil {
+		return nil, err
+	}
+	defer func() { _ = os.Chdir(prevCwd) }()
+
+	return s.reader.Read(ctx, []string{"./..."})
+}
+
+// reloadOverlayLocked reloads the overlay assuming the caller holds the
+// write lock. Missing archai.yaml clears the cached config.
+func (s *State) reloadOverlayLocked() error {
+	overlayPath := filepath.Join(s.root, "archai.yaml")
+	goModPath := filepath.Join(s.root, "go.mod")
+	if _, err := os.Stat(overlayPath); err != nil {
+		// No overlay on disk: clear cache, not an error.
+		s.overlayCfg = nil
+		s.overlayPath = ""
+		s.goModPath = ""
+		return nil
+	}
+	cfg, err := overlay.Load(overlayPath)
+	if err != nil {
+		return err
+	}
+	s.overlayCfg = cfg
+	s.overlayPath = overlayPath
+	if _, err := os.Stat(goModPath); err == nil {
+		s.goModPath = goModPath
+	} else {
+		s.goModPath = ""
+	}
+	return nil
+}
+
+// FindOwningPackage walks up from the directory of path until it finds
+// a directory containing .go files, then converts that absolute
+// directory into a module-relative package path by stripping the root
+// prefix. Returns "" when no owning package is found (e.g. the change
+// was outside the project root or in a non-Go directory tree).
+func (s *State) FindOwningPackage(path string) string {
+	abs := path
+	if !filepath.IsAbs(abs) {
+		abs = filepath.Join(s.root, path)
+	}
+	dir := filepath.Dir(abs)
+	rootAbs, err := filepath.Abs(s.root)
+	if err != nil {
+		rootAbs = s.root
+	}
+
+	for {
+		if !strings.HasPrefix(dir, rootAbs) {
+			return ""
+		}
+		if hasGoFiles(dir) {
+			rel, err := filepath.Rel(rootAbs, dir)
+			if err != nil {
+				return ""
+			}
+			if rel == "." {
+				return "."
+			}
+			return filepath.ToSlash(rel)
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return ""
+		}
+		dir = parent
+	}
+}
+
+// hasGoFiles reports whether dir contains at least one .go file
+// (excluding _test.go files is unnecessary here — we only need to know
+// the directory is a Go package for reload purposes).
+func hasGoFiles(dir string) bool {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		if filepath.Ext(e.Name()) == ".go" {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/serve/state_test.go
+++ b/internal/serve/state_test.go
@@ -1,0 +1,186 @@
+package serve
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kgatilin/archai/internal/domain"
+)
+
+// writeFile is a tiny helper for building fixture trees inside tests.
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// newFixture creates a minimal Go module under t.TempDir() containing
+// two packages (internal/foo, internal/bar) plus an archai.yaml. The
+// returned path is the module root.
+func newFixture(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+
+	writeFile(t, filepath.Join(root, "go.mod"), "module example.com/fixture\n\ngo 1.21\n")
+
+	writeFile(t, filepath.Join(root, "internal", "foo", "foo.go"), `package foo
+
+// Thing is a trivial exported struct so the extractor has something to find.
+type Thing struct {
+	Name string
+}
+
+// New returns a Thing.
+func New() *Thing { return &Thing{} }
+`)
+
+	writeFile(t, filepath.Join(root, "internal", "bar", "bar.go"), `package bar
+
+// Bar is a trivial exported struct.
+type Bar struct{}
+`)
+
+	writeFile(t, filepath.Join(root, "archai.yaml"), `module: example.com/fixture
+layers:
+  domain:
+    - "internal/foo/..."
+    - "internal/bar/..."
+layer_rules:
+  domain: []
+`)
+
+	return root
+}
+
+func TestStateLoadExtractsPackages(t *testing.T) {
+	root := newFixture(t)
+	st := NewState(root)
+
+	if err := st.Load(context.Background()); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	snap := st.Snapshot()
+	if len(snap.Packages) == 0 {
+		t.Fatalf("expected at least one package, got 0")
+	}
+	// Overlay should have loaded.
+	if snap.Overlay == nil {
+		t.Fatalf("expected overlay to be loaded")
+	}
+	if snap.Overlay.Module != "example.com/fixture" {
+		t.Fatalf("overlay module = %q, want %q", snap.Overlay.Module, "example.com/fixture")
+	}
+
+	// Spot-check that at least one of our fixture packages is present.
+	found := false
+	for _, p := range snap.Packages {
+		if p.Path == "internal/foo" || p.Path == "internal/bar" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected internal/foo or internal/bar in model, got: %v", packagePaths(snap.Packages))
+	}
+}
+
+func TestStateReloadPackageUpdatesModel(t *testing.T) {
+	root := newFixture(t)
+	st := NewState(root)
+
+	ctx := context.Background()
+	if err := st.Load(ctx); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	// Capture the initial struct count for internal/foo.
+	initial := countStructs(t, st, "internal/foo")
+
+	// Edit foo.go to add a second struct and reload just that package.
+	writeFile(t, filepath.Join(root, "internal", "foo", "foo.go"), `package foo
+
+type Thing struct{ Name string }
+type Second struct{ X int }
+
+func New() *Thing { return &Thing{} }
+`)
+
+	if err := st.ReloadPackage(ctx, "internal/foo"); err != nil {
+		t.Fatalf("ReloadPackage: %v", err)
+	}
+	after := countStructs(t, st, "internal/foo")
+	if after <= initial {
+		t.Fatalf("expected struct count to grow after reload (initial=%d after=%d)", initial, after)
+	}
+}
+
+func TestStateSwitchTargetUpdatesID(t *testing.T) {
+	st := NewState(t.TempDir())
+	if got := st.Snapshot().CurrentTarget; got != "" {
+		t.Fatalf("initial CurrentTarget = %q, want empty", got)
+	}
+	if err := st.SwitchTarget("v1"); err != nil {
+		t.Fatalf("SwitchTarget: %v", err)
+	}
+	if got := st.Snapshot().CurrentTarget; got != "v1" {
+		t.Fatalf("after switch, CurrentTarget = %q, want %q", got, "v1")
+	}
+	if err := st.SwitchTarget(""); err != nil {
+		t.Fatalf("SwitchTarget clear: %v", err)
+	}
+	if got := st.Snapshot().CurrentTarget; got != "" {
+		t.Fatalf("after clear, CurrentTarget = %q, want empty", got)
+	}
+}
+
+func TestStateFindOwningPackage(t *testing.T) {
+	root := newFixture(t)
+	st := NewState(root)
+	if err := st.Load(context.Background()); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	cases := []struct {
+		path string
+		want string
+	}{
+		{filepath.Join(root, "internal", "foo", "foo.go"), "internal/foo"},
+		{filepath.Join(root, "internal", "foo", "nonexistent.go"), "internal/foo"},
+		{filepath.Join(root, "internal", "bar", "bar.go"), "internal/bar"},
+	}
+	for _, tc := range cases {
+		got := st.FindOwningPackage(tc.path)
+		if got != tc.want {
+			t.Errorf("FindOwningPackage(%s) = %q, want %q", tc.path, got, tc.want)
+		}
+	}
+}
+
+// countStructs returns the number of structs extracted for the given
+// module-relative package path in the state.
+func countStructs(t *testing.T, st *State, pkgPath string) int {
+	t.Helper()
+	for _, p := range st.Snapshot().Packages {
+		if p.Path == pkgPath {
+			return len(p.Structs)
+		}
+	}
+	t.Fatalf("package %q not in snapshot", pkgPath)
+	return 0
+}
+
+// packagePaths flattens snapshot.Packages to its Path slice (for error output).
+func packagePaths(ps []domain.PackageModel) []string {
+	out := make([]string, 0, len(ps))
+	for _, p := range ps {
+		out = append(out, p.Path)
+	}
+	return out
+}

--- a/internal/serve/watcher.go
+++ b/internal/serve/watcher.go
@@ -1,0 +1,209 @@
+package serve
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// DefaultDebounce is the window used to coalesce rapid file events into
+// a single batch. 200ms is enough to swallow editor save bursts and
+// git checkout storms without noticeably delaying single-change reloads.
+const DefaultDebounce = 200 * time.Millisecond
+
+// EventHandler is invoked for each flushed batch of file paths. The
+// Watcher calls it serially; the handler itself is responsible for any
+// further concurrency.
+type EventHandler func(paths []string)
+
+// Watcher wraps an fsnotify.Watcher with a debounced event channel.
+// Events arriving within Debounce of one another are coalesced into a
+// single batch and delivered to the handler.
+type Watcher struct {
+	inner    *fsnotify.Watcher
+	root     string
+	debounce time.Duration
+
+	// skipDir returns true when the given directory should not be
+	// walked into when adding watches. Tests inject one; production
+	// code uses defaultSkipDir.
+	skipDir func(name string) bool
+}
+
+// NewWatcher creates a fsnotify-backed Watcher rooted at root. The
+// watcher recursively adds every directory under root that passes
+// skipDir. Debounce defaults to DefaultDebounce when zero.
+func NewWatcher(root string, debounce time.Duration) (*Watcher, error) {
+	inner, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, fmt.Errorf("serve: creating fsnotify watcher: %w", err)
+	}
+	if debounce <= 0 {
+		debounce = DefaultDebounce
+	}
+	w := &Watcher{
+		inner:    inner,
+		root:     root,
+		debounce: debounce,
+		skipDir:  defaultSkipDir,
+	}
+	if err := w.addTree(root); err != nil {
+		_ = inner.Close()
+		return nil, err
+	}
+	return w, nil
+}
+
+// Close stops the underlying fsnotify watcher. Safe to call multiple times.
+func (w *Watcher) Close() error {
+	if w == nil || w.inner == nil {
+		return nil
+	}
+	return w.inner.Close()
+}
+
+// Run pumps events from fsnotify into debounced batches and invokes
+// handler for each batch. It returns when ctx is cancelled or the
+// fsnotify event channel is closed. Errors from the underlying watcher
+// are reported via the error channel and logged to stderr; they are not
+// fatal.
+func (w *Watcher) Run(ctx context.Context, handler EventHandler) error {
+	if handler == nil {
+		return errors.New("serve: watcher handler is nil")
+	}
+
+	pending := make(map[string]struct{})
+	var timer *time.Timer
+	// tickC is nil while no debounce window is active; assigning to
+	// timer.C makes the select wake up when the window elapses.
+	var tickC <-chan time.Time
+
+	flush := func() {
+		if len(pending) == 0 {
+			return
+		}
+		paths := make([]string, 0, len(pending))
+		for p := range pending {
+			paths = append(paths, p)
+		}
+		pending = make(map[string]struct{})
+		handler(paths)
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			// Drain any pending batch before exiting so in-flight
+			// edits are not silently lost.
+			flush()
+			return nil
+
+		case ev, ok := <-w.inner.Events:
+			if !ok {
+				flush()
+				return nil
+			}
+			// If the event is the creation of a new directory, start
+			// watching it too so nested edits are picked up.
+			if ev.Op&fsnotify.Create != 0 {
+				if fi, err := os.Stat(ev.Name); err == nil && fi.IsDir() {
+					// Best-effort: errors here are non-fatal.
+					_ = w.addTree(ev.Name)
+				}
+			}
+			if w.shouldIgnore(ev.Name) {
+				continue
+			}
+			pending[ev.Name] = struct{}{}
+			if timer == nil {
+				timer = time.NewTimer(w.debounce)
+				tickC = timer.C
+			} else {
+				if !timer.Stop() {
+					// Drain the expired timer so Reset cannot race.
+					select {
+					case <-timer.C:
+					default:
+					}
+				}
+				timer.Reset(w.debounce)
+				tickC = timer.C
+			}
+
+		case err, ok := <-w.inner.Errors:
+			if !ok {
+				flush()
+				return nil
+			}
+			// Non-fatal: log and continue. Callers that need stricter
+			// handling can wrap EventHandler.
+			fmt.Fprintf(os.Stderr, "serve: watcher error: %v\n", err)
+
+		case <-tickC:
+			flush()
+			tickC = nil
+			timer = nil
+		}
+	}
+}
+
+// addTree recursively registers every directory under root (that isn't
+// skipped) with the underlying watcher.
+func (w *Watcher) addTree(root string) error {
+	return filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			// Skip dirs we can't read rather than aborting the whole walk.
+			return nil
+		}
+		if !d.IsDir() {
+			return nil
+		}
+		if w.skipDir(d.Name()) && path != root {
+			return filepath.SkipDir
+		}
+		if err := w.inner.Add(path); err != nil {
+			// If a single directory can't be watched (e.g. too many
+			// inodes) log and keep going; the daemon degrades to
+			// whatever subset it can monitor.
+			fmt.Fprintf(os.Stderr, "serve: adding watch %s: %v\n", path, err)
+		}
+		return nil
+	})
+}
+
+// shouldIgnore returns true for paths the daemon should never react to
+// (vendored code, VCS metadata, target snapshots, editor swap files).
+func (w *Watcher) shouldIgnore(path string) bool {
+	base := filepath.Base(path)
+	// Editor/VCS junk.
+	if strings.HasPrefix(base, ".#") || strings.HasSuffix(base, "~") || strings.HasSuffix(base, ".swp") {
+		return true
+	}
+	// Changes inside .arch/targets are generated; reacting would
+	// loop the daemon against its own writes.
+	if strings.Contains(filepath.ToSlash(path), "/.arch/targets/") {
+		// ...except the CURRENT pointer, which callers care about.
+		if base == "CURRENT" {
+			return false
+		}
+		return true
+	}
+	return false
+}
+
+// defaultSkipDir returns true for directories the watcher should not
+// descend into when adding watches. Keeping this list tight is
+// important: each directory adds an inotify (or equivalent) watch.
+func defaultSkipDir(name string) bool {
+	switch name {
+	case ".git", "node_modules", "vendor", ".idea", ".vscode":
+		return true
+	}
+	return false
+}

--- a/internal/serve/watcher_test.go
+++ b/internal/serve/watcher_test.go
@@ -1,0 +1,131 @@
+package serve
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestWatcherDebounceCoalesces verifies that several fsnotify events
+// arriving within the debounce window are delivered as a single batch.
+func TestWatcherDebounceCoalesces(t *testing.T) {
+	root := t.TempDir()
+
+	w, err := NewWatcher(root, 50*time.Millisecond)
+	if err != nil {
+		t.Fatalf("NewWatcher: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	var (
+		mu      sync.Mutex
+		batches [][]string
+	)
+	done := make(chan struct{})
+
+	handler := func(paths []string) {
+		mu.Lock()
+		batches = append(batches, append([]string(nil), paths...))
+		mu.Unlock()
+		// Signal on first batch so the test can proceed without
+		// waiting for a second flush that should never arrive.
+		select {
+		case done <- struct{}{}:
+		default:
+		}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	runErr := make(chan error, 1)
+	go func() { runErr <- w.Run(ctx, handler) }()
+
+	// Give the watcher a moment to be ready for events.
+	time.Sleep(20 * time.Millisecond)
+
+	// Produce a rapid burst of events well inside the debounce window.
+	for i := 0; i < 5; i++ {
+		p := filepath.Join(root, "f.txt")
+		if err := os.WriteFile(p, []byte{byte('a' + i)}, 0o644); err != nil {
+			t.Fatalf("writefile: %v", err)
+		}
+	}
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out waiting for debounce flush")
+	}
+
+	// Allow a cushion for any stray events to NOT produce a second batch.
+	time.Sleep(150 * time.Millisecond)
+
+	cancel()
+	<-runErr
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(batches) == 0 {
+		t.Fatalf("expected at least one batch, got none")
+	}
+	// The 5 writes to the same file should coalesce into a single
+	// batch containing that one path.
+	if len(batches) > 1 {
+		t.Fatalf("expected single coalesced batch, got %d batches: %v", len(batches), batches)
+	}
+	if len(batches[0]) != 1 {
+		t.Fatalf("expected 1 unique path in batch, got %d: %v", len(batches[0]), batches[0])
+	}
+}
+
+// TestWatcherIgnoresTargetsSubtree verifies that writes under
+// .arch/targets/ (except CURRENT) do not produce batches.
+func TestWatcherIgnoresTargetsSubtree(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".arch", "targets", "v1"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	w, err := NewWatcher(root, 30*time.Millisecond)
+	if err != nil {
+		t.Fatalf("NewWatcher: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	var (
+		mu      sync.Mutex
+		batches int
+	)
+	handler := func(paths []string) {
+		mu.Lock()
+		batches++
+		mu.Unlock()
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	runErr := make(chan error, 1)
+	go func() { runErr <- w.Run(ctx, handler) }()
+
+	time.Sleep(20 * time.Millisecond)
+	// Write under .arch/targets/v1/ — should be ignored.
+	if err := os.WriteFile(filepath.Join(root, ".arch", "targets", "v1", "meta.yaml"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("writefile: %v", err)
+	}
+	// Wait well past the debounce window.
+	time.Sleep(120 * time.Millisecond)
+
+	cancel()
+	<-runErr
+
+	mu.Lock()
+	defer mu.Unlock()
+	if batches != 0 {
+		t.Fatalf("expected 0 batches for ignored subtree, got %d", batches)
+	}
+}


### PR DESCRIPTION
## Summary

Implements `archai serve`, a long-running daemon that holds the Go model, `archai.yaml` overlay, and active target id in memory and keeps them fresh via fsnotify. MCP stdio (M5b) and HTTP (M7a) transports are wired as stubs so subsequent milestones can slot in without further plumbing changes.

### What's new
- `internal/serve/state.go` — thread-safe `State` (RWMutex) with `Load`, `ReloadPackage`, `ReloadOverlay`, `SwitchTarget`, `Snapshot`; `FindOwningPackage` walks up from a changed file to its enclosing Go package.
- `internal/serve/watcher.go` — fsnotify wrapper delivering debounced (200ms) batches, recursively watching new directories, ignoring `.arch/targets/` (except `CURRENT`) and editor/VCS junk.
- `internal/serve/daemon.go` — `Serve(ctx, opts)` wires state + watcher; dispatches `.go` edits → `ReloadPackage`, `archai.yaml` → `ReloadOverlay`, `.arch/targets/CURRENT` → `SwitchTarget`.
- `cmd/archai serve` with `--root`, `--mcp-stdio`, `--http`, `--debug`; SIGINT/SIGTERM bridged into a cancellable context for graceful shutdown.

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (new serve package + existing suites)
- [x] `archai serve --help` shows the command with all flags
- [ ] Manual smoke: run `archai serve` in a project, edit a `.go` file, confirm package reload log in `--debug` mode

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)