### PR TITLE
M5b: MCP tools — extract, list_packages, get_package

### DIFF
--- a/cmd/archai/main.go
+++ b/cmd/archai/main.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/kgatilin/archai/internal/adapter/d2"
 	"github.com/kgatilin/archai/internal/adapter/golang"
+	"github.com/kgatilin/archai/internal/adapter/mcp"
 	yamlAdapter "github.com/kgatilin/archai/internal/adapter/yaml"
 	"github.com/kgatilin/archai/internal/apply"
 	"github.com/kgatilin/archai/internal/diff"
@@ -304,7 +305,7 @@ manual verification and as a base for future features.`,
 		RunE: runServe,
 	}
 	serveCmd.Flags().String("root", ".", "Project root directory")
-	serveCmd.Flags().Bool("mcp-stdio", false, "Enable MCP stdio transport (stub in M5a)")
+	serveCmd.Flags().Bool("mcp-stdio", false, "Enable MCP stdio transport")
 	serveCmd.Flags().String("http", "", "HTTP transport address, e.g. :8080 (stub in M5a)")
 	serveCmd.Flags().Bool("debug", false, "Verbose per-event logging")
 	rootCmd.AddCommand(serveCmd)
@@ -360,6 +361,9 @@ func runServe(cmd *cobra.Command, args []string) error {
 	return serve.Serve(ctx, serve.Options{
 		Root:     root,
 		MCPStdio: mcpStdio,
+		MCPServe: func(ctx context.Context, state *serve.State) error {
+			return mcp.Serve(ctx, state)
+		},
 		HTTPAddr: httpAddr,
 		Debug:    debug,
 	})

--- a/cmd/archai/mcp_stdio_e2e_test.go
+++ b/cmd/archai/mcp_stdio_e2e_test.go
@@ -1,0 +1,262 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestE2E_MCPStdio spawns `archai serve --mcp-stdio` as a subprocess in
+// a throwaway Go module and drives it through initialize → tools/list →
+// tools/call for each of the three tools, asserting the responses.
+func TestE2E_MCPStdio(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping subprocess E2E in -short mode")
+	}
+
+	// Build the CLI binary from the repo root (two levels up from cwd).
+	binDir := t.TempDir()
+	binPath := filepath.Join(binDir, "archai")
+	build := exec.Command("go", "build", "-o", binPath, ".")
+	build.Stdout = os.Stdout
+	build.Stderr = os.Stderr
+	if err := build.Run(); err != nil {
+		t.Fatalf("build archai: %v", err)
+	}
+
+	// Create a minimal Go module with two packages so the daemon has
+	// something to return.
+	projectDir := t.TempDir()
+	mustWriteE2E(t, filepath.Join(projectDir, "go.mod"), "module mcp.test\n\ngo 1.21\n")
+	mustWriteE2E(t, filepath.Join(projectDir, "alpha", "alpha.go"), `package alpha
+
+type Service interface{ Do() }
+type Impl struct{}
+func New() *Impl { return &Impl{} }
+`)
+	mustWriteE2E(t, filepath.Join(projectDir, "beta", "beta.go"), `package beta
+
+func Hello() string { return "hi" }
+`)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, binPath, "serve", "--mcp-stdio", "--root", projectDir)
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		t.Fatalf("stdin pipe: %v", err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatalf("stdout pipe: %v", err)
+	}
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer func() {
+		_ = stdin.Close()
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	}()
+
+	reader := bufio.NewReader(stdout)
+
+	sendRequest := func(method string, id int, params any) Response {
+		t.Helper()
+		req := map[string]any{
+			"jsonrpc": "2.0",
+			"id":      id,
+			"method":  method,
+		}
+		if params != nil {
+			req["params"] = params
+		}
+		data, err := json.Marshal(req)
+		if err != nil {
+			t.Fatalf("marshal request: %v", err)
+		}
+		if _, err := stdin.Write(append(data, '\n')); err != nil {
+			t.Fatalf("write request: %v", err)
+		}
+		line, err := readLineWithTimeout(reader, 5*time.Second)
+		if err != nil {
+			t.Fatalf("read response (%s): %v (stderr=%s)", method, err, stderr.String())
+		}
+		var resp Response
+		if err := json.Unmarshal(line, &resp); err != nil {
+			t.Fatalf("unmarshal response (%s): %v — line=%s", method, err, line)
+		}
+		return resp
+	}
+
+	// 1) initialize
+	resp := sendRequest("initialize", 1, nil)
+	if resp.Error != nil {
+		t.Fatalf("initialize error: %+v", resp.Error)
+	}
+
+	// 2) tools/list — confirm the three tool names
+	resp = sendRequest("tools/list", 2, nil)
+	if resp.Error != nil {
+		t.Fatalf("tools/list error: %+v", resp.Error)
+	}
+	toolsPayload, _ := json.Marshal(resp.Result)
+	var toolsWrapper struct {
+		Tools []struct {
+			Name string `json:"name"`
+		} `json:"tools"`
+	}
+	if err := json.Unmarshal(toolsPayload, &toolsWrapper); err != nil {
+		t.Fatalf("decode tools: %v", err)
+	}
+	names := map[string]bool{}
+	for _, tl := range toolsWrapper.Tools {
+		names[tl.Name] = true
+	}
+	for _, want := range []string{"extract", "list_packages", "get_package"} {
+		if !names[want] {
+			t.Errorf("missing tool %q in tools/list: %+v", want, toolsWrapper.Tools)
+		}
+	}
+
+	// 3) tools/call list_packages — expect both packages.
+	resp = sendRequest("tools/call", 3, map[string]any{
+		"name":      "list_packages",
+		"arguments": map[string]any{},
+	})
+	if resp.Error != nil {
+		t.Fatalf("list_packages error: %+v", resp.Error)
+	}
+	listText := textContent(t, resp)
+	if !strings.Contains(listText, `"path": "alpha"`) || !strings.Contains(listText, `"path": "beta"`) {
+		t.Errorf("list_packages did not include both packages: %s", listText)
+	}
+
+	// 4) tools/call extract with a filter
+	resp = sendRequest("tools/call", 4, map[string]any{
+		"name": "extract",
+		"arguments": map[string]any{
+			"paths": []string{"alpha"},
+		},
+	})
+	if resp.Error != nil {
+		t.Fatalf("extract error: %+v", resp.Error)
+	}
+	extractText := textContent(t, resp)
+	if !strings.Contains(extractText, `"Path": "alpha"`) {
+		t.Errorf("extract did not include alpha (mixed-case Path): %s", extractText)
+	}
+	if strings.Contains(extractText, `"Path": "beta"`) {
+		t.Errorf("extract should not include beta when filtered: %s", extractText)
+	}
+
+	// 5) tools/call get_package for beta
+	resp = sendRequest("tools/call", 5, map[string]any{
+		"name": "get_package",
+		"arguments": map[string]any{
+			"path": "beta",
+		},
+	})
+	if resp.Error != nil {
+		t.Fatalf("get_package error: %+v", resp.Error)
+	}
+	pkgText := textContent(t, resp)
+	if !strings.Contains(pkgText, `"Name": "beta"`) {
+		t.Errorf("get_package did not return beta payload: %s", pkgText)
+	}
+
+	// 6) tools/call get_package for unknown path → isError=true
+	resp = sendRequest("tools/call", 6, map[string]any{
+		"name": "get_package",
+		"arguments": map[string]any{
+			"path": "nope",
+		},
+	})
+	if resp.Error != nil {
+		t.Fatalf("get_package (unknown) RPC error: %+v", resp.Error)
+	}
+	payload, _ := json.Marshal(resp.Result)
+	if !strings.Contains(string(payload), `"isError":true`) {
+		t.Errorf("expected isError=true for unknown package, got %s", payload)
+	}
+}
+
+// Response mirrors the adapter/mcp.Response shape for test-local use so
+// the e2e test doesn't import an internal package outside its module
+// subtree (it's same module, but keeping the boundary clean).
+type Response struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
+	Result  any             `json:"result,omitempty"`
+	Error   *rpcErr         `json:"error,omitempty"`
+}
+
+type rpcErr struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+func textContent(t *testing.T, resp Response) string {
+	t.Helper()
+	payload, err := json.Marshal(resp.Result)
+	if err != nil {
+		t.Fatalf("marshal result: %v", err)
+	}
+	var tr struct {
+		Content []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"content"`
+	}
+	if err := json.Unmarshal(payload, &tr); err != nil {
+		t.Fatalf("unmarshal tool result: %v", err)
+	}
+	if len(tr.Content) == 0 {
+		t.Fatalf("tool result has no content: %s", payload)
+	}
+	return tr.Content[0].Text
+}
+
+func mustWriteE2E(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// readLineWithTimeout reads until '\n' or the timeout expires. A helper
+// so a hung daemon surfaces as a test failure rather than a deadlock.
+func readLineWithTimeout(r *bufio.Reader, d time.Duration) ([]byte, error) {
+	type result struct {
+		line []byte
+		err  error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		line, err := r.ReadBytes('\n')
+		ch <- result{line: line, err: err}
+	}()
+	select {
+	case res := <-ch:
+		if res.err != nil && res.err != io.EOF {
+			return nil, res.err
+		}
+		return res.line, nil
+	case <-time.After(d):
+		return nil, context.DeadlineExceeded
+	}
+}

--- a/internal/adapter/mcp/protocol.go
+++ b/internal/adapter/mcp/protocol.go
@@ -1,0 +1,106 @@
+// Package mcp implements a minimal Model Context Protocol (MCP) stdio
+// transport for the archai daemon. The transport speaks line-based
+// JSON-RPC 2.0 over stdin/stdout and exposes three read-only tools
+// (extract, list_packages, get_package) backed by the in-memory
+// serve.State model.
+//
+// Only the subset of MCP needed to advertise and dispatch tools is
+// implemented: the initialize handshake, tools/list and tools/call.
+// Extract/list_packages/get_package return tool results as
+// [{type: "text", text: "<JSON payload>"}] content blocks.
+package mcp
+
+import (
+	"encoding/json"
+)
+
+// JSON-RPC 2.0 message shapes. Requests may carry an id (client calls)
+// or omit it (notifications). Responses always echo the request id.
+
+// jsonRPCVersion is the protocol version string required on every
+// JSON-RPC 2.0 message.
+const jsonRPCVersion = "2.0"
+
+// protocolVersion is the MCP protocol version we advertise during
+// initialize. Clients that don't recognize the exact string typically
+// negotiate down — for the current read-only tool set this is fine.
+const protocolVersion = "2024-11-05"
+
+// Request is an incoming JSON-RPC 2.0 request or notification. ID is
+// kept as a RawMessage so we can echo it back verbatim (clients may use
+// numbers or strings interchangeably).
+type Request struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+// Response is a JSON-RPC 2.0 response. Exactly one of Result / Error is
+// set on the wire; Response uses pointers so omitempty elides the other.
+type Response struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Result  interface{}     `json:"result,omitempty"`
+	Error   *RPCError       `json:"error,omitempty"`
+}
+
+// RPCError is the error object defined by JSON-RPC 2.0.
+type RPCError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+	Data    any    `json:"data,omitempty"`
+}
+
+// Standard JSON-RPC 2.0 error codes we surface.
+const (
+	ErrParseError     = -32700
+	ErrInvalidRequest = -32600
+	ErrMethodNotFound = -32601
+	ErrInvalidParams  = -32602
+	ErrInternal       = -32603
+)
+
+// serverInfo is returned from initialize so clients know who they're
+// talking to.
+type serverInfo struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+// initializeResult is the payload returned for the initialize request.
+// We advertise the tools capability (the bag is empty — MCP defines no
+// required fields inside it yet).
+type initializeResult struct {
+	ProtocolVersion string         `json:"protocolVersion"`
+	Capabilities    map[string]any `json:"capabilities"`
+	ServerInfo      serverInfo     `json:"serverInfo"`
+}
+
+// newInitializeResult builds the fixed response for initialize.
+func newInitializeResult() initializeResult {
+	return initializeResult{
+		ProtocolVersion: protocolVersion,
+		Capabilities: map[string]any{
+			"tools": map[string]any{},
+		},
+		ServerInfo: serverInfo{
+			Name:    "archai",
+			Version: "0.1.0",
+		},
+	}
+}
+
+// newResponse builds a successful response for id with result.
+func newResponse(id json.RawMessage, result interface{}) Response {
+	return Response{JSONRPC: jsonRPCVersion, ID: id, Result: result}
+}
+
+// newErrorResponse builds an error response for id with code/message.
+func newErrorResponse(id json.RawMessage, code int, message string) Response {
+	return Response{
+		JSONRPC: jsonRPCVersion,
+		ID:      id,
+		Error:   &RPCError{Code: code, Message: message},
+	}
+}

--- a/internal/adapter/mcp/stdio.go
+++ b/internal/adapter/mcp/stdio.go
@@ -1,0 +1,168 @@
+package mcp
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+
+	"github.com/kgatilin/archai/internal/serve"
+)
+
+// Serve runs the MCP stdio transport: it reads line-delimited JSON-RPC
+// 2.0 messages from stdin, dispatches them against state, and writes
+// responses back to stdout. Diagnostic logs go to stderr.
+//
+// Serve returns when stdin is closed (io.EOF) or ctx is cancelled.
+// It is safe to call concurrently with state mutations — all reads go
+// through serve.State.Snapshot().
+func Serve(ctx context.Context, state *serve.State) error {
+	return serveIO(ctx, state, os.Stdin, os.Stdout, os.Stderr)
+}
+
+// serveIO is the testable form of Serve with explicit streams.
+func serveIO(ctx context.Context, state *serve.State, in io.Reader, out io.Writer, errOut io.Writer) error {
+	// bufio.Scanner has a default 64KiB line cap which is too small for
+	// packages-worth of JSON. Use a buffered reader with ReadBytes('\n')
+	// so messages of any length are supported.
+	reader := bufio.NewReader(in)
+
+	// Stdout writes must not interleave: dispatch is synchronous here,
+	// but we keep a mutex so future async extensions don't regress.
+	var writeMu sync.Mutex
+	writeLine := func(resp Response) error {
+		data, err := json.Marshal(resp)
+		if err != nil {
+			return err
+		}
+		writeMu.Lock()
+		defer writeMu.Unlock()
+		if _, err := out.Write(data); err != nil {
+			return err
+		}
+		_, err = out.Write([]byte{'\n'})
+		return err
+	}
+
+	// readCh decouples the blocking ReadBytes call from ctx so we can
+	// exit promptly when the caller cancels.
+	type readResult struct {
+		line []byte
+		err  error
+	}
+	readCh := make(chan readResult, 1)
+	go func() {
+		for {
+			line, err := reader.ReadBytes('\n')
+			readCh <- readResult{line: line, err: err}
+			if err != nil {
+				return
+			}
+		}
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case r := <-readCh:
+			// ReadBytes may return a partial final line with io.EOF.
+			if len(r.line) > 0 {
+				if err := handleLine(state, r.line, writeLine, errOut); err != nil {
+					fmt.Fprintf(errOut, "mcp: write response: %v\n", err)
+				}
+			}
+			if r.err != nil {
+				if errors.Is(r.err, io.EOF) {
+					return nil
+				}
+				return r.err
+			}
+		}
+	}
+}
+
+// handleLine parses a single incoming line and emits exactly one
+// response (unless the message is a notification — has no id — in
+// which case nothing is written).
+func handleLine(state *serve.State, line []byte, writeLine func(Response) error, errOut io.Writer) error {
+	var req Request
+	if err := json.Unmarshal(line, &req); err != nil {
+		// Unparseable input: respond with ParseError and a null id.
+		return writeLine(newErrorResponse(nil, ErrParseError, fmt.Sprintf("parse error: %v", err)))
+	}
+
+	// Notifications (no id) require no response per JSON-RPC 2.0.
+	isNotification := len(req.ID) == 0
+
+	switch req.Method {
+	case "initialize":
+		if isNotification {
+			return nil
+		}
+		return writeLine(newResponse(req.ID, newInitializeResult()))
+
+	case "notifications/initialized", "initialized":
+		// Client acknowledgement — no response required.
+		return nil
+
+	case "tools/list":
+		if isNotification {
+			return nil
+		}
+		return writeLine(newResponse(req.ID, map[string]any{
+			"tools": ToolDefinitions(),
+		}))
+
+	case "tools/call":
+		if isNotification {
+			return nil
+		}
+		return dispatchToolsCall(state, req, writeLine, errOut)
+
+	case "ping":
+		if isNotification {
+			return nil
+		}
+		return writeLine(newResponse(req.ID, map[string]any{}))
+
+	default:
+		if isNotification {
+			return nil
+		}
+		return writeLine(newErrorResponse(req.ID, ErrMethodNotFound, fmt.Sprintf("method %q not supported", req.Method)))
+	}
+}
+
+// toolsCallParams is the shape of tools/call params per the MCP spec.
+type toolsCallParams struct {
+	Name      string          `json:"name"`
+	Arguments json.RawMessage `json:"arguments"`
+}
+
+// dispatchToolsCall extracts name+arguments from the request, invokes
+// the tool, and writes the response.
+func dispatchToolsCall(state *serve.State, req Request, writeLine func(Response) error, errOut io.Writer) error {
+	var params toolsCallParams
+	if len(req.Params) > 0 {
+		if err := json.Unmarshal(req.Params, &params); err != nil {
+			return writeLine(newErrorResponse(req.ID, ErrInvalidParams, fmt.Sprintf("invalid params: %v", err)))
+		}
+	}
+	if params.Name == "" {
+		return writeLine(newErrorResponse(req.ID, ErrInvalidParams, "missing tool name"))
+	}
+
+	result, rpcErr := Dispatch(state, params.Name, params.Arguments)
+	if rpcErr != nil {
+		if errOut != nil {
+			fmt.Fprintf(errOut, "mcp: tool %q error: %s\n", params.Name, rpcErr.Message)
+		}
+		return writeLine(Response{JSONRPC: jsonRPCVersion, ID: req.ID, Error: rpcErr})
+	}
+	return writeLine(newResponse(req.ID, result))
+}

--- a/internal/adapter/mcp/stdio_test.go
+++ b/internal/adapter/mcp/stdio_test.go
@@ -1,0 +1,167 @@
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"strings"
+	"testing"
+	"time"
+)
+
+// runServeLines feeds input to serveIO and returns the response lines
+// written to the fake stdout. serveIO exits when the reader reaches
+// io.EOF; if it hasn't returned within timeout we fail the test to
+// avoid hangs.
+func runServeLines(t *testing.T, input string) []string {
+	t.Helper()
+	in := strings.NewReader(input)
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- serveIO(ctx, nil, in, &out, &errOut) }()
+
+	select {
+	case err := <-done:
+		if err != nil && err != io.EOF {
+			t.Fatalf("serveIO: %v (stderr=%s)", err, errOut.String())
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatalf("serveIO did not return in time")
+	}
+
+	raw := strings.TrimRight(out.String(), "\n")
+	if raw == "" {
+		return nil
+	}
+	return strings.Split(raw, "\n")
+}
+
+func TestStdio_Initialize(t *testing.T) {
+	lines := runServeLines(t, `{"jsonrpc":"2.0","id":1,"method":"initialize"}`+"\n")
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 response, got %d: %v", len(lines), lines)
+	}
+	var resp Response
+	if err := json.Unmarshal([]byte(lines[0]), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %+v", resp.Error)
+	}
+	// Result is returned as map[string]any since Response.Result is any.
+	resultJSON, _ := json.Marshal(resp.Result)
+	var result initializeResult
+	if err := json.Unmarshal(resultJSON, &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if result.ServerInfo.Name != "archai" {
+		t.Errorf("wrong server name: %q", result.ServerInfo.Name)
+	}
+	if _, ok := result.Capabilities["tools"]; !ok {
+		t.Errorf("missing tools capability: %+v", result.Capabilities)
+	}
+}
+
+func TestStdio_ToolsList(t *testing.T) {
+	lines := runServeLines(t, `{"jsonrpc":"2.0","id":2,"method":"tools/list"}`+"\n")
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 response, got %d", len(lines))
+	}
+	var resp Response
+	if err := json.Unmarshal([]byte(lines[0]), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.Error != nil {
+		t.Fatalf("error: %+v", resp.Error)
+	}
+	payload, _ := json.Marshal(resp.Result)
+	var wrapper struct {
+		Tools []ToolDefinition `json:"tools"`
+	}
+	if err := json.Unmarshal(payload, &wrapper); err != nil {
+		t.Fatalf("unmarshal tools: %v", err)
+	}
+	if len(wrapper.Tools) != 3 {
+		t.Fatalf("expected 3 tools, got %d", len(wrapper.Tools))
+	}
+}
+
+func TestStdio_ToolsCall_ListPackages_EmptyState(t *testing.T) {
+	body := `{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"list_packages","arguments":{}}}` + "\n"
+	lines := runServeLines(t, body)
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 response, got %d", len(lines))
+	}
+	var resp Response
+	if err := json.Unmarshal([]byte(lines[0]), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.Error != nil {
+		t.Fatalf("error: %+v", resp.Error)
+	}
+	payload, _ := json.Marshal(resp.Result)
+	var tr ToolResult
+	if err := json.Unmarshal(payload, &tr); err != nil {
+		t.Fatalf("unmarshal toolResult: %v", err)
+	}
+	if len(tr.Content) != 1 || tr.Content[0].Type != "text" {
+		t.Fatalf("unexpected content: %+v", tr.Content)
+	}
+	text := strings.TrimSpace(tr.Content[0].Text)
+	if text != "[]" {
+		t.Errorf("expected empty array, got %q", text)
+	}
+}
+
+func TestStdio_UnknownMethod(t *testing.T) {
+	lines := runServeLines(t, `{"jsonrpc":"2.0","id":4,"method":"no/such"}`+"\n")
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 response")
+	}
+	var resp Response
+	if err := json.Unmarshal([]byte(lines[0]), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.Error == nil || resp.Error.Code != ErrMethodNotFound {
+		t.Fatalf("expected method-not-found, got %+v", resp.Error)
+	}
+}
+
+func TestStdio_ParseError(t *testing.T) {
+	lines := runServeLines(t, "not-json\n")
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 response, got %d", len(lines))
+	}
+	var resp Response
+	if err := json.Unmarshal([]byte(lines[0]), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.Error == nil || resp.Error.Code != ErrParseError {
+		t.Fatalf("expected parse error, got %+v", resp.Error)
+	}
+}
+
+func TestStdio_Notification_NoResponse(t *testing.T) {
+	// "notifications/initialized" is a no-id client notification; we
+	// must not write anything back.
+	lines := runServeLines(t, `{"jsonrpc":"2.0","method":"notifications/initialized"}`+"\n")
+	if len(lines) != 0 {
+		t.Fatalf("expected 0 responses for notification, got %d: %v", len(lines), lines)
+	}
+}
+
+func TestStdio_MultipleRequestsInOneSession(t *testing.T) {
+	input := `{"jsonrpc":"2.0","id":"a","method":"initialize"}` + "\n" +
+		`{"jsonrpc":"2.0","method":"notifications/initialized"}` + "\n" +
+		`{"jsonrpc":"2.0","id":"b","method":"tools/list"}` + "\n"
+	lines := runServeLines(t, input)
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 responses, got %d: %v", len(lines), lines)
+	}
+}

--- a/internal/adapter/mcp/tools.go
+++ b/internal/adapter/mcp/tools.go
@@ -1,0 +1,233 @@
+package mcp
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/kgatilin/archai/internal/domain"
+	"github.com/kgatilin/archai/internal/serve"
+)
+
+// ToolDefinition describes a single MCP tool exposed via tools/list.
+// InputSchema is a JSON Schema object; we keep it as an any so each
+// tool can define its own shape without a shared struct.
+type ToolDefinition struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	InputSchema any    `json:"inputSchema"`
+}
+
+// ToolResultContent is one "content" item returned by tools/call. We
+// only emit text blocks; binary/resource blocks are out of scope for
+// the M5b read-only surface.
+type ToolResultContent struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+// ToolResult is the payload returned by tools/call. IsError is a hint
+// for clients — JSON-RPC errors are used for protocol-level failures
+// (unknown tool etc.) while tool-level errors (package not found) are
+// reported via IsError + a text message so the model can see them.
+type ToolResult struct {
+	Content []ToolResultContent `json:"content"`
+	IsError bool                `json:"isError,omitempty"`
+}
+
+// PackageSummary is the minimal record returned by list_packages. The
+// summary is intentionally small so agents can decide which package to
+// drill into via get_package without paying for the full payload.
+type PackageSummary struct {
+	Path           string `json:"path"`
+	Name           string `json:"name"`
+	Layer          string `json:"layer,omitempty"`
+	InterfaceCount int    `json:"interface_count"`
+	StructCount    int    `json:"struct_count"`
+	FunctionCount  int    `json:"function_count"`
+}
+
+// ToolDefinitions returns the three tools we advertise. Kept as a
+// function rather than a var so the JSON-Schema maps don't become
+// mutable package state.
+func ToolDefinitions() []ToolDefinition {
+	return []ToolDefinition{
+		{
+			Name:        "extract",
+			Description: "Return the full extracted Go model (all packages) from the archai daemon's in-memory state. Optionally filter to specific package paths.",
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"paths": map[string]any{
+						"type":        "array",
+						"items":       map[string]any{"type": "string"},
+						"description": "Module-relative package paths to include. When omitted or empty, all packages are returned.",
+					},
+				},
+			},
+		},
+		{
+			Name:        "list_packages",
+			Description: "List packages known to the daemon with minimal summary fields (path, name, layer, counts).",
+			InputSchema: map[string]any{
+				"type":       "object",
+				"properties": map[string]any{},
+			},
+		},
+		{
+			Name:        "get_package",
+			Description: "Return the full PackageModel for a single package identified by its module-relative path.",
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"path": map[string]any{
+						"type":        "string",
+						"description": "Module-relative package path, e.g. internal/service.",
+					},
+				},
+				"required": []string{"path"},
+			},
+		},
+	}
+}
+
+// Dispatch routes a tools/call invocation to the matching handler.
+// Unknown tool names surface as JSON-RPC method-not-found errors; the
+// three known tools all return ToolResult (possibly with IsError=true
+// when inputs are invalid).
+func Dispatch(state *serve.State, name string, rawArgs json.RawMessage) (ToolResult, *RPCError) {
+	switch name {
+	case "extract":
+		return handleExtract(state, rawArgs)
+	case "list_packages":
+		return handleListPackages(state)
+	case "get_package":
+		return handleGetPackage(state, rawArgs)
+	default:
+		return ToolResult{}, &RPCError{
+			Code:    ErrMethodNotFound,
+			Message: fmt.Sprintf("unknown tool %q", name),
+		}
+	}
+}
+
+// extractArgs is the input schema for the extract tool.
+type extractArgs struct {
+	Paths []string `json:"paths"`
+}
+
+// handleExtract returns the (optionally filtered) package list. An
+// empty Paths slice means "return everything"; an unknown path is not
+// an error — it just contributes nothing.
+func handleExtract(state *serve.State, rawArgs json.RawMessage) (ToolResult, *RPCError) {
+	var args extractArgs
+	if len(rawArgs) > 0 {
+		if err := json.Unmarshal(rawArgs, &args); err != nil {
+			return ToolResult{}, &RPCError{
+				Code:    ErrInvalidParams,
+				Message: fmt.Sprintf("invalid arguments: %v", err),
+			}
+		}
+	}
+
+	snap := snapshotOrEmpty(state)
+	out := snap.Packages
+	if len(args.Paths) > 0 {
+		want := make(map[string]struct{}, len(args.Paths))
+		for _, p := range args.Paths {
+			want[p] = struct{}{}
+		}
+		filtered := make([]domain.PackageModel, 0, len(args.Paths))
+		for _, m := range snap.Packages {
+			if _, ok := want[m.Path]; ok {
+				filtered = append(filtered, m)
+			}
+		}
+		out = filtered
+	}
+	if out == nil {
+		out = []domain.PackageModel{}
+	}
+	return textResult(out)
+}
+
+// handleListPackages returns the minimal per-package summary.
+func handleListPackages(state *serve.State) (ToolResult, *RPCError) {
+	snap := snapshotOrEmpty(state)
+	summaries := make([]PackageSummary, 0, len(snap.Packages))
+	for _, m := range snap.Packages {
+		summaries = append(summaries, PackageSummary{
+			Path:           m.Path,
+			Name:           m.Name,
+			Layer:          m.Layer,
+			InterfaceCount: len(m.Interfaces),
+			StructCount:    len(m.Structs),
+			FunctionCount:  len(m.Functions),
+		})
+	}
+	return textResult(summaries)
+}
+
+// getPackageArgs is the input schema for the get_package tool.
+type getPackageArgs struct {
+	Path string `json:"path"`
+}
+
+// handleGetPackage returns a single PackageModel. Missing/empty paths
+// and unknown packages come back as IsError=true tool results (not
+// JSON-RPC errors) so the model can see the message and recover.
+func handleGetPackage(state *serve.State, rawArgs json.RawMessage) (ToolResult, *RPCError) {
+	var args getPackageArgs
+	if len(rawArgs) > 0 {
+		if err := json.Unmarshal(rawArgs, &args); err != nil {
+			return ToolResult{}, &RPCError{
+				Code:    ErrInvalidParams,
+				Message: fmt.Sprintf("invalid arguments: %v", err),
+			}
+		}
+	}
+	if args.Path == "" {
+		return errorResult("missing required argument: path"), nil
+	}
+
+	snap := snapshotOrEmpty(state)
+	for _, m := range snap.Packages {
+		if m.Path == args.Path {
+			return textResult(m)
+		}
+	}
+	return errorResult(fmt.Sprintf("package %q not found", args.Path)), nil
+}
+
+// snapshotOrEmpty returns a Snapshot even when state is nil, so the
+// tools can be unit-tested in isolation and the daemon can answer
+// requests before Load completes.
+func snapshotOrEmpty(state *serve.State) serve.Snapshot {
+	if state == nil {
+		return serve.Snapshot{Packages: []domain.PackageModel{}}
+	}
+	return state.Snapshot()
+}
+
+// textResult marshals payload as indented JSON and wraps it in a
+// single text content block.
+func textResult(payload any) (ToolResult, *RPCError) {
+	data, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return ToolResult{}, &RPCError{
+			Code:    ErrInternal,
+			Message: fmt.Sprintf("marshalling result: %v", err),
+		}
+	}
+	return ToolResult{
+		Content: []ToolResultContent{{Type: "text", Text: string(data)}},
+	}, nil
+}
+
+// errorResult wraps a human-readable message as an IsError=true tool
+// result. Used for input validation failures the agent can surface.
+func errorResult(msg string) ToolResult {
+	return ToolResult{
+		Content: []ToolResultContent{{Type: "text", Text: msg}},
+		IsError: true,
+	}
+}

--- a/internal/adapter/mcp/tools_test.go
+++ b/internal/adapter/mcp/tools_test.go
@@ -1,0 +1,223 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kgatilin/archai/internal/domain"
+	"github.com/kgatilin/archai/internal/serve"
+)
+
+// loadFakeState creates a tiny Go module on disk with two packages
+// and loads it into a serve.State. Slow-ish (calls go/packages) but
+// it exercises the full integration.
+func loadFakeState(t *testing.T) *serve.State {
+	t.Helper()
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "go.mod"), "module fake.test\n\ngo 1.21\n")
+	mustWrite(t, filepath.Join(dir, "alpha", "alpha.go"), `package alpha
+
+type Service interface{ Do() }
+
+type Impl struct{}
+
+func New() *Impl { return &Impl{} }
+`)
+	mustWrite(t, filepath.Join(dir, "beta", "beta.go"), `package beta
+
+type Thing struct{ Name string }
+
+func Hello() string { return "hi" }
+`)
+	state := serve.NewState(dir)
+	if err := state.Load(context.Background()); err != nil {
+		t.Fatalf("load state: %v", err)
+	}
+	return state
+}
+
+func mustWrite(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func TestToolDefinitions(t *testing.T) {
+	defs := ToolDefinitions()
+	if len(defs) != 3 {
+		t.Fatalf("expected 3 tool definitions, got %d", len(defs))
+	}
+	names := map[string]bool{}
+	for _, d := range defs {
+		names[d.Name] = true
+		if d.Description == "" {
+			t.Errorf("tool %q missing description", d.Name)
+		}
+		if d.InputSchema == nil {
+			t.Errorf("tool %q missing input schema", d.Name)
+		}
+	}
+	for _, want := range []string{"extract", "list_packages", "get_package"} {
+		if !names[want] {
+			t.Errorf("missing tool definition for %q", want)
+		}
+	}
+}
+
+func TestDispatchUnknownTool(t *testing.T) {
+	_, rpcErr := Dispatch(nil, "does_not_exist", nil)
+	if rpcErr == nil {
+		t.Fatal("expected RPC error for unknown tool")
+	}
+	if rpcErr.Code != ErrMethodNotFound {
+		t.Errorf("want ErrMethodNotFound, got %d", rpcErr.Code)
+	}
+}
+
+func TestExtract_EmptyStateReturnsEmptyArray(t *testing.T) {
+	res, rpcErr := Dispatch(nil, "extract", nil)
+	if rpcErr != nil {
+		t.Fatalf("unexpected RPC error: %v", rpcErr)
+	}
+	if len(res.Content) != 1 || res.Content[0].Type != "text" {
+		t.Fatalf("unexpected content: %+v", res.Content)
+	}
+	var pkgs []domain.PackageModel
+	if err := json.Unmarshal([]byte(res.Content[0].Text), &pkgs); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(pkgs) != 0 {
+		t.Errorf("expected 0 packages, got %d", len(pkgs))
+	}
+}
+
+func TestExtract_ReturnsAllPackages(t *testing.T) {
+	state := loadFakeState(t)
+	res, rpcErr := Dispatch(state, "extract", nil)
+	if rpcErr != nil {
+		t.Fatalf("unexpected RPC error: %v", rpcErr)
+	}
+	var pkgs []domain.PackageModel
+	if err := json.Unmarshal([]byte(res.Content[0].Text), &pkgs); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(pkgs) != 2 {
+		t.Fatalf("expected 2 packages, got %d: %+v", len(pkgs), pkgs)
+	}
+}
+
+func TestExtract_FilterByPath(t *testing.T) {
+	state := loadFakeState(t)
+	args := json.RawMessage(`{"paths":["alpha"]}`)
+	res, rpcErr := Dispatch(state, "extract", args)
+	if rpcErr != nil {
+		t.Fatalf("unexpected RPC error: %v", rpcErr)
+	}
+	var pkgs []domain.PackageModel
+	if err := json.Unmarshal([]byte(res.Content[0].Text), &pkgs); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(pkgs) != 1 || pkgs[0].Path != "alpha" {
+		t.Fatalf("expected single 'alpha' package, got %+v", pkgs)
+	}
+}
+
+func TestExtract_InvalidArguments(t *testing.T) {
+	// paths should be an array; pass a string to trigger schema error.
+	args := json.RawMessage(`{"paths":"alpha"}`)
+	_, rpcErr := Dispatch(nil, "extract", args)
+	if rpcErr == nil {
+		t.Fatal("expected invalid-params error")
+	}
+	if rpcErr.Code != ErrInvalidParams {
+		t.Errorf("want ErrInvalidParams, got %d", rpcErr.Code)
+	}
+}
+
+func TestListPackages(t *testing.T) {
+	state := loadFakeState(t)
+	res, rpcErr := Dispatch(state, "list_packages", nil)
+	if rpcErr != nil {
+		t.Fatalf("unexpected RPC error: %v", rpcErr)
+	}
+	var summaries []PackageSummary
+	if err := json.Unmarshal([]byte(res.Content[0].Text), &summaries); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(summaries) != 2 {
+		t.Fatalf("expected 2 summaries, got %d", len(summaries))
+	}
+	byPath := map[string]PackageSummary{}
+	for _, s := range summaries {
+		byPath[s.Path] = s
+	}
+	alpha, ok := byPath["alpha"]
+	if !ok {
+		t.Fatalf("no alpha in summaries: %+v", summaries)
+	}
+	if alpha.InterfaceCount != 1 || alpha.StructCount != 1 || alpha.FunctionCount != 1 {
+		t.Errorf("alpha counts wrong: %+v", alpha)
+	}
+}
+
+func TestListPackages_EmptyStateReturnsEmptyArray(t *testing.T) {
+	res, rpcErr := Dispatch(nil, "list_packages", nil)
+	if rpcErr != nil {
+		t.Fatalf("unexpected RPC error: %v", rpcErr)
+	}
+	if !strings.HasPrefix(strings.TrimSpace(res.Content[0].Text), "[") {
+		t.Errorf("expected JSON array, got %q", res.Content[0].Text)
+	}
+}
+
+func TestGetPackage_Found(t *testing.T) {
+	state := loadFakeState(t)
+	args := json.RawMessage(`{"path":"beta"}`)
+	res, rpcErr := Dispatch(state, "get_package", args)
+	if rpcErr != nil {
+		t.Fatalf("unexpected RPC error: %v", rpcErr)
+	}
+	if res.IsError {
+		t.Fatalf("expected non-error result, got %+v", res)
+	}
+	var pkg domain.PackageModel
+	if err := json.Unmarshal([]byte(res.Content[0].Text), &pkg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if pkg.Path != "beta" || pkg.Name != "beta" {
+		t.Errorf("unexpected package: %+v", pkg)
+	}
+}
+
+func TestGetPackage_NotFound(t *testing.T) {
+	state := loadFakeState(t)
+	args := json.RawMessage(`{"path":"gamma"}`)
+	res, rpcErr := Dispatch(state, "get_package", args)
+	if rpcErr != nil {
+		t.Fatalf("unexpected RPC error: %v", rpcErr)
+	}
+	if !res.IsError {
+		t.Fatal("expected IsError result for unknown package")
+	}
+	if !strings.Contains(res.Content[0].Text, "gamma") {
+		t.Errorf("expected error text to mention path; got %q", res.Content[0].Text)
+	}
+}
+
+func TestGetPackage_MissingPath(t *testing.T) {
+	res, rpcErr := Dispatch(nil, "get_package", json.RawMessage(`{}`))
+	if rpcErr != nil {
+		t.Fatalf("unexpected RPC error: %v", rpcErr)
+	}
+	if !res.IsError {
+		t.Fatal("expected IsError result for missing path")
+	}
+}

--- a/internal/serve/daemon.go
+++ b/internal/serve/daemon.go
@@ -16,9 +16,15 @@ type Options struct {
 	// Root is the project root directory. Defaults to cwd when empty.
 	Root string
 
-	// MCPStdio enables the MCP stdio transport. Currently a stub
-	// (M5a only wires the flag so M5b can implement it).
+	// MCPStdio enables the MCP stdio transport. When true, MCPServe is
+	// invoked with the live State so the transport can answer tool
+	// calls from its in-memory snapshot.
 	MCPStdio bool
+
+	// MCPServe is the MCP stdio entry point. Left as a callback so the
+	// serve package avoids importing the mcp adapter (which depends on
+	// serve). cmd/archai wires this to mcp.Serve.
+	MCPServe func(ctx context.Context, state *State) error
 
 	// HTTPAddr enables the HTTP transport on the given address
 	// (e.g. ":8080"). Empty disables HTTP. Stub until M7a.
@@ -68,12 +74,6 @@ func Serve(ctx context.Context, opts Options) error {
 	fmt.Fprintf(logOut, "serve: loaded %d package(s), overlay=%v, target=%q\n",
 		len(snap.Packages), snap.Overlay != nil, snap.CurrentTarget)
 
-	// Transport stubs. M5b / M7a will replace these with real
-	// implementations; for now we log so operators know they were
-	// requested.
-	if opts.MCPStdio {
-		fmt.Fprintln(logOut, "serve: MCP stdio transport requested — not implemented yet (stub)")
-	}
 	if opts.HTTPAddr != "" {
 		fmt.Fprintf(logOut, "serve: HTTP transport requested on %s — not implemented yet (stub)\n", opts.HTTPAddr)
 	}
@@ -85,6 +85,38 @@ func Serve(ctx context.Context, opts Options) error {
 	defer func() { _ = watcher.Close() }()
 
 	handler := buildHandler(ctx, state, logOut, opts.Debug)
+
+	// When the MCP stdio transport is requested, it owns the process's
+	// stdin/stdout and drives shutdown: we run the watcher loop in a
+	// goroutine for the duration of the MCP session. Stdout is reserved
+	// for JSON-RPC frames; diagnostics stay on stderr (logOut).
+	if opts.MCPStdio {
+		if opts.MCPServe == nil {
+			return fmt.Errorf("serve: --mcp-stdio set but MCPServe is nil")
+		}
+
+		childCtx, cancel := context.WithCancel(ctx)
+		defer cancel()
+
+		watchErrCh := make(chan error, 1)
+		go func() {
+			fmt.Fprintln(logOut, "serve: watching for changes (MCP stdio mode)")
+			watchErrCh <- watcher.Run(childCtx, handler)
+		}()
+
+		fmt.Fprintln(logOut, "serve: starting MCP stdio transport")
+		mcpErr := opts.MCPServe(childCtx, state)
+		cancel()
+
+		// Drain the watcher goroutine so we don't leak it.
+		<-watchErrCh
+
+		if mcpErr != nil && !errors.Is(mcpErr, context.Canceled) {
+			return mcpErr
+		}
+		fmt.Fprintln(logOut, "serve: shutdown complete")
+		return nil
+	}
 
 	fmt.Fprintln(logOut, "serve: watching for changes (Ctrl-C to stop)")
 	if err := watcher.Run(ctx, handler); err != nil {


### PR DESCRIPTION
Closes #17.

## Summary
- New `internal/adapter/mcp/` package implementing line-framed JSON-RPC 2.0 over stdin/stdout.
- `initialize`, `tools/list`, `tools/call` handlers plus `ping` and `notifications/initialized`.
- Three read-only tools dispatched against `serve.State.Snapshot()` — no re-extraction:
  - `extract` — returns `[]domain.PackageModel` (all packages, or filtered by `paths`).
  - `list_packages` — minimal summary per package (path, name, layer, interface/struct/function counts).
  - `get_package` — full `PackageModel` for one package; unknown path is surfaced as `isError: true` tool result.
- `serve.Options` gains an `MCPServe` callback so the `serve` package does not depend on the `mcp` adapter (which itself depends on `serve`). When `--mcp-stdio` is set, the daemon runs the fsnotify watcher in parallel and exits when stdin closes.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] Unit tests: `tools_test.go` (ToolDefinitions, Dispatch, extract filter, list_packages, get_package found/not-found/missing-path), `stdio_test.go` (initialize, tools/list, tools/call, notifications are silent, parse errors, unknown methods).
- [x] Subprocess e2e: `cmd/archai/mcp_stdio_e2e_test.go` builds the binary, spawns `archai serve --mcp-stdio --root <tmp>` against a generated two-package Go module, and exercises initialize → tools/list → tools/call for all three tools plus an unknown-path `get_package`.

## Notes
- Diagnostics go to stderr; stdout is reserved for JSON-RPC frames.
- `get_package` with missing/unknown path returns `isError: true` (tool-level error) rather than a JSON-RPC error so the model can recover.
- Empty state returns empty arrays (`[]`) instead of errors, matching issue guidance.