### PR TITLE
feat: M7b dashboard + layers views (#22)

### DIFF
--- a/internal/adapter/http/assets/styles.css
+++ b/internal/adapter/http/assets/styles.css
@@ -142,6 +142,63 @@ a {
     margin-bottom: 0.5rem;
 }
 
+/* ---- Dashboard + Layers (M7b) ---- */
+
+.card {
+    border: 1px solid var(--border);
+    border-radius: 0.5rem;
+    padding: 1rem 1.25rem;
+    background: var(--nav-bg);
+    margin-bottom: 1rem;
+}
+
+.card h2 {
+    font-size: 1rem;
+    margin-bottom: 0.5rem;
+    color: var(--muted);
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+}
+
+.card h3 {
+    font-size: 0.95rem;
+    margin-bottom: 0.5rem;
+}
+
+.dash-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1rem;
+    margin-bottom: 1rem;
+}
+
+.stat-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.stat-list li {
+    display: flex;
+    align-items: baseline;
+    gap: 0.5rem;
+    padding: 0.15rem 0;
+}
+
+.stat-num {
+    font-weight: 600;
+    font-size: 1.15rem;
+    min-width: 2.5rem;
+    text-align: right;
+    color: var(--fg);
+}
+
+.mono {
+    font-family: ui-monospace, "SF Mono", Menlo, Monaco, Consolas, monospace;
+    font-size: 0.95em;
+    word-break: break-all;
+}
+
 /* --- M7e: Diff + Targets views -------------------------------------- */
 
 /* Semantic diff colors. Defined as their own CSS variables so the dark
@@ -272,6 +329,82 @@ a {
 }
 
 .diff-filter ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.small {
+    font-size: 0.85em;
+}
+
+.pill {
+    display: inline-block;
+    padding: 0.1rem 0.5rem;
+    border-radius: 0.75rem;
+    font-size: 0.8rem;
+    font-weight: 500;
+    border: 1px solid transparent;
+}
+
+.pill-green {
+    background: rgba(22, 163, 74, 0.15);
+    color: #16a34a;
+    border-color: rgba(22, 163, 74, 0.4);
+}
+
+.pill-red {
+    background: rgba(220, 38, 38, 0.15);
+    color: #dc2626;
+    border-color: rgba(220, 38, 38, 0.4);
+}
+
+.pill-gray {
+    background: rgba(148, 163, 184, 0.15);
+    color: var(--muted);
+    border-color: rgba(148, 163, 184, 0.4);
+}
+
+.diagram-frame {
+    border: 1px solid var(--border);
+    border-radius: 0.375rem;
+    padding: 0.75rem;
+    background: var(--bg);
+    overflow-x: auto;
+}
+
+.diagram-frame svg {
+    max-width: 100%;
+    height: auto;
+    display: block;
+}
+
+.diagram-frame.small svg {
+    max-height: 240px;
+}
+
+.diagram-link {
+    display: block;
+    text-decoration: none;
+}
+
+.layer-preview {
+    margin-top: 0;
+}
+
+.layer-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1rem;
+    margin-bottom: 1rem;
+}
+
+.layer-card h3 {
+    margin: 0 0 0.5rem 0;
+    color: var(--fg);
+}
+
+.pkg-list {
     list-style: none;
     padding: 0;
     margin: 0;
@@ -503,4 +636,56 @@ a {
     border-radius: 0.3rem;
     font-family: inherit;
     font-size: 0.9rem;
+}
+
+.pkg-list li {
+    padding: 0.15rem 0;
+}
+
+.pkg-link {
+    text-decoration: none;
+    font-family: ui-monospace, "SF Mono", Menlo, Monaco, Consolas, monospace;
+    font-size: 0.9em;
+}
+
+.pkg-link:hover {
+    text-decoration: underline;
+}
+
+.legend {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+    margin-top: 0.5rem;
+}
+
+.edge-head {
+    margin-top: 1rem;
+    font-size: 0.9rem;
+}
+
+.edge-head-red    { color: #dc2626; }
+.edge-head-green  { color: #16a34a; }
+.edge-head-gray   { color: var(--muted); }
+
+.edge-list {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 0.5rem 0;
+}
+
+.edge-list > li {
+    padding: 0.3rem 0;
+}
+
+.edge-detail {
+    list-style: disc;
+    padding-left: 1.25rem;
+    margin: 0.25rem 0 0 0;
+    color: var(--muted);
+}
+
+.edge-detail code {
+    background: transparent;
+    padding: 0;
 }

--- a/internal/adapter/http/dashboard.go
+++ b/internal/adapter/http/dashboard.go
@@ -1,0 +1,192 @@
+package http
+
+import (
+	"context"
+	"fmt"
+	nethttp "net/http"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"golang.org/x/mod/modfile"
+
+	yamlAdapter "github.com/kgatilin/archai/internal/adapter/yaml"
+	"github.com/kgatilin/archai/internal/diff"
+	"github.com/kgatilin/archai/internal/domain"
+	"github.com/kgatilin/archai/internal/overlay"
+)
+
+// dashboardData is the full data model for the dashboard page. Each
+// section is computed best-effort — a missing overlay or absent target
+// is not an error, it just leaves the corresponding section empty.
+type dashboardData struct {
+	pageData
+
+	Module    string // Module path, e.g. "github.com/kgatilin/archai"
+	GoVersion string // Go toolchain directive from go.mod, e.g. "1.25.1"
+
+	CurrentTarget string // Active target id (empty if none locked)
+	HasTarget     bool   // True when CurrentTarget is non-empty
+	DriftStatus   string // "matches", "drifted", "unknown" (no target), or "error"
+	DriftCount    int    // Number of changes when drifted
+	DriftMessage  string // Free-form explanation (errors, "no target set", etc.)
+
+	PackageCount   int
+	TypeCount      int // structs + interfaces + typedefs
+	FunctionCount  int
+	InterfaceCount int
+
+	LayerMapSVG string // Small D2 layer-map render as inline SVG (empty if no overlay)
+}
+
+// handleDashboard renders the dashboard at "/". It composes a
+// dashboardData from a fresh state Snapshot plus the on-disk go.mod
+// and (optionally) the active target snapshot.
+func (s *Server) handleDashboard(w nethttp.ResponseWriter, r *nethttp.Request) {
+	if r.URL.Path != "/" {
+		nethttp.NotFound(w, r)
+		return
+	}
+
+	snap := s.state.Snapshot()
+	data := dashboardData{
+		pageData: pageData{
+			Title:      "Dashboard",
+			ActivePath: "/",
+			NavItems:   buildNav("/"),
+		},
+	}
+
+	// Module + Go version from go.mod (best-effort — empty on failure).
+	if snap.Overlay != nil && snap.Overlay.Module != "" {
+		data.Module = snap.Overlay.Module
+	}
+	if module, goVer, ok := readGoModInfo(filepath.Join(snap.Root, "go.mod")); ok {
+		if data.Module == "" {
+			data.Module = module
+		}
+		data.GoVersion = goVer
+	}
+
+	// Counts across packages.
+	for _, p := range snap.Packages {
+		data.PackageCount++
+		data.InterfaceCount += len(p.Interfaces)
+		data.FunctionCount += len(p.Functions)
+		data.TypeCount += len(p.Structs) + len(p.Interfaces) + len(p.TypeDefs)
+	}
+
+	// Target + drift status.
+	data.CurrentTarget = snap.CurrentTarget
+	data.HasTarget = snap.CurrentTarget != ""
+	switch {
+	case !data.HasTarget:
+		data.DriftStatus = "unknown"
+		data.DriftMessage = "no target selected (lock one with `archai target lock`)"
+	default:
+		status, count, msg := computeDrift(r.Context(), snap.Root, snap.CurrentTarget, snap.Packages)
+		data.DriftStatus = status
+		data.DriftCount = count
+		data.DriftMessage = msg
+	}
+
+	// Layer map preview — render only when the overlay defines layers.
+	if snap.Overlay != nil && len(snap.Overlay.Layers) > 0 {
+		svg, err := renderLayerMapSVG(r.Context(), snap.Overlay, snap.Packages)
+		if err == nil {
+			data.LayerMapSVG = svg
+		}
+	}
+
+	s.renderPage(w, "index.html", data)
+}
+
+// readGoModInfo returns (module, goVersion, ok) for the go.mod at
+// path. ok=false when the file is missing or unparseable; callers
+// should treat that as "no data" rather than a fatal error.
+func readGoModInfo(path string) (string, string, bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", "", false
+	}
+	f, err := modfile.Parse(filepath.Base(path), data, nil)
+	if err != nil {
+		return "", "", false
+	}
+	var module, goVer string
+	if f.Module != nil {
+		module = f.Module.Mod.Path
+	}
+	if f.Go != nil {
+		goVer = f.Go.Version
+	}
+	return module, goVer, true
+}
+
+// computeDrift compares the in-memory current model against the locked
+// target snapshot on disk. Returns a status ("matches" / "drifted" /
+// "error"), a change count, and a human-readable message.
+func computeDrift(ctx context.Context, root, targetID string, current []domain.PackageModel) (string, int, string) {
+	if targetID == "" {
+		return "unknown", 0, "no target selected"
+	}
+	targetDir := filepath.Join(root, ".arch", "targets", targetID)
+	modelDir := filepath.Join(targetDir, "model")
+	if _, err := os.Stat(modelDir); err != nil {
+		return "error", 0, fmt.Sprintf("target %q has no model on disk", targetID)
+	}
+	files, err := collectTargetYAMLFiles(modelDir)
+	if err != nil {
+		return "error", 0, fmt.Sprintf("reading target: %v", err)
+	}
+	if len(files) == 0 {
+		return "error", 0, fmt.Sprintf("target %q has no model files", targetID)
+	}
+	targetModel, err := yamlAdapter.NewReader().Read(ctx, files)
+	if err != nil {
+		return "error", 0, fmt.Sprintf("parsing target: %v", err)
+	}
+	d := diff.Compute(current, targetModel)
+	if d.IsEmpty() {
+		return "matches", 0, "current code matches target"
+	}
+	return "drifted", len(d.Changes), fmt.Sprintf("%d change(s) between current code and target", len(d.Changes))
+}
+
+// collectTargetYAMLFiles walks root and returns every *.yaml / *.yml
+// file. Duplicated from cmd/archai/main.go intentionally — pulling the
+// CLI helper into a shared package would widen the dependency surface
+// of the http adapter for no real gain.
+func collectTargetYAMLFiles(root string) ([]string, error) {
+	var out []string
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		ext := filepath.Ext(path)
+		if ext == ".yaml" || ext == ".yml" {
+			out = append(out, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+// renderLayerMapSVG produces a small D2 diagram showing the layer map
+// (one box per layer annotated with its package count) plus allowed
+// edges from LayerRules. Used as the dashboard's layer-map preview.
+func renderLayerMapSVG(ctx context.Context, cfg *overlay.Config, packages []domain.PackageModel) (string, error) {
+	src := buildLayerMapD2(cfg, packages, false)
+	svg, err := renderD2(ctx, src)
+	if err != nil {
+		return "", err
+	}
+	return string(svg), nil
+}

--- a/internal/adapter/http/dashboard_test.go
+++ b/internal/adapter/http/dashboard_test.go
@@ -1,0 +1,149 @@
+package http
+
+import (
+	"context"
+	"io"
+	nethttp "net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kgatilin/archai/internal/domain"
+)
+
+func TestReadGoModInfo(t *testing.T) {
+	dir := t.TempDir()
+	gomod := filepath.Join(dir, "go.mod")
+	if err := os.WriteFile(gomod, []byte("module example.com/app\n\ngo 1.23\n"), 0o644); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+	mod, ver, ok := readGoModInfo(gomod)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if mod != "example.com/app" {
+		t.Errorf("module = %q, want example.com/app", mod)
+	}
+	if ver != "1.23" {
+		t.Errorf("goVer = %q, want 1.23", ver)
+	}
+}
+
+func TestReadGoModInfo_Missing(t *testing.T) {
+	_, _, ok := readGoModInfo(filepath.Join(t.TempDir(), "does-not-exist"))
+	if ok {
+		t.Fatal("expected ok=false for missing file")
+	}
+}
+
+func TestComputeDrift_NoTarget(t *testing.T) {
+	status, count, msg := computeDrift(context.Background(), t.TempDir(), "", nil)
+	if status != "unknown" || count != 0 || msg == "" {
+		t.Errorf("got (%s, %d, %q); want (unknown, 0, non-empty)", status, count, msg)
+	}
+}
+
+func TestComputeDrift_MissingTargetDir(t *testing.T) {
+	status, count, _ := computeDrift(context.Background(), t.TempDir(), "v1", nil)
+	if status != "error" || count != 0 {
+		t.Errorf("got (%s, %d); want (error, 0)", status, count)
+	}
+}
+
+// TestHandleDashboard_EmptyProject exercises the happy path on a project
+// with no overlay, no target, and no Go packages. The handler should
+// still return 200 with the standard dashboard sections.
+func TestHandleDashboard_EmptyProject(t *testing.T) {
+	ts := newTestServer(t)
+	defer ts.Close()
+
+	resp, err := ts.Client().Get(ts.URL + "/")
+	if err != nil {
+		t.Fatalf("GET /: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != nethttp.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	s := string(body)
+	for _, want := range []string{"Module", "Target", "Counts", "packages", "no target selected"} {
+		if !strings.Contains(s, want) {
+			t.Errorf("dashboard missing %q: %s", want, truncate(s, 400))
+		}
+	}
+}
+
+// TestHandleDashboard_WithFixture uses a project with a real go.mod +
+// overlay + source packages so the handler populates every section.
+func TestHandleDashboard_WithFixture(t *testing.T) {
+	ts, _ := newFixtureServer(t)
+	defer ts.Close()
+
+	resp, err := ts.Client().Get(ts.URL + "/")
+	if err != nil {
+		t.Fatalf("GET /: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != nethttp.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, body = %s", resp.StatusCode, string(body))
+	}
+	body, _ := io.ReadAll(resp.Body)
+	s := string(body)
+	// Module name from the fixture go.mod.
+	if !strings.Contains(s, "example.com/fixture") {
+		t.Errorf("expected module path in dashboard, body:\n%s", truncate(s, 400))
+	}
+	// Go version from the fixture go.mod.
+	if !strings.Contains(s, "Go 1.21") {
+		t.Errorf("expected Go 1.21 in dashboard, body:\n%s", truncate(s, 400))
+	}
+	// Layer map SVG preview should be inlined (renderD2 always emits <svg).
+	if !strings.Contains(s, "<svg") {
+		t.Errorf("expected inline <svg for layer map preview, body:\n%s", truncate(s, 400))
+	}
+}
+
+// TestDashboardCounts_AggregatesAcrossPackages ensures the handler
+// sums interfaces/structs/functions across every package rather than
+// reporting per-package counts.
+func TestDashboardCounts_AggregatesAcrossPackages(t *testing.T) {
+	// Exercised through the helper: build a synthetic snapshot by
+	// constructing dashboardData the same way the handler does so
+	// the counting logic is covered without spinning a full server.
+	pkgs := []domain.PackageModel{
+		{
+			Path:       "internal/a",
+			Interfaces: []domain.InterfaceDef{{Name: "I"}},
+			Structs:    []domain.StructDef{{Name: "S"}},
+			Functions:  []domain.FunctionDef{{Name: "F"}},
+		},
+		{
+			Path:      "internal/b",
+			TypeDefs:  []domain.TypeDef{{Name: "T"}},
+			Functions: []domain.FunctionDef{{Name: "G"}, {Name: "H"}},
+		},
+	}
+	var data dashboardData
+	for _, p := range pkgs {
+		data.PackageCount++
+		data.InterfaceCount += len(p.Interfaces)
+		data.FunctionCount += len(p.Functions)
+		data.TypeCount += len(p.Structs) + len(p.Interfaces) + len(p.TypeDefs)
+	}
+	if data.PackageCount != 2 {
+		t.Errorf("PackageCount = %d, want 2", data.PackageCount)
+	}
+	if data.InterfaceCount != 1 {
+		t.Errorf("InterfaceCount = %d, want 1", data.InterfaceCount)
+	}
+	if data.FunctionCount != 3 {
+		t.Errorf("FunctionCount = %d, want 3", data.FunctionCount)
+	}
+	// structs(1) + interfaces(1) + typedefs(1) = 3.
+	if data.TypeCount != 3 {
+		t.Errorf("TypeCount = %d, want 3", data.TypeCount)
+	}
+}

--- a/internal/adapter/http/handlers.go
+++ b/internal/adapter/http/handlers.go
@@ -3,9 +3,19 @@ package http
 import (
 	"bytes"
 	"fmt"
+	"html/template"
 	"io"
 	nethttp "net/http"
 )
+
+// templateFuncs returns the funcmap shared by every page template.
+// safeHTML lets a handler inline trusted HTML (e.g. a server-rendered
+// SVG diagram) without html/template escaping it.
+func templateFuncs() template.FuncMap {
+	return template.FuncMap{
+		"safeHTML": func(s string) template.HTML { return template.HTML(s) },
+	}
+}
 
 // navItem is one link in the top navigation bar. Active is set on the
 // link matching the current page so the base template can highlight
@@ -48,7 +58,7 @@ func (s *Server) routes(mux *nethttp.ServeMux) {
 
 	// Nav pages. The root handler must stay last so it doesn't shadow
 	// more-specific routes.
-	mux.HandleFunc("/layers", s.pageHandler("layers.html", "Layers", "/layers"))
+	mux.HandleFunc("/layers", s.handleLayers)
 	mux.HandleFunc("/packages", s.pageHandler("packages.html", "Packages", "/packages"))
 	mux.HandleFunc("/configs", s.pageHandler("configs.html", "Configs", "/configs"))
 	mux.HandleFunc("/search", s.pageHandler("search.html", "Search", "/search"))
@@ -56,18 +66,7 @@ func (s *Server) routes(mux *nethttp.ServeMux) {
 	// for /diff and /targets and add sub-routes for target switching +
 	// cross-target comparison.
 	s.registerDiffTargetsRoutes(mux)
-	mux.HandleFunc("/", s.handleIndex)
-}
-
-// handleIndex serves the dashboard at "/". net/http's ServeMux routes
-// every unmatched path to "/", so we reject anything that isn't the
-// root with a 404 to keep URLs predictable.
-func (s *Server) handleIndex(w nethttp.ResponseWriter, r *nethttp.Request) {
-	if r.URL.Path != "/" {
-		nethttp.NotFound(w, r)
-		return
-	}
-	s.pageHandler("index.html", "Dashboard", "/")(w, r)
+	mux.HandleFunc("/", s.handleDashboard)
 }
 
 // pageHandler returns a handler that renders the named template inside

--- a/internal/adapter/http/layers.go
+++ b/internal/adapter/http/layers.go
@@ -1,0 +1,404 @@
+package http
+
+import (
+	"fmt"
+	nethttp "net/http"
+	"sort"
+	"strings"
+
+	"github.com/kgatilin/archai/internal/domain"
+	"github.com/kgatilin/archai/internal/overlay"
+)
+
+// layersData is the model passed to layers.html. When the project has
+// no overlay Overlay=false and the template renders an empty-state
+// explanation instead of the diagram.
+type layersData struct {
+	pageData
+
+	HasOverlay bool
+	Module     string
+
+	Layers          []layerView // one entry per layer in lexical order
+	Violations      []edgeView  // forbidden cross-layer edges (deduplicated)
+	AllowedEdges    []edgeView  // allowed cross-layer edges observed in code
+	DeclaredEdges   []edgeView  // declared-but-unused edges from LayerRules
+	ViolationsCount int         // total package-pairs with violations
+
+	LayersSVG string // D2 diagram rendered as SVG (empty on render failure)
+}
+
+// layerView describes one layer on the Layers page.
+type layerView struct {
+	Name     string
+	Packages []layerPackage // packages in this layer, sorted by relative path
+}
+
+// layerPackage represents a package inside a layer. Rel is the
+// module-relative path (used as anchor target); Name is the trailing
+// component to show as the link label.
+type layerPackage struct {
+	Rel  string
+	Name string
+}
+
+// edgeView describes a directed edge between two layers. Color is
+// "green" for allowed edges and "red" for violations so the template
+// can style them without branching on meaning.
+type edgeView struct {
+	From    string
+	To      string
+	Color   string
+	Details []string // human-readable "pkg -> pkg" details backing the edge
+}
+
+// handleLayers renders the Layers page. It reads a snapshot of the
+// state and derives layer membership, allowed/violating edges, and a
+// D2 diagram from the overlay config.
+func (s *Server) handleLayers(w nethttp.ResponseWriter, r *nethttp.Request) {
+	snap := s.state.Snapshot()
+	data := layersData{
+		pageData: pageData{
+			Title:      "Layers",
+			ActivePath: "/layers",
+			NavItems:   buildNav("/layers"),
+		},
+	}
+
+	if snap.Overlay == nil || len(snap.Overlay.Layers) == 0 {
+		s.renderPage(w, "layers.html", data)
+		return
+	}
+
+	data.HasOverlay = true
+	data.Module = snap.Overlay.Module
+	data.Layers = buildLayerViews(snap.Overlay, snap.Packages)
+	data.Violations, data.AllowedEdges, data.DeclaredEdges = buildLayerEdges(snap.Overlay, snap.Packages)
+	for _, v := range data.Violations {
+		data.ViolationsCount += len(v.Details)
+	}
+
+	src := buildLayerMapD2(snap.Overlay, snap.Packages, true)
+	if svg, err := renderD2(r.Context(), src); err == nil {
+		data.LayersSVG = string(svg)
+	}
+
+	s.renderPage(w, "layers.html", data)
+}
+
+// buildLayerViews constructs one layerView per layer, with packages
+// assigned to that layer via overlay globs. The layer ordering is
+// lexical so reloads produce stable HTML.
+func buildLayerViews(cfg *overlay.Config, packages []domain.PackageModel) []layerView {
+	layerNames := make([]string, 0, len(cfg.Layers))
+	for name := range cfg.Layers {
+		layerNames = append(layerNames, name)
+	}
+	sort.Strings(layerNames)
+
+	// Assign each package to the first layer whose glob it matches
+	// (same rule as overlay.Merge, kept local to avoid mutating the
+	// caller's models slice just to read membership).
+	pkgLayer := computePackageLayers(cfg, packages)
+
+	views := make([]layerView, 0, len(layerNames))
+	for _, name := range layerNames {
+		var pkgs []layerPackage
+		for _, p := range packages {
+			rel := moduleRel(cfg.Module, p.Path)
+			if pkgLayer[p.Path] != name {
+				continue
+			}
+			pkgs = append(pkgs, layerPackage{
+				Rel:  rel,
+				Name: shortName(rel),
+			})
+		}
+		sort.Slice(pkgs, func(i, j int) bool { return pkgs[i].Rel < pkgs[j].Rel })
+		views = append(views, layerView{Name: name, Packages: pkgs})
+	}
+	return views
+}
+
+// buildLayerEdges derives three edge groups for the Layers page:
+//   - violations: cross-layer edges observed in code that LayerRules forbid.
+//   - allowed:    cross-layer edges observed in code that LayerRules allow.
+//   - declared:   edges declared in LayerRules but not observed in code yet.
+func buildLayerEdges(cfg *overlay.Config, packages []domain.PackageModel) (violations, allowed, declared []edgeView) {
+	pkgLayer := computePackageLayers(cfg, packages)
+
+	allowSet := make(map[string]map[string]struct{}, len(cfg.LayerRules))
+	for src, targets := range cfg.LayerRules {
+		inner := make(map[string]struct{}, len(targets))
+		for _, t := range targets {
+			inner[t] = struct{}{}
+		}
+		allowSet[src] = inner
+	}
+
+	type edgeKey struct{ from, to string }
+	type edgeAcc struct {
+		details map[string]struct{}
+	}
+	addDetail := func(m map[edgeKey]*edgeAcc, k edgeKey, detail string) {
+		if _, ok := m[k]; !ok {
+			m[k] = &edgeAcc{details: make(map[string]struct{})}
+		}
+		m[k].details[detail] = struct{}{}
+	}
+
+	violationAcc := make(map[edgeKey]*edgeAcc)
+	allowedAcc := make(map[edgeKey]*edgeAcc)
+
+	for _, p := range packages {
+		fromLayer := pkgLayer[p.Path]
+		if fromLayer == "" {
+			continue
+		}
+		for _, dep := range p.Dependencies {
+			if dep.To.External {
+				continue
+			}
+			// Normalize the import target to a module-relative path so
+			// it lines up with PackageModel.Path (which is how pkgLayer
+			// is keyed). Dependencies from the Go reader are
+			// fully-qualified; from the YAML reader they may already
+			// be relative — the helper handles both.
+			toRel := moduleRel(cfg.Module, dep.To.Package)
+			if toRel == p.Path {
+				continue
+			}
+			toLayer, ok := pkgLayer[toRel]
+			if !ok || toLayer == "" || toLayer == fromLayer {
+				continue
+			}
+			key := edgeKey{from: fromLayer, to: toLayer}
+			detail := fmt.Sprintf("%s -> %s", p.Path, toRel)
+
+			rules, hasRule := allowSet[fromLayer]
+			if !hasRule {
+				// No outbound rules declared: every cross-layer dep is a violation.
+				addDetail(violationAcc, key, detail)
+				continue
+			}
+			if _, ok := rules[toLayer]; ok {
+				addDetail(allowedAcc, key, detail)
+				continue
+			}
+			addDetail(violationAcc, key, detail)
+		}
+	}
+
+	// Declared-but-unused edges: every LayerRules entry that wasn't
+	// observed as "allowed" in code.
+	declaredSeen := make(map[edgeKey]struct{})
+	for src, targets := range cfg.LayerRules {
+		for _, t := range targets {
+			k := edgeKey{from: src, to: t}
+			if _, obs := allowedAcc[k]; obs {
+				continue
+			}
+			declaredSeen[k] = struct{}{}
+		}
+	}
+
+	flatten := func(m map[edgeKey]*edgeAcc, color string) []edgeView {
+		out := make([]edgeView, 0, len(m))
+		for k, v := range m {
+			details := make([]string, 0, len(v.details))
+			for d := range v.details {
+				details = append(details, d)
+			}
+			sort.Strings(details)
+			out = append(out, edgeView{
+				From:    k.from,
+				To:      k.to,
+				Color:   color,
+				Details: details,
+			})
+		}
+		sort.Slice(out, func(i, j int) bool {
+			if out[i].From != out[j].From {
+				return out[i].From < out[j].From
+			}
+			return out[i].To < out[j].To
+		})
+		return out
+	}
+
+	violations = flatten(violationAcc, "red")
+	allowed = flatten(allowedAcc, "green")
+
+	declared = make([]edgeView, 0, len(declaredSeen))
+	for k := range declaredSeen {
+		declared = append(declared, edgeView{
+			From:  k.from,
+			To:    k.to,
+			Color: "gray",
+		})
+	}
+	sort.Slice(declared, func(i, j int) bool {
+		if declared[i].From != declared[j].From {
+			return declared[i].From < declared[j].From
+		}
+		return declared[i].To < declared[j].To
+	})
+	return violations, allowed, declared
+}
+
+// buildLayerMapD2 assembles a compact D2 source for the layer map.
+// When detailed=true each layer node shows a package count and inter-
+// layer edges are annotated with their kind (allowed / violation).
+// When detailed=false only layers + allowed edges are drawn, suitable
+// for the small dashboard preview.
+func buildLayerMapD2(cfg *overlay.Config, packages []domain.PackageModel, detailed bool) string {
+	var b strings.Builder
+
+	pkgLayer := computePackageLayers(cfg, packages)
+	pkgCount := make(map[string]int)
+	for _, p := range packages {
+		if l := pkgLayer[p.Path]; l != "" {
+			pkgCount[l]++
+		}
+	}
+
+	layerNames := make([]string, 0, len(cfg.Layers))
+	for name := range cfg.Layers {
+		layerNames = append(layerNames, name)
+	}
+	sort.Strings(layerNames)
+
+	for _, name := range layerNames {
+		id := d2ID(name)
+		label := name
+		if detailed {
+			label = fmt.Sprintf("%s (%d)", name, pkgCount[name])
+		}
+		fmt.Fprintf(&b, "%s: %q\n", id, label)
+	}
+
+	violations, allowed, declared := buildLayerEdges(cfg, packages)
+
+	// Declared (gray dashed) — drawn first so code-backed edges layer on top.
+	if detailed {
+		for _, e := range declared {
+			fmt.Fprintf(&b, "%s -> %s: {style.stroke: \"#9ca3af\"; style.stroke-dash: 3}\n",
+				d2ID(e.From), d2ID(e.To))
+		}
+	}
+	// Allowed (green).
+	for _, e := range allowed {
+		fmt.Fprintf(&b, "%s -> %s: {style.stroke: \"#16a34a\"}\n", d2ID(e.From), d2ID(e.To))
+	}
+	// Violations (red). Only drawn in detailed view so the dashboard
+	// preview stays clean; the full Layers page is where violations live.
+	if detailed {
+		for _, e := range violations {
+			fmt.Fprintf(&b, "%s -> %s: violation {style.stroke: \"#dc2626\"; style.stroke-width: 2}\n",
+				d2ID(e.From), d2ID(e.To))
+		}
+	}
+
+	return b.String()
+}
+
+// computePackageLayers returns a map from PackageModel.Path to the
+// layer name assigned by the overlay. Packages that match no layer
+// are absent from the map.
+func computePackageLayers(cfg *overlay.Config, packages []domain.PackageModel) map[string]string {
+	out := make(map[string]string, len(packages))
+	layerNames := make([]string, 0, len(cfg.Layers))
+	for name := range cfg.Layers {
+		layerNames = append(layerNames, name)
+	}
+	sort.Strings(layerNames)
+
+	for _, p := range packages {
+		rel := moduleRel(cfg.Module, p.Path)
+		for _, layer := range layerNames {
+			if matchLayerGlobs(cfg.Layers[layer], rel) {
+				out[p.Path] = layer
+				break
+			}
+		}
+	}
+	return out
+}
+
+// matchLayerGlobs returns true when any of globs matches pkgPath.
+// Duplicates overlay.matchGlob semantics (trailing "..." = recursive
+// prefix; trailing "*" = single-segment wildcard; else exact).
+// Kept local so the http adapter stays decoupled from overlay internals.
+func matchLayerGlobs(globs []string, pkgPath string) bool {
+	for _, g := range globs {
+		if g == "..." {
+			return true
+		}
+		if strings.HasSuffix(g, "/...") {
+			prefix := strings.TrimSuffix(g, "/...")
+			if pkgPath == prefix || strings.HasPrefix(pkgPath, prefix+"/") {
+				return true
+			}
+			continue
+		}
+		if strings.HasSuffix(g, "/*") {
+			prefix := strings.TrimSuffix(g, "/*")
+			if !strings.HasPrefix(pkgPath, prefix+"/") {
+				continue
+			}
+			rest := pkgPath[len(prefix)+1:]
+			if rest != "" && !strings.Contains(rest, "/") {
+				return true
+			}
+			continue
+		}
+		if g == pkgPath {
+			return true
+		}
+	}
+	return false
+}
+
+// moduleRel strips the module prefix from a fully-qualified package
+// path. An input without the module prefix is returned unchanged,
+// which is the format used throughout the archai model.
+func moduleRel(module, pkgPath string) string {
+	if module == "" {
+		return pkgPath
+	}
+	if pkgPath == module {
+		return ""
+	}
+	if strings.HasPrefix(pkgPath, module+"/") {
+		return strings.TrimPrefix(pkgPath, module+"/")
+	}
+	return pkgPath
+}
+
+// shortName returns the trailing path component of rel, suitable as a
+// human-readable label in the layer view.
+func shortName(rel string) string {
+	if rel == "" {
+		return "."
+	}
+	if idx := strings.LastIndex(rel, "/"); idx >= 0 {
+		return rel[idx+1:]
+	}
+	return rel
+}
+
+// d2ID returns a D2-safe node id for s. D2 accepts most unicode in ids
+// but chokes on spaces, dashes at the start, and reserved punctuation
+// — a simple alphanumeric-with-underscores encoding is safest.
+func d2ID(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	return b.String()
+}

--- a/internal/adapter/http/layers_test.go
+++ b/internal/adapter/http/layers_test.go
@@ -1,0 +1,299 @@
+package http
+
+import (
+	"context"
+	"io"
+	nethttp "net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kgatilin/archai/internal/domain"
+	"github.com/kgatilin/archai/internal/overlay"
+	"github.com/kgatilin/archai/internal/serve"
+)
+
+// sampleOverlay is the three-layer overlay shared by most layers_test
+// cases (domain → service → adapter hexagonal style).
+func sampleOverlay() *overlay.Config {
+	return &overlay.Config{
+		Module: "example.com/app",
+		Layers: map[string][]string{
+			"domain":  {"internal/domain/..."},
+			"service": {"internal/service/..."},
+			"adapter": {"internal/adapter/..."},
+		},
+		LayerRules: map[string][]string{
+			"service": {"domain"},
+			"adapter": {"domain", "service"},
+			"domain":  {},
+		},
+	}
+}
+
+func TestComputePackageLayers_AssignsFromGlobs(t *testing.T) {
+	cfg := sampleOverlay()
+	pkgs := []domain.PackageModel{
+		{Path: "internal/domain"},
+		{Path: "internal/domain/order"},
+		{Path: "internal/service"},
+		{Path: "internal/adapter/yaml"},
+		{Path: "tests/integration"},
+	}
+	got := computePackageLayers(cfg, pkgs)
+	want := map[string]string{
+		"internal/domain":       "domain",
+		"internal/domain/order": "domain",
+		"internal/service":      "service",
+		"internal/adapter/yaml": "adapter",
+	}
+	for path, layer := range want {
+		if got[path] != layer {
+			t.Errorf("%s: got layer %q, want %q", path, got[path], layer)
+		}
+	}
+	if _, ok := got["tests/integration"]; ok {
+		t.Errorf("tests/integration should not be assigned a layer, got %q", got["tests/integration"])
+	}
+}
+
+func TestBuildLayerEdges_SplitsAllowedAndViolations(t *testing.T) {
+	cfg := sampleOverlay()
+	pkgs := []domain.PackageModel{
+		{
+			Path: "internal/service",
+			Dependencies: []domain.Dependency{
+				// service -> domain: allowed.
+				{To: domain.SymbolRef{Package: "example.com/app/internal/domain", Symbol: "Thing"}},
+			},
+		},
+		{
+			Path: "internal/domain",
+			Dependencies: []domain.Dependency{
+				// domain -> service: violation (domain has empty rules).
+				{To: domain.SymbolRef{Package: "example.com/app/internal/service", Symbol: "Svc"}},
+			},
+		},
+		{Path: "internal/adapter/yaml"},
+	}
+
+	violations, allowed, declared := buildLayerEdges(cfg, pkgs)
+
+	if len(violations) != 1 {
+		t.Fatalf("violations: got %d, want 1 (%+v)", len(violations), violations)
+	}
+	if violations[0].From != "domain" || violations[0].To != "service" {
+		t.Errorf("violation edge: got %s -> %s, want domain -> service", violations[0].From, violations[0].To)
+	}
+	if violations[0].Color != "red" {
+		t.Errorf("violation color: got %q, want red", violations[0].Color)
+	}
+	if len(violations[0].Details) != 1 || !strings.Contains(violations[0].Details[0], "internal/domain -> internal/service") {
+		t.Errorf("violation details unexpected: %v", violations[0].Details)
+	}
+
+	if len(allowed) != 1 {
+		t.Fatalf("allowed: got %d, want 1 (%+v)", len(allowed), allowed)
+	}
+	if allowed[0].From != "service" || allowed[0].To != "domain" {
+		t.Errorf("allowed edge: got %s -> %s, want service -> domain", allowed[0].From, allowed[0].To)
+	}
+	if allowed[0].Color != "green" {
+		t.Errorf("allowed color: got %q, want green", allowed[0].Color)
+	}
+
+	// adapter -> {domain, service} is declared but unused here.
+	declaredSet := make(map[string]bool)
+	for _, e := range declared {
+		declaredSet[e.From+"->"+e.To] = true
+	}
+	for _, key := range []string{"adapter->domain", "adapter->service"} {
+		if !declaredSet[key] {
+			t.Errorf("missing declared edge %q in %v", key, declaredSet)
+		}
+	}
+}
+
+func TestBuildLayerEdges_SkipsExternalAndSelfDeps(t *testing.T) {
+	cfg := sampleOverlay()
+	pkgs := []domain.PackageModel{
+		{
+			Path: "internal/service",
+			Dependencies: []domain.Dependency{
+				{To: domain.SymbolRef{Package: "context", Symbol: "Context", External: true}},
+				{To: domain.SymbolRef{Package: "example.com/app/internal/service", Symbol: "Self"}},
+			},
+		},
+		{Path: "internal/domain"},
+	}
+	violations, allowed, _ := buildLayerEdges(cfg, pkgs)
+	if len(violations) != 0 {
+		t.Errorf("violations should be empty, got %+v", violations)
+	}
+	if len(allowed) != 0 {
+		t.Errorf("allowed should be empty, got %+v", allowed)
+	}
+}
+
+func TestBuildLayerMapD2_RendersNodesAndEdges(t *testing.T) {
+	cfg := sampleOverlay()
+	pkgs := []domain.PackageModel{
+		{
+			Path: "internal/service",
+			Dependencies: []domain.Dependency{
+				{To: domain.SymbolRef{Package: "example.com/app/internal/domain", Symbol: "Thing"}},
+			},
+		},
+		{Path: "internal/domain"},
+	}
+	src := buildLayerMapD2(cfg, pkgs, true)
+
+	// Every layer must appear as a node.
+	for _, expect := range []string{"domain:", "service:", "adapter:"} {
+		if !strings.Contains(src, expect) {
+			t.Errorf("expected D2 source to contain %q, got:\n%s", expect, src)
+		}
+	}
+	// The allowed green edge must be present.
+	if !strings.Contains(src, "service -> domain") {
+		t.Errorf("expected edge service -> domain in D2 source:\n%s", src)
+	}
+	// And the D2 source must actually render to SVG.
+	svg, err := renderD2(context.Background(), src)
+	if err != nil {
+		t.Fatalf("renderD2: %v\nsource:\n%s", err, src)
+	}
+	if !strings.Contains(string(svg), "<svg") {
+		t.Fatalf("rendered output missing <svg tag")
+	}
+}
+
+func TestMatchLayerGlobs(t *testing.T) {
+	cases := []struct {
+		name  string
+		globs []string
+		path  string
+		want  bool
+	}{
+		{"recursive match", []string{"internal/foo/..."}, "internal/foo/bar", true},
+		{"recursive match self", []string{"internal/foo/..."}, "internal/foo", true},
+		{"recursive miss", []string{"internal/foo/..."}, "internal/bar", false},
+		{"single-wildcard match", []string{"cmd/*"}, "cmd/archai", true},
+		{"single-wildcard no nested match", []string{"cmd/*"}, "cmd/archai/sub", false},
+		{"exact match", []string{"internal/foo"}, "internal/foo", true},
+		{"exact miss", []string{"internal/foo"}, "internal/bar", false},
+		{"ellipsis root", []string{"..."}, "anything", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := matchLayerGlobs(tc.globs, tc.path)
+			if got != tc.want {
+				t.Errorf("matchLayerGlobs(%v, %q) = %v, want %v", tc.globs, tc.path, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestModuleRel(t *testing.T) {
+	mod := "example.com/app"
+	cases := map[string]string{
+		"example.com/app":              "",
+		"example.com/app/internal/foo": "internal/foo",
+		"internal/foo":                 "internal/foo", // already relative
+		"other.com/lib":                "other.com/lib",
+	}
+	for in, want := range cases {
+		if got := moduleRel(mod, in); got != want {
+			t.Errorf("moduleRel(%q, %q) = %q, want %q", mod, in, got, want)
+		}
+	}
+}
+
+// TestHandleLayers_NoOverlay confirms the page renders a no-overlay
+// empty state when the state carries no archai.yaml.
+func TestHandleLayers_NoOverlay(t *testing.T) {
+	ts := newTestServer(t)
+	defer ts.Close()
+
+	resp, err := ts.Client().Get(ts.URL + "/layers")
+	if err != nil {
+		t.Fatalf("GET /layers: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != nethttp.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "No overlay") {
+		t.Errorf("expected empty-state message, got: %s", truncate(string(body), 400))
+	}
+}
+
+// TestHandleLayers_WithOverlay boots a real Server backed by a fixture
+// project tree so the full handler path (snapshot → build views → D2
+// render) runs end-to-end.
+func TestHandleLayers_WithOverlay(t *testing.T) {
+	ts, _ := newFixtureServer(t)
+	defer ts.Close()
+
+	resp, err := ts.Client().Get(ts.URL + "/layers")
+	if err != nil {
+		t.Fatalf("GET /layers: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != nethttp.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, body = %s", resp.StatusCode, string(body))
+	}
+	body, _ := io.ReadAll(resp.Body)
+	s := string(body)
+	// Layer names, diagram and legend pills must all be present.
+	for _, want := range []string{"domain", "Layer map", "allowed", "violation"} {
+		if !strings.Contains(s, want) {
+			t.Errorf("/layers body missing %q: %s", want, truncate(s, 400))
+		}
+	}
+}
+
+// newFixtureServer builds a tiny Go fixture project with an overlay,
+// loads it into a serve.State, wires up a Server, and returns an
+// httptest.Server. The caller must Close() the returned server.
+func newFixtureServer(t *testing.T) (*httptest.Server, *serve.State) {
+	t.Helper()
+	root := t.TempDir()
+
+	writeFile := func(path, content string) {
+		t.Helper()
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+
+	writeFile(filepath.Join(root, "go.mod"), "module example.com/fixture\n\ngo 1.21\n")
+	writeFile(filepath.Join(root, "internal", "domain", "thing.go"),
+		"package domain\n\ntype Thing struct{}\n")
+	writeFile(filepath.Join(root, "archai.yaml"), `module: example.com/fixture
+layers:
+  domain:
+    - "internal/domain/..."
+layer_rules:
+  domain: []
+`)
+
+	state := serve.NewState(root)
+	if err := state.Load(context.Background()); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	srv, err := NewServer(state)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	mux := nethttp.NewServeMux()
+	srv.routes(mux)
+	return httptest.NewServer(mux), state
+}

--- a/internal/adapter/http/server.go
+++ b/internal/adapter/http/server.go
@@ -42,7 +42,7 @@ func NewServer(state *serve.State) (*Server, error) {
 		return nil, errors.New("http: nil state")
 	}
 
-	tmpls, err := template.ParseFS(embedded, "templates/*.html")
+	tmpls, err := template.New("").Funcs(templateFuncs()).ParseFS(embedded, "templates/*.html")
 	if err != nil {
 		return nil, fmt.Errorf("http: parse templates: %w", err)
 	}

--- a/internal/adapter/http/templates/index.html
+++ b/internal/adapter/http/templates/index.html
@@ -1,8 +1,59 @@
 {{define "content"}}
 <h1>Dashboard</h1>
-<p class="lede">High-level overview of the current architecture model.</p>
-<div class="coming-soon">
-    <div class="tag">M7b</div>
-    <p>Dashboard content is coming in M7b — summary counts, active target, overlay status, recent reloads.</p>
-</div>
+<p class="lede">Live overview of the project's architecture model.</p>
+
+<section class="dash-grid">
+    <div class="card">
+        <h2>Module</h2>
+        {{if .Module}}
+            <p class="mono">{{.Module}}</p>
+        {{else}}
+            <p class="muted">no module detected</p>
+        {{end}}
+        {{if .GoVersion}}
+            <p class="muted">Go {{.GoVersion}}</p>
+        {{end}}
+    </div>
+
+    <div class="card">
+        <h2>Target</h2>
+        {{if .HasTarget}}
+            <p class="mono">{{.CurrentTarget}}</p>
+            {{if eq .DriftStatus "matches"}}
+                <p><span class="pill pill-green">matches</span></p>
+            {{else if eq .DriftStatus "drifted"}}
+                <p><span class="pill pill-red">drifted</span> <span class="muted">{{.DriftCount}} change(s)</span></p>
+            {{else}}
+                <p><span class="pill pill-gray">{{.DriftStatus}}</span></p>
+            {{end}}
+            {{if .DriftMessage}}
+                <p class="muted small">{{.DriftMessage}}</p>
+            {{end}}
+        {{else}}
+            <p class="muted">no target selected</p>
+            <p class="muted small">{{.DriftMessage}}</p>
+        {{end}}
+    </div>
+
+    <div class="card">
+        <h2>Counts</h2>
+        <ul class="stat-list">
+            <li><span class="stat-num">{{.PackageCount}}</span> packages</li>
+            <li><span class="stat-num">{{.TypeCount}}</span> types</li>
+            <li><span class="stat-num">{{.FunctionCount}}</span> functions</li>
+            <li><span class="stat-num">{{.InterfaceCount}}</span> interfaces</li>
+        </ul>
+    </div>
+</section>
+
+<section class="card layer-preview">
+    <h2>Layer map</h2>
+    {{if .LayerMapSVG}}
+        <a href="/layers" class="diagram-link" aria-label="Open Layers view">
+            <div class="diagram-frame small">{{.LayerMapSVG | safeHTML}}</div>
+        </a>
+    {{else}}
+        <p class="muted">Layer map unavailable — no overlay (archai.yaml) loaded.</p>
+    {{end}}
+</section>
 {{end}}

--- a/internal/adapter/http/templates/layers.html
+++ b/internal/adapter/http/templates/layers.html
@@ -1,8 +1,88 @@
 {{define "content"}}
 <h1>Layers</h1>
-<p class="lede">Overlay layers and their package membership.</p>
+<p class="lede">Architectural layers declared in <code>archai.yaml</code> with cross-layer dependency edges.</p>
+
+{{if not .HasOverlay}}
 <div class="coming-soon">
-    <div class="tag">M7c</div>
-    <p>Layer browser is coming in M7c — hierarchy, rules, violations.</p>
+    <div class="tag">no overlay</div>
+    <p>No overlay (<code>archai.yaml</code>) was found for this project. Add one to declare layers and inter-layer rules.</p>
 </div>
+{{else}}
+
+<section class="card">
+    <h2>Layer map</h2>
+    {{if .LayersSVG}}
+        <div class="diagram-frame">{{.LayersSVG | safeHTML}}</div>
+    {{else}}
+        <p class="muted">Diagram could not be rendered.</p>
+    {{end}}
+    <p class="legend">
+        <span class="pill pill-green">allowed</span>
+        <span class="pill pill-red">violation</span>
+        <span class="pill pill-gray">declared, unused</span>
+    </p>
+</section>
+
+<section class="layer-grid">
+    {{range .Layers}}
+        <div class="card layer-card">
+            <h3>{{.Name}}</h3>
+            {{if .Packages}}
+                <ul class="pkg-list">
+                    {{range .Packages}}
+                        <li><a href="/packages#{{.Rel}}" class="pkg-link" title="{{.Rel}}">{{.Name}}</a></li>
+                    {{end}}
+                </ul>
+            {{else}}
+                <p class="muted small">no packages match this layer</p>
+            {{end}}
+        </div>
+    {{end}}
+</section>
+
+<section class="card">
+    <h2>Inter-layer edges</h2>
+    {{if .Violations}}
+        <h3 class="edge-head edge-head-red">Violations ({{.ViolationsCount}})</h3>
+        <ul class="edge-list">
+        {{range .Violations}}
+            <li>
+                <span class="pill pill-red">{{.From}} → {{.To}}</span>
+                <ul class="edge-detail">
+                    {{range .Details}}<li><code>{{.}}</code></li>{{end}}
+                </ul>
+            </li>
+        {{end}}
+        </ul>
+    {{end}}
+
+    {{if .AllowedEdges}}
+        <h3 class="edge-head edge-head-green">Allowed (observed in code)</h3>
+        <ul class="edge-list">
+        {{range .AllowedEdges}}
+            <li>
+                <span class="pill pill-green">{{.From}} → {{.To}}</span>
+                <ul class="edge-detail">
+                    {{range .Details}}<li><code>{{.}}</code></li>{{end}}
+                </ul>
+            </li>
+        {{end}}
+        </ul>
+    {{end}}
+
+    {{if .DeclaredEdges}}
+        <h3 class="edge-head edge-head-gray">Declared but unused</h3>
+        <ul class="edge-list">
+        {{range .DeclaredEdges}}
+            <li><span class="pill pill-gray">{{.From}} → {{.To}}</span></li>
+        {{end}}
+        </ul>
+    {{end}}
+
+    {{if and (not .Violations) (not .AllowedEdges) (not .DeclaredEdges)}}
+        <p class="muted">No inter-layer edges observed.</p>
+    {{end}}
+</section>
+
+{{end}}
 {{end}}


### PR DESCRIPTION
## Summary

Delivers the M7b browser views on top of the M7a HTTP skeleton.

**Dashboard (`/`)**
- Module path + Go version (from `go.mod`)
- Active target id + drift status (`matches` / `drifted N change(s)` / `unknown`)
- Counts: packages, types (structs+interfaces+typedefs), functions, interfaces
- Small inline D2 SVG layer-map preview that links to `/layers`

**Layers (`/layers`)**
- D2 SVG layer diagram with edges colored green (allowed), red (violation), gray-dashed (declared but unused)
- One card per layer listing its member packages with anchor links to `/packages#<pkg>` for M7c
- Itemized inter-layer edge list (violations → allowed → declared) with the specific `pkg -> pkg` pairs backing each edge
- Clean empty-state when no `archai.yaml` overlay is present

Under the hood:
- New `dashboard.go` / `layers.go` handlers read a `state.Snapshot()` and compute views
- Shared `buildLayerMapD2` emitter (detailed + preview variants) feeding `renderD2`
- Drift computed by `diff.Compute(current, target)` loaded via the YAML adapter
- `safeHTML` template func lets handlers inline trusted server-rendered SVG
- Routes in `handlers.go` now dispatch `/` → `handleDashboard`, `/layers` → `handleLayers`; `renderPage` accepts any page struct that embeds `pageData`

## Acceptance Criteria

- [x] Dashboard shows project overview with live data
- [x] Layers view renders layer diagram
- [x] Violation edges highlighted in red
- [x] Navigation between views works (nav bar + dashboard preview → layers)

## Tests

- Helper unit tests: `computePackageLayers`, `buildLayerEdges`, `buildLayerMapD2`, `matchLayerGlobs`, `moduleRel`, `readGoModInfo`, `computeDrift`
- Handler end-to-end tests using an `httptest.Server` backed by a fixture Go module with real `go.mod` + `archai.yaml` — exercises the full snapshot → template → D2 render path

## Test plan

- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] `gofmt -l internal/adapter/http/` clean
- [x] `go run ./cmd/archai overlay check` still OK
- [x] `go build ./cmd/archai` succeeds

Closes #22. Depends on #21 (M7a, merged).