### PR TITLE
M6b: CLI 'archai sequence' command + D2 sequence emitter

### DIFF
--- a/cmd/archai/main.go
+++ b/cmd/archai/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/kgatilin/archai/internal/diff"
 	"github.com/kgatilin/archai/internal/domain"
 	"github.com/kgatilin/archai/internal/overlay"
+	"github.com/kgatilin/archai/internal/sequence"
 	"github.com/kgatilin/archai/internal/serve"
 	"github.com/kgatilin/archai/internal/service"
 	"github.com/kgatilin/archai/internal/target"
@@ -308,6 +309,33 @@ manual verification and as a base for future features.`,
 	serveCmd.Flags().Bool("debug", false, "Verbose per-event logging")
 	rootCmd.AddCommand(serveCmd)
 
+	// Sequence command (M6b)
+	sequenceCmd := &cobra.Command{
+		Use:   "sequence <target>",
+		Short: "Render a static call-sequence tree rooted at a function or method",
+		Long: `Walk the static call graph starting at the given symbol and print
+the resulting tree as either an indented outline (default) or a D2 sequence
+diagram.
+
+Target format:
+  <pkg/path>.<FuncName>
+  <pkg/path>.<TypeName>.<MethodName>
+
+The current model is loaded from per-package .arch/*.yaml files when
+present; otherwise the Go reader parses ./... directly.
+
+Examples:
+  archai sequence internal/service.Service.Generate
+  archai sequence internal/service.Service.Generate --depth 3
+  archai sequence internal/service.Service.Generate --format d2 -o gen.d2`,
+		Args: cobra.ExactArgs(1),
+		RunE: runSequence,
+	}
+	sequenceCmd.Flags().Int("depth", 5, "Maximum call-chain depth")
+	sequenceCmd.Flags().StringP("format", "f", "text", "Output format: text or d2")
+	sequenceCmd.Flags().StringP("output", "o", "", "Write output to file instead of stdout")
+	rootCmd.AddCommand(sequenceCmd)
+
 	// Execute root command
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
@@ -335,6 +363,60 @@ func runServe(cmd *cobra.Command, args []string) error {
 		HTTPAddr: httpAddr,
 		Debug:    debug,
 	})
+}
+
+// runSequence handles `archai sequence <target>`. It parses the target,
+// loads the current model (YAML specs preferred, Go reader fallback),
+// builds the call-sequence tree and emits it in the requested format.
+func runSequence(cmd *cobra.Command, args []string) error {
+	target := args[0]
+	depth, _ := cmd.Flags().GetInt("depth")
+	format, _ := cmd.Flags().GetString("format")
+	output, _ := cmd.Flags().GetString("output")
+
+	start, ok := sequence.ParseTarget(target)
+	if !ok {
+		return fmt.Errorf("invalid target %q (expected pkg/path.Func or pkg/path.Type.Method)", target)
+	}
+
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	projectRoot, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("resolving cwd: %w", err)
+	}
+
+	models, err := loadCurrentModel(ctx, projectRoot)
+	if err != nil {
+		return fmt.Errorf("loading current model: %w", err)
+	}
+
+	tree := sequence.Build(models, start, depth)
+	if tree == nil {
+		return fmt.Errorf("could not build sequence for %q", target)
+	}
+
+	var rendered string
+	switch format {
+	case "", "text":
+		rendered = sequence.FormatText(tree)
+	case "d2":
+		rendered = sequence.FormatD2(tree)
+	default:
+		return fmt.Errorf("unsupported format %q (use text or d2)", format)
+	}
+
+	if output == "" {
+		fmt.Print(rendered)
+		return nil
+	}
+	if err := os.WriteFile(output, []byte(rendered), 0o644); err != nil {
+		return fmt.Errorf("writing %s: %w", output, err)
+	}
+	return nil
 }
 
 // runOverlayCheck executes `archai overlay check`. It loads the overlay,

--- a/internal/sequence/build.go
+++ b/internal/sequence/build.go
@@ -1,0 +1,156 @@
+package sequence
+
+import (
+	"strings"
+
+	"github.com/kgatilin/archai/internal/domain"
+)
+
+// Build walks the static call graph rooted at start and returns a Node tree
+// capped at maxDepth. Depth 0 means "root only, no children". Calls that
+// revisit a symbol already on the current path are marked Cycle and not
+// recursed into. When a CallEdge points at a symbol that cannot be
+// resolved in models (e.g., stdlib filter already dropped it, or the
+// package is not loaded), a NotFound leaf is emitted so renderers can
+// still show the edge.
+//
+// models must be the full set of PackageModels for the analyzed module.
+// The builder indexes them by (Package, Symbol) on first call.
+func Build(models []domain.PackageModel, start domain.SymbolRef, maxDepth int) *Node {
+	idx := buildIndex(models)
+	return buildNode(idx, start, "", maxDepth, map[string]bool{})
+}
+
+// symbolKey returns the composite key we use to look up (and detect
+// cycles over) a symbol. Package + "|" + Symbol is unique because the
+// Go reader stores methods as "Type.Method" in Symbol, so there is no
+// ambiguity between a function and a method of the same package.
+func symbolKey(ref domain.SymbolRef) string {
+	return ref.Package + "|" + ref.Symbol
+}
+
+// index maps symbol keys to their call lists and back-references to the
+// PackageModel/symbol they came from. We store only what the builder
+// needs: the outgoing calls for that symbol.
+type index struct {
+	calls map[string][]domain.CallEdge
+}
+
+func buildIndex(models []domain.PackageModel) *index {
+	idx := &index{calls: make(map[string][]domain.CallEdge)}
+	for _, m := range models {
+		for _, fn := range m.Functions {
+			ref := domain.SymbolRef{Package: m.Path, Symbol: fn.Name}
+			idx.calls[symbolKey(ref)] = fn.Calls
+		}
+		for _, s := range m.Structs {
+			for _, meth := range s.Methods {
+				ref := domain.SymbolRef{
+					Package: m.Path,
+					Symbol:  s.Name + "." + meth.Name,
+				}
+				idx.calls[symbolKey(ref)] = meth.Calls
+			}
+		}
+	}
+	return idx
+}
+
+// buildNode constructs the subtree rooted at ref. visited is the set of
+// symbol keys on the path from the true root down to (but not including)
+// ref. It's copied on each recursion so sibling branches don't falsely
+// report each other as cycles.
+func buildNode(
+	idx *index,
+	ref domain.SymbolRef,
+	via string,
+	depth int,
+	visited map[string]bool,
+) *Node {
+	n := &Node{Symbol: ref, Via: via}
+
+	key := symbolKey(ref)
+	if visited[key] {
+		n.Cycle = true
+		return n
+	}
+
+	calls, ok := idx.calls[key]
+	if !ok {
+		// Only mark as NotFound for non-root nodes — the root is
+		// always "found" by definition (it's what the caller asked
+		// for). When depth is 0 and the root has no entry, we simply
+		// return a childless node.
+		if len(visited) > 0 {
+			n.NotFound = true
+		}
+		return n
+	}
+
+	if depth <= 0 {
+		if len(calls) > 0 {
+			n.DepthLimit = true
+		}
+		return n
+	}
+
+	childVisited := copyVisited(visited)
+	childVisited[key] = true
+
+	for _, edge := range calls {
+		child := buildNode(idx, edge.To, edge.Via, depth-1, childVisited)
+		n.Children = append(n.Children, child)
+	}
+	return n
+}
+
+func copyVisited(src map[string]bool) map[string]bool {
+	dst := make(map[string]bool, len(src)+1)
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
+}
+
+// ParseTarget converts a CLI target like
+//
+//	internal/service.Service.Generate    (method)
+//	internal/service.NewService          (function)
+//	cmd/archai.main                      (function)
+//
+// into a SymbolRef. Heuristic: the last dot separates Symbol from
+// Package ONLY if the token before it starts lower-case (function) OR
+// the token before it is uppercase and the token before that is also
+// uppercase-looking (method — "Type.Method"). We keep it simple:
+// - Count the dots in the final path segment.
+// - If the segment has one dot, treat it as "pkg.Func".
+// - If the segment has two dots, treat it as "pkg.Type.Method".
+// - More dots: everything after the first dot is the Symbol.
+//
+// The package portion may contain slashes (e.g. "internal/service").
+func ParseTarget(target string) (domain.SymbolRef, bool) {
+	// Split off the package prefix at the last slash, if any.
+	slash := strings.LastIndex(target, "/")
+	var pkgPrefix, rest string
+	if slash >= 0 {
+		pkgPrefix = target[:slash+1] // includes trailing slash
+		rest = target[slash+1:]
+	} else {
+		rest = target
+	}
+
+	// rest is "pkgLeaf.Symbol" or "pkgLeaf.Type.Method".
+	firstDot := strings.Index(rest, ".")
+	if firstDot < 0 {
+		return domain.SymbolRef{}, false
+	}
+	pkgLeaf := rest[:firstDot]
+	sym := rest[firstDot+1:]
+	if pkgLeaf == "" || sym == "" {
+		return domain.SymbolRef{}, false
+	}
+	return domain.SymbolRef{
+		Package: pkgPrefix + pkgLeaf,
+		Symbol:  sym,
+	}, true
+}

--- a/internal/sequence/build_test.go
+++ b/internal/sequence/build_test.go
@@ -1,0 +1,228 @@
+package sequence
+
+import (
+	"testing"
+
+	"github.com/kgatilin/archai/internal/domain"
+)
+
+// fixture builds a set of PackageModels covering:
+//   - a simple A → B → C chain (functions);
+//   - a method calling another method on a different struct;
+//   - a cycle A → B → A;
+//   - interface dispatch with two implementations.
+func fixture() []domain.PackageModel {
+	// Simple chain: pkg/a.Alpha → pkg/b.Beta → pkg/c.Gamma.
+	alpha := domain.FunctionDef{
+		Name: "Alpha",
+		Calls: []domain.CallEdge{
+			{To: domain.SymbolRef{Package: "pkg/b", Symbol: "Beta"}},
+		},
+	}
+	beta := domain.FunctionDef{
+		Name: "Beta",
+		Calls: []domain.CallEdge{
+			{To: domain.SymbolRef{Package: "pkg/c", Symbol: "Gamma"}},
+		},
+	}
+	gamma := domain.FunctionDef{Name: "Gamma"}
+
+	// Cycle: pkg/c.Loop → pkg/c.Loop.
+	loop := domain.FunctionDef{
+		Name: "Loop",
+		Calls: []domain.CallEdge{
+			{To: domain.SymbolRef{Package: "pkg/c", Symbol: "Loop"}},
+		},
+	}
+
+	// Method chain + interface dispatch.
+	// pkg/svc.Service.Generate calls pkg/rd.Reader.Read via interface
+	// io.Reader, which has two impls: fileReader.Read and memReader.Read.
+	service := domain.StructDef{
+		Name: "Service",
+		Methods: []domain.MethodDef{
+			{
+				Name: "Generate",
+				Calls: []domain.CallEdge{
+					{
+						To:  domain.SymbolRef{Package: "pkg/rd", Symbol: "fileReader.Read"},
+						Via: "io.Reader",
+					},
+					{
+						To:  domain.SymbolRef{Package: "pkg/rd", Symbol: "memReader.Read"},
+						Via: "io.Reader",
+					},
+				},
+			},
+		},
+	}
+	rdStruct1 := domain.StructDef{
+		Name:    "fileReader",
+		Methods: []domain.MethodDef{{Name: "Read"}},
+	}
+	rdStruct2 := domain.StructDef{
+		Name:    "memReader",
+		Methods: []domain.MethodDef{{Name: "Read"}},
+	}
+
+	return []domain.PackageModel{
+		{Path: "pkg/a", Name: "a", Functions: []domain.FunctionDef{alpha}},
+		{Path: "pkg/b", Name: "b", Functions: []domain.FunctionDef{beta}},
+		{Path: "pkg/c", Name: "c", Functions: []domain.FunctionDef{gamma, loop}},
+		{Path: "pkg/svc", Name: "svc", Structs: []domain.StructDef{service}},
+		{Path: "pkg/rd", Name: "rd", Structs: []domain.StructDef{rdStruct1, rdStruct2}},
+	}
+}
+
+func TestBuildSimpleChain(t *testing.T) {
+	models := fixture()
+	start := domain.SymbolRef{Package: "pkg/a", Symbol: "Alpha"}
+	root := Build(models, start, 5)
+
+	if root == nil || root.Symbol != start {
+		t.Fatalf("root mismatch: %+v", root)
+	}
+	if len(root.Children) != 1 || root.Children[0].Symbol.Symbol != "Beta" {
+		t.Fatalf("expected single Beta child, got %+v", root.Children)
+	}
+	beta := root.Children[0]
+	if len(beta.Children) != 1 || beta.Children[0].Symbol.Symbol != "Gamma" {
+		t.Fatalf("expected single Gamma grandchild, got %+v", beta.Children)
+	}
+	gamma := beta.Children[0]
+	if len(gamma.Children) != 0 || gamma.Cycle || gamma.DepthLimit {
+		t.Errorf("Gamma should be a clean leaf: %+v", gamma)
+	}
+}
+
+func TestBuildDepthLimit(t *testing.T) {
+	models := fixture()
+	start := domain.SymbolRef{Package: "pkg/a", Symbol: "Alpha"}
+	root := Build(models, start, 1)
+
+	if len(root.Children) != 1 {
+		t.Fatalf("expected 1 child at depth 1, got %d", len(root.Children))
+	}
+	beta := root.Children[0]
+	// With depth=1, Alpha→Beta is rendered, and Beta is called with
+	// depth=0, so Beta should be marked DepthLimit (since Beta has
+	// outgoing calls) and have no children.
+	if !beta.DepthLimit {
+		t.Errorf("expected Beta to be marked DepthLimit, got %+v", beta)
+	}
+	if len(beta.Children) != 0 {
+		t.Errorf("DepthLimit node should have no children, got %d", len(beta.Children))
+	}
+}
+
+func TestBuildCycleDetection(t *testing.T) {
+	models := fixture()
+	start := domain.SymbolRef{Package: "pkg/c", Symbol: "Loop"}
+	root := Build(models, start, 5)
+
+	if len(root.Children) != 1 {
+		t.Fatalf("expected 1 child (cycle), got %d", len(root.Children))
+	}
+	child := root.Children[0]
+	if !child.Cycle {
+		t.Errorf("expected cycle flag on recursive child, got %+v", child)
+	}
+	if len(child.Children) != 0 {
+		t.Errorf("cycle leaf must have no children, got %d", len(child.Children))
+	}
+}
+
+func TestBuildInterfaceDispatchFanOut(t *testing.T) {
+	models := fixture()
+	start := domain.SymbolRef{Package: "pkg/svc", Symbol: "Service.Generate"}
+	root := Build(models, start, 5)
+
+	if len(root.Children) != 2 {
+		t.Fatalf("expected 2 interface impls as siblings, got %d", len(root.Children))
+	}
+	for _, c := range root.Children {
+		if c.Via != "io.Reader" {
+			t.Errorf("child %s should have Via=io.Reader, got %q", c.Symbol.Symbol, c.Via)
+		}
+	}
+	syms := []string{root.Children[0].Symbol.Symbol, root.Children[1].Symbol.Symbol}
+	if syms[0] != "fileReader.Read" || syms[1] != "memReader.Read" {
+		t.Errorf("unexpected impl order: %v", syms)
+	}
+}
+
+func TestBuildSiblingsNotFalseCycles(t *testing.T) {
+	// Diamond: root calls helper twice. Neither call is a cycle.
+	helper := domain.FunctionDef{Name: "Helper"}
+	rootFn := domain.FunctionDef{
+		Name: "Root",
+		Calls: []domain.CallEdge{
+			{To: domain.SymbolRef{Package: "pkg/x", Symbol: "Helper"}},
+			{To: domain.SymbolRef{Package: "pkg/x", Symbol: "Helper"}},
+		},
+	}
+	models := []domain.PackageModel{
+		{Path: "pkg/x", Name: "x", Functions: []domain.FunctionDef{rootFn, helper}},
+	}
+	start := domain.SymbolRef{Package: "pkg/x", Symbol: "Root"}
+	root := Build(models, start, 5)
+
+	// The addEdge dedup in the Go reader would normally collapse these,
+	// but the builder itself must treat siblings independently.
+	for _, c := range root.Children {
+		if c.Cycle {
+			t.Errorf("sibling should not be marked cycle: %+v", c)
+		}
+	}
+}
+
+func TestBuildNotFoundEdge(t *testing.T) {
+	// A function whose callee is not in the loaded models.
+	rootFn := domain.FunctionDef{
+		Name: "Root",
+		Calls: []domain.CallEdge{
+			{To: domain.SymbolRef{Package: "pkg/missing", Symbol: "Missing"}},
+		},
+	}
+	models := []domain.PackageModel{
+		{Path: "pkg/x", Name: "x", Functions: []domain.FunctionDef{rootFn}},
+	}
+	start := domain.SymbolRef{Package: "pkg/x", Symbol: "Root"}
+	root := Build(models, start, 5)
+
+	if len(root.Children) != 1 {
+		t.Fatalf("expected one child, got %d", len(root.Children))
+	}
+	if !root.Children[0].NotFound {
+		t.Errorf("expected NotFound flag on unresolved edge: %+v", root.Children[0])
+	}
+}
+
+func TestParseTarget(t *testing.T) {
+	cases := []struct {
+		in      string
+		wantPkg string
+		wantSym string
+		wantOK  bool
+	}{
+		{"internal/service.Service.Generate", "internal/service", "Service.Generate", true},
+		{"internal/service.NewService", "internal/service", "NewService", true},
+		{"pkg.Func", "pkg", "Func", true},
+		{"pkg.Type.Method", "pkg", "Type.Method", true},
+		{"nodot", "", "", false},
+		{"", "", "", false},
+	}
+	for _, tc := range cases {
+		got, ok := ParseTarget(tc.in)
+		if ok != tc.wantOK {
+			t.Errorf("ParseTarget(%q) ok=%v want %v", tc.in, ok, tc.wantOK)
+			continue
+		}
+		if !ok {
+			continue
+		}
+		if got.Package != tc.wantPkg || got.Symbol != tc.wantSym {
+			t.Errorf("ParseTarget(%q) = %+v, want {%s %s}", tc.in, got, tc.wantPkg, tc.wantSym)
+		}
+	}
+}

--- a/internal/sequence/format_d2.go
+++ b/internal/sequence/format_d2.go
@@ -1,0 +1,127 @@
+package sequence
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/kgatilin/archai/internal/domain"
+)
+
+// FormatD2 renders the Node tree as a D2 sequence diagram. Each unique
+// actor (package leaf plus optional type for methods) becomes an
+// implicit participant; every call becomes an arrow from caller to
+// callee labeled with the method (or function) name. Interface
+// dispatch edges are annotated with "[via pkg.Iface]".
+//
+// Example output:
+//
+//	shape: sequence_diagram
+//	service.Service -> golang.reader: Read
+//	golang.reader -> service.Service: validate
+//
+// Cycle, unresolved, and depth-limit leaves are emitted as labeled
+// arrows so the diagram still communicates why a branch terminated.
+func FormatD2(root *Node) string {
+	if root == nil {
+		return ""
+	}
+	var sb strings.Builder
+	sb.WriteString("shape: sequence_diagram\n")
+	writeD2Edges(&sb, root)
+	return sb.String()
+}
+
+func writeD2Edges(sb *strings.Builder, n *Node) {
+	caller := actorName(n.Symbol)
+	for _, c := range n.Children {
+		callee := actorName(c.Symbol)
+		label := methodLabel(c.Symbol)
+		if c.Via != "" {
+			label += " [via " + c.Via + "]"
+		}
+		switch {
+		case c.Cycle:
+			label += " (cycle)"
+		case c.NotFound:
+			label += " (unresolved)"
+		case c.DepthLimit:
+			label += " (depth limit)"
+		}
+		fmt.Fprintf(sb, "%s -> %s: %s\n",
+			d2Ident(caller), d2Ident(callee), label)
+		if !c.Cycle && !c.NotFound && !c.DepthLimit {
+			writeD2Edges(sb, c)
+		}
+	}
+}
+
+// actorName returns the D2 participant label for a SymbolRef.
+//   - Method symbols ("Type.Method") → "pkgleaf.Type"
+//   - Function symbols                → "pkgleaf.FuncName" (one actor
+//     per function — this keeps the diagram readable even when many
+//     package-level functions exist in the same package).
+func actorName(ref domain.SymbolRef) string {
+	leaf := pkgLeaf(ref.Package)
+	typ, _ := splitMethodSymbol(ref.Symbol)
+	if typ != "" {
+		if leaf == "" {
+			return typ
+		}
+		return leaf + "." + typ
+	}
+	if leaf == "" {
+		return ref.Symbol
+	}
+	return leaf + "." + ref.Symbol
+}
+
+// methodLabel returns the call-arrow label: the method name for a
+// "Type.Method" symbol, or the function name otherwise.
+func methodLabel(ref domain.SymbolRef) string {
+	_, method := splitMethodSymbol(ref.Symbol)
+	if method != "" {
+		return method
+	}
+	return ref.Symbol
+}
+
+// splitMethodSymbol splits "Type.Method" into ("Type", "Method"). Returns
+// ("", "") for plain function symbols.
+func splitMethodSymbol(sym string) (typ, method string) {
+	dot := strings.Index(sym, ".")
+	if dot < 0 {
+		return "", ""
+	}
+	return sym[:dot], sym[dot+1:]
+}
+
+// pkgLeaf returns the last path segment of a package path, e.g.
+// "internal/service" → "service".
+func pkgLeaf(pkg string) string {
+	if pkg == "" {
+		return ""
+	}
+	slash := strings.LastIndex(pkg, "/")
+	if slash < 0 {
+		return pkg
+	}
+	return pkg[slash+1:]
+}
+
+// d2Ident quotes identifiers that contain characters D2 would
+// otherwise treat specially. A conservative allow-list: letters,
+// digits, underscore, and "." are fine bare; anything else triggers
+// quoting.
+func d2Ident(s string) string {
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= 'A' && r <= 'Z':
+		case r >= '0' && r <= '9':
+		case r == '_' || r == '.':
+		default:
+			return `"` + strings.ReplaceAll(s, `"`, `\"`) + `"`
+		}
+	}
+	return s
+}

--- a/internal/sequence/format_d2_test.go
+++ b/internal/sequence/format_d2_test.go
@@ -1,0 +1,73 @@
+package sequence
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kgatilin/archai/internal/domain"
+)
+
+func TestFormatD2HasHeader(t *testing.T) {
+	models := fixture()
+	start := domain.SymbolRef{Package: "pkg/a", Symbol: "Alpha"}
+	out := FormatD2(Build(models, start, 5))
+	if !strings.HasPrefix(out, "shape: sequence_diagram\n") {
+		t.Errorf("D2 output must start with shape directive, got:\n%s", out)
+	}
+}
+
+func TestFormatD2SimpleChainArrows(t *testing.T) {
+	models := fixture()
+	start := domain.SymbolRef{Package: "pkg/a", Symbol: "Alpha"}
+	out := FormatD2(Build(models, start, 5))
+
+	for _, want := range []string{
+		"a.Alpha -> b.Beta: Beta",
+		"b.Beta -> c.Gamma: Gamma",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected arrow %q in output:\n%s", want, out)
+		}
+	}
+}
+
+func TestFormatD2MethodActorsShareType(t *testing.T) {
+	models := fixture()
+	start := domain.SymbolRef{Package: "pkg/svc", Symbol: "Service.Generate"}
+	out := FormatD2(Build(models, start, 5))
+	// Actor for Service.Generate should be "svc.Service"; for
+	// fileReader.Read it should be "rd.fileReader"; arrow label is
+	// just "Read" with a [via io.Reader] annotation.
+	for _, want := range []string{
+		"svc.Service -> rd.fileReader: Read [via io.Reader]",
+		"svc.Service -> rd.memReader: Read [via io.Reader]",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in D2 output:\n%s", want, out)
+		}
+	}
+}
+
+func TestFormatD2CycleAnnotation(t *testing.T) {
+	models := fixture()
+	start := domain.SymbolRef{Package: "pkg/c", Symbol: "Loop"}
+	out := FormatD2(Build(models, start, 5))
+	if !strings.Contains(out, "(cycle)") {
+		t.Errorf("D2 cycle arrow missing annotation:\n%s", out)
+	}
+}
+
+func TestFormatD2DepthLimitAnnotation(t *testing.T) {
+	models := fixture()
+	start := domain.SymbolRef{Package: "pkg/a", Symbol: "Alpha"}
+	out := FormatD2(Build(models, start, 1))
+	if !strings.Contains(out, "(depth limit)") {
+		t.Errorf("D2 depth-limit arrow missing annotation:\n%s", out)
+	}
+}
+
+func TestFormatD2NilSafe(t *testing.T) {
+	if FormatD2(nil) != "" {
+		t.Errorf("FormatD2(nil) should be empty")
+	}
+}

--- a/internal/sequence/format_text.go
+++ b/internal/sequence/format_text.go
@@ -1,0 +1,67 @@
+package sequence
+
+import (
+	"strings"
+)
+
+// FormatText renders a Node tree as an indented outline. Example:
+//
+//	internal/service.Service.Generate
+//	  └─ internal/adapter/golang.reader.Read
+//	     └─ internal/service.Service.validate
+//	  └─ internal/service.Service.Generate (cycle)
+//	  └─ ... (depth limit)
+//
+// The root is printed at column 0; each level of children is indented
+// two spaces and prefixed with "└─ ". Via annotations are shown inline
+// when non-empty.
+func FormatText(root *Node) string {
+	if root == nil {
+		return ""
+	}
+	var sb strings.Builder
+	writeTextNode(&sb, root, "", true)
+	return sb.String()
+}
+
+func writeTextNode(sb *strings.Builder, n *Node, indent string, isRoot bool) {
+	if isRoot {
+		sb.WriteString(n.Symbol.String())
+		writeAnnotations(sb, n)
+		sb.WriteString("\n")
+	} else {
+		sb.WriteString(indent)
+		sb.WriteString("└─ ")
+		sb.WriteString(n.Symbol.String())
+		writeAnnotations(sb, n)
+		sb.WriteString("\n")
+	}
+
+	// Depth-limit / cycle leaves never have children, but if the node is
+	// a non-leaf that hit the depth limit we already marked it with
+	// DepthLimit — children is empty in that case anyway.
+	childIndent := indent
+	if !isRoot {
+		childIndent = indent + "   "
+	}
+	for _, c := range n.Children {
+		writeTextNode(sb, c, childIndent, false)
+	}
+}
+
+func writeAnnotations(sb *strings.Builder, n *Node) {
+	if n.Via != "" {
+		sb.WriteString(" [via ")
+		sb.WriteString(n.Via)
+		sb.WriteString("]")
+	}
+	if n.Cycle {
+		sb.WriteString(" (cycle)")
+	}
+	if n.NotFound {
+		sb.WriteString(" (unresolved)")
+	}
+	if n.DepthLimit {
+		sb.WriteString(" (depth limit)")
+	}
+}

--- a/internal/sequence/format_text_test.go
+++ b/internal/sequence/format_text_test.go
@@ -1,0 +1,57 @@
+package sequence
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kgatilin/archai/internal/domain"
+)
+
+func TestFormatTextSimpleChain(t *testing.T) {
+	models := fixture()
+	start := domain.SymbolRef{Package: "pkg/a", Symbol: "Alpha"}
+	out := FormatText(Build(models, start, 5))
+
+	want := "pkg/a.Alpha\n" +
+		"└─ pkg/b.Beta\n" +
+		"   └─ pkg/c.Gamma\n"
+	if out != want {
+		t.Errorf("text output mismatch.\n got:\n%s\nwant:\n%s", out, want)
+	}
+}
+
+func TestFormatTextCycleMarker(t *testing.T) {
+	models := fixture()
+	start := domain.SymbolRef{Package: "pkg/c", Symbol: "Loop"}
+	out := FormatText(Build(models, start, 5))
+	if !strings.Contains(out, "(cycle)") {
+		t.Errorf("expected (cycle) marker in output:\n%s", out)
+	}
+}
+
+func TestFormatTextDepthLimit(t *testing.T) {
+	models := fixture()
+	start := domain.SymbolRef{Package: "pkg/a", Symbol: "Alpha"}
+	out := FormatText(Build(models, start, 1))
+	if !strings.Contains(out, "(depth limit)") {
+		t.Errorf("expected (depth limit) marker in output:\n%s", out)
+	}
+}
+
+func TestFormatTextInterfaceVia(t *testing.T) {
+	models := fixture()
+	start := domain.SymbolRef{Package: "pkg/svc", Symbol: "Service.Generate"}
+	out := FormatText(Build(models, start, 5))
+	if !strings.Contains(out, "[via io.Reader]") {
+		t.Errorf("expected [via io.Reader] annotation:\n%s", out)
+	}
+	if !strings.Contains(out, "fileReader.Read") || !strings.Contains(out, "memReader.Read") {
+		t.Errorf("expected both impls as siblings:\n%s", out)
+	}
+}
+
+func TestFormatTextNilSafe(t *testing.T) {
+	if FormatText(nil) != "" {
+		t.Errorf("FormatText(nil) should be empty string")
+	}
+}

--- a/internal/sequence/sequence.go
+++ b/internal/sequence/sequence.go
@@ -1,0 +1,41 @@
+// Package sequence builds and renders static call-sequence trees rooted at
+// a given function or method. Input is a set of PackageModels populated by
+// the Go reader (M6a); output is a Node tree that can be rendered as a
+// text outline or a D2 sequence diagram.
+package sequence
+
+import "github.com/kgatilin/archai/internal/domain"
+
+// Node is a single step in a rendered call chain. Root nodes represent the
+// starting symbol; Children are the callees resolved from Symbol's Calls.
+// Nodes flagged with Cycle are leaves — the caller should not recurse
+// further, but the node is kept so renderers can show "(cycle)" markers.
+// Nodes flagged with DepthLimit are leaves that were cut off because the
+// --depth budget was exhausted; they indicate the sequence may have more
+// structure that simply wasn't expanded.
+type Node struct {
+	// Symbol identifies the function/method at this step. For methods
+	// Symbol.Symbol is "Type.Method"; for functions it is just the name.
+	Symbol domain.SymbolRef
+
+	// Via is the interface through which this node was reached from its
+	// parent (empty for direct calls). Copied from CallEdge.Via and
+	// useful for renderers that want to annotate interface dispatch.
+	Via string
+
+	// Children are the resolved callees.
+	Children []*Node
+
+	// Cycle is true when this node revisits an ancestor in the call
+	// chain. Children is always empty when Cycle is true.
+	Cycle bool
+
+	// DepthLimit is true when this node was the depth-N cutoff — the
+	// real call graph may continue, but the builder stopped recursing.
+	DepthLimit bool
+
+	// NotFound is true when the parent's CallEdge pointed at a symbol
+	// that could not be resolved against the loaded models (e.g., the
+	// symbol's package is not loaded). Children is empty.
+	NotFound bool
+}


### PR DESCRIPTION
## Summary

Implements `archai sequence <target>` — walks the static call graph (populated by M6a) rooted at a function or method and renders it as either an indented text tree (default) or a D2 sequence diagram.

## What's new

- **New package `internal/sequence/`** with a pure-domain `Node` tree, a DFS builder, and two formatters.
- **`archai sequence <pkg/path.Type.Method|pkg/path.Func>`** CLI command with:
  - `--depth N` (default 5) — caps recursion; truncated leaves marked `(depth limit)`
  - `--format text|d2` — pick the renderer
  - `--output FILE` — write to file instead of stdout
- **Cycle detection** via per-path visited set; revisited symbols become leaves marked `(cycle)`.
- **Interface dispatch fan-out**: each impl appears as a sibling child with a `[via pkg.Iface]` annotation (reuses the `Via` field M6a populated).
- **Unresolved edges** (callee package not loaded) are marked `(unresolved)` so users see why a chain terminated instead of silent drops.

## Model loading

Reuses the existing `loadCurrentModel` helper: prefers per-package `.arch/*.yaml` specs (which preserve `Calls` + `Via`) and falls back to running the Go reader on `./...`.

## Smoke test output (on archai itself)

```
internal/service.Service.Generate
└─ internal/service.Service.generateInternal
   └─ internal/adapter/golang.reader.Read [via internal/service.ModelReader]
      └─ internal/adapter/golang.reader.extractCalls (depth limit)
   ...
```

```
shape: sequence_diagram
service.Service -> service.Service: generateInternal
service.Service -> golang.reader: Read [via internal/service.ModelReader] (depth limit)
...
```

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` — new tests cover simple chain, depth limit, cycle detection, interface fan-out, sibling non-cycles, unresolved edges, target parsing, text/D2 output snapshots.
- [x] Manual smoke test: `archai sequence internal/service.Service.Generate --depth 3` and `--format d2`.

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)