### PR TITLE
feat: M7e diff + targets views (#25)

### DIFF
--- a/internal/adapter/http/assets/styles.css
+++ b/internal/adapter/http/assets/styles.css
@@ -141,3 +141,366 @@ a {
     font-weight: 600;
     margin-bottom: 0.5rem;
 }
+
+/* --- M7e: Diff + Targets views -------------------------------------- */
+
+/* Semantic diff colors. Defined as their own CSS variables so the dark
+   theme overrides can swap them in one place. */
+:root {
+    --diff-add-bg: #ecfdf5;
+    --diff-add-fg: #047857;
+    --diff-add-border: #10b981;
+    --diff-remove-bg: #fef2f2;
+    --diff-remove-fg: #b91c1c;
+    --diff-remove-border: #ef4444;
+    --diff-change-bg: #fefce8;
+    --diff-change-fg: #a16207;
+    --diff-change-border: #eab308;
+    --banner-warn-bg: #fef3c7;
+    --banner-warn-fg: #92400e;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --diff-add-bg: #052e22;
+        --diff-add-fg: #6ee7b7;
+        --diff-add-border: #047857;
+        --diff-remove-bg: #3f1212;
+        --diff-remove-fg: #fca5a5;
+        --diff-remove-border: #b91c1c;
+        --diff-change-bg: #3a2d0a;
+        --diff-change-fg: #fde68a;
+        --diff-change-border: #a16207;
+        --banner-warn-bg: #3a2d0a;
+        --banner-warn-fg: #fde68a;
+    }
+}
+
+.banner {
+    padding: 0.75rem 1rem;
+    border-radius: 0.4rem;
+    margin: 1rem 0;
+    border: 1px solid var(--border);
+}
+
+.banner.warning {
+    background: var(--banner-warn-bg);
+    color: var(--banner-warn-fg);
+    border-color: var(--diff-change-border);
+}
+
+.muted {
+    color: var(--muted);
+}
+
+/* Diff page layout */
+.diff-page {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.diff-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 1rem;
+    padding: 0.75rem 1rem;
+    background: var(--nav-bg);
+    border: 1px solid var(--border);
+    border-radius: 0.4rem;
+}
+
+.diff-summary {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+}
+
+.diff-summary .stat {
+    display: inline-block;
+    padding: 0.15rem 0.5rem;
+    border-radius: 0.25rem;
+    font-size: 0.85rem;
+    font-weight: 600;
+    font-family: ui-monospace, "SF Mono", Menlo, Monaco, Consolas, monospace;
+}
+
+.diff-summary .stat.add {
+    background: var(--diff-add-bg);
+    color: var(--diff-add-fg);
+}
+
+.diff-summary .stat.remove {
+    background: var(--diff-remove-bg);
+    color: var(--diff-remove-fg);
+}
+
+.diff-summary .stat.change {
+    background: var(--diff-change-bg);
+    color: var(--diff-change-fg);
+}
+
+.diff-summary .stat.total {
+    background: var(--code-bg);
+    color: var(--muted);
+}
+
+.diff-body {
+    display: grid;
+    grid-template-columns: 180px 1fr;
+    gap: 1rem;
+    align-items: start;
+}
+
+.diff-filter {
+    position: sticky;
+    top: 1rem;
+    background: var(--nav-bg);
+    border: 1px solid var(--border);
+    border-radius: 0.4rem;
+    padding: 0.5rem;
+}
+
+.diff-filter h3 {
+    margin: 0 0 0.5rem;
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--muted);
+}
+
+.diff-filter ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.diff-filter .filter-link {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.25rem 0.5rem;
+    border-radius: 0.25rem;
+    text-decoration: none;
+    color: var(--fg);
+    font-size: 0.9rem;
+}
+
+.diff-filter .filter-link:hover {
+    background: var(--hover);
+}
+
+.diff-filter .filter-link.active {
+    background: var(--accent);
+    color: var(--accent-fg);
+}
+
+.diff-filter .filter-link.active .badge {
+    background: rgba(255, 255, 255, 0.2);
+    color: var(--accent-fg);
+}
+
+.badge {
+    display: inline-block;
+    min-width: 1.5em;
+    text-align: center;
+    background: var(--code-bg);
+    color: var(--muted);
+    padding: 0 0.35rem;
+    border-radius: 0.75rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+}
+
+.diff-content {
+    min-width: 0;
+}
+
+.diff-group {
+    margin-bottom: 1.5rem;
+    border: 1px solid var(--border);
+    border-left-width: 4px;
+    border-radius: 0.4rem;
+    overflow: hidden;
+}
+
+.diff-group.added {
+    border-left-color: var(--diff-add-border);
+}
+
+.diff-group.removed {
+    border-left-color: var(--diff-remove-border);
+}
+
+.diff-group.changed {
+    border-left-color: var(--diff-change-border);
+}
+
+.diff-group h2 {
+    margin: 0;
+    padding: 0.5rem 0.75rem;
+    font-size: 1rem;
+    background: var(--nav-bg);
+    border-bottom: 1px solid var(--border);
+}
+
+.diff-table {
+    width: 100%;
+    border-collapse: collapse;
+    table-layout: fixed;
+}
+
+.diff-table th, .diff-table td {
+    text-align: left;
+    padding: 0.4rem 0.75rem;
+    border-bottom: 1px solid var(--border);
+    vertical-align: top;
+    font-size: 0.88rem;
+}
+
+.diff-table thead th {
+    background: var(--nav-bg);
+    font-weight: 600;
+    color: var(--muted);
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.diff-table .col-kind { width: 10%; }
+.diff-table .col-path { width: 28%; word-break: break-all; }
+.diff-table .col-side { width: 31%; }
+
+.diff-table tr.row-add {
+    background: color-mix(in srgb, var(--diff-add-bg) 60%, transparent);
+}
+.diff-table tr.row-remove {
+    background: color-mix(in srgb, var(--diff-remove-bg) 60%, transparent);
+}
+.diff-table tr.row-change {
+    background: color-mix(in srgb, var(--diff-change-bg) 60%, transparent);
+}
+
+.diff-table .side-before code { color: var(--diff-remove-fg); }
+.diff-table .side-after code { color: var(--diff-add-fg); }
+
+.trunc {
+    display: inline-block;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    vertical-align: bottom;
+}
+
+.kind-tag {
+    display: inline-block;
+    font-family: ui-monospace, "SF Mono", Menlo, Monaco, Consolas, monospace;
+    font-size: 0.78rem;
+    padding: 0.1rem 0.4rem;
+    border-radius: 0.25rem;
+    background: var(--code-bg);
+    color: var(--muted);
+}
+
+.diff-empty {
+    padding: 2rem;
+    text-align: center;
+    color: var(--muted);
+    border: 1px dashed var(--border);
+    border-radius: 0.4rem;
+}
+
+/* Targets view */
+.targets-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: 1.5rem;
+}
+
+.targets-table th, .targets-table td {
+    text-align: left;
+    padding: 0.5rem 0.75rem;
+    border-bottom: 1px solid var(--border);
+    font-size: 0.9rem;
+    vertical-align: middle;
+}
+
+.targets-table thead th {
+    background: var(--nav-bg);
+    font-weight: 600;
+    color: var(--muted);
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.targets-table tr.target-row.active {
+    background: color-mix(in srgb, var(--accent) 10%, transparent);
+}
+
+.targets-table .actions {
+    text-align: right;
+}
+
+.btn {
+    background: var(--code-bg);
+    color: var(--fg);
+    border: 1px solid var(--border);
+    border-radius: 0.3rem;
+    padding: 0.3rem 0.7rem;
+    font-size: 0.85rem;
+    cursor: pointer;
+    font-family: inherit;
+}
+
+.btn:hover { background: var(--hover); }
+
+.btn-primary {
+    background: var(--accent);
+    color: var(--accent-fg);
+    border-color: var(--accent);
+}
+
+.btn-primary:hover {
+    opacity: 0.9;
+}
+
+.active-badge {
+    background: var(--accent);
+    color: var(--accent-fg);
+}
+
+.compare-section {
+    margin-top: 2rem;
+    padding-top: 1rem;
+    border-top: 1px solid var(--border);
+}
+
+.compare-form {
+    display: flex;
+    gap: 1rem;
+    align-items: end;
+    margin: 1rem 0;
+    flex-wrap: wrap;
+}
+
+.compare-form label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    font-size: 0.85rem;
+    color: var(--muted);
+}
+
+.compare-form select {
+    padding: 0.3rem 0.5rem;
+    background: var(--bg);
+    color: var(--fg);
+    border: 1px solid var(--border);
+    border-radius: 0.3rem;
+    font-family: inherit;
+    font-size: 0.9rem;
+}

--- a/internal/adapter/http/diff_targets.go
+++ b/internal/adapter/http/diff_targets.go
@@ -1,0 +1,567 @@
+package http
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	nethttp "net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	yamlAdapter "github.com/kgatilin/archai/internal/adapter/yaml"
+	"github.com/kgatilin/archai/internal/diff"
+	"github.com/kgatilin/archai/internal/domain"
+	"github.com/kgatilin/archai/internal/target"
+)
+
+// diffPageData is the template model for the Diff view.
+type diffPageData struct {
+	pageData
+	ActiveTarget string
+	HasActive    bool
+	Targets      []target.TargetMeta
+	// Error is set when the diff could not be computed (no target,
+	// missing snapshot, read failure, etc.). When non-empty, the
+	// template shows the banner instead of the diff body.
+	Error   string
+	Summary diffSummary
+	Kinds   []kindFilter
+	Groups  []diffGroup
+	// Filter is the currently-selected kind filter ("" = all).
+	Filter string
+}
+
+// comparePageData is the template model for the cross-target compare
+// fragment served at /targets/compare.
+type comparePageData struct {
+	A       string
+	B       string
+	Error   string
+	Summary diffSummary
+	Kinds   []kindFilter
+	Groups  []diffGroup
+	Filter  string
+}
+
+// targetsPageData is the template model for the Targets view.
+type targetsPageData struct {
+	pageData
+	ActiveTarget string
+	HasActive    bool
+	Targets      []target.TargetMeta
+	// Error, if non-empty, is rendered as a banner at the top of the
+	// page (e.g. reading .arch/targets/ failed).
+	Error string
+}
+
+// diffSummary holds aggregate counts plus per-kind counts for the
+// sidebar filter.
+type diffSummary struct {
+	Additions int
+	Removals  int
+	Changes   int
+	Total     int
+}
+
+// kindFilter represents one entry in the kind-filter sidebar. Count is
+// the number of changes of that kind in the current diff (used to hide
+// entirely-empty kinds and to show badges).
+type kindFilter struct {
+	Kind     string
+	Label    string
+	Count    int
+	Selected bool
+}
+
+// diffGroup is a contiguous group of changes sharing the same Op,
+// ordered as they will appear in the rendered view. We keep Op-grouping
+// at the top level (adds, then changes, then removes) so the viewer can
+// scan by semantic category.
+type diffGroup struct {
+	Op      string // "add" | "remove" | "change"
+	Label   string // "Additions" | "Removals" | "Changes"
+	CSSTag  string // "added" | "removed" | "changed" (matches CSS)
+	Entries []diffEntry
+}
+
+// diffEntry is a single change rendered in the diff view.
+type diffEntry struct {
+	Op     string
+	Kind   string
+	Path   string
+	Before string
+	After  string
+}
+
+// kindOrder fixes the display order of kind filters. Every kind
+// referenced in internal/diff must appear here so the sidebar is stable
+// even when a kind has zero changes.
+var kindOrder = []struct {
+	Kind  diff.Kind
+	Label string
+}{
+	{diff.KindPackage, "Packages"},
+	{diff.KindInterface, "Interfaces"},
+	{diff.KindStruct, "Structs"},
+	{diff.KindFunction, "Functions"},
+	{diff.KindMethod, "Methods"},
+	{diff.KindField, "Fields"},
+	{diff.KindTypeDef, "TypeDefs"},
+	{diff.KindConst, "Constants"},
+	{diff.KindVar, "Variables"},
+	{diff.KindError, "Errors"},
+	{diff.KindDep, "Dependencies"},
+	{diff.KindLayerRule, "Layer rules"},
+}
+
+// opOrder fixes the order of change groups in the rendered view.
+var opOrder = []struct {
+	Op    diff.Op
+	Label string
+	CSS   string
+}{
+	{diff.OpAdd, "Additions", "added"},
+	{diff.OpChange, "Changes", "changed"},
+	{diff.OpRemove, "Removals", "removed"},
+}
+
+// registerDiffTargetsRoutes installs the handlers added by M7e. Kept as
+// a separate function so handlers.go's routes() stays uncluttered.
+func (s *Server) registerDiffTargetsRoutes(mux *nethttp.ServeMux) {
+	// Replace the placeholder pageHandler registrations with the real
+	// M7e handlers. net/http's ServeMux panics on duplicate
+	// registration so the caller must ensure this runs instead of the
+	// old pageHandler("diff.html"/"targets.html") lines.
+	mux.HandleFunc("/diff", s.handleDiff)
+	mux.HandleFunc("/targets", s.handleTargets)
+	mux.HandleFunc("/targets/use", s.handleTargetsUse)
+	mux.HandleFunc("/targets/compare", s.handleTargetsCompare)
+}
+
+// handleDiff renders the Diff page: current code vs active target,
+// filtered by kind when ?kind=... is set. Without HX-Request, it
+// returns the full page; with HX-Request it returns only the diff
+// fragment (no nav, no layout).
+func (s *Server) handleDiff(w nethttp.ResponseWriter, r *nethttp.Request) {
+	ctx := r.Context()
+	snap := s.state.Snapshot()
+	filter := r.URL.Query().Get("kind")
+
+	data := diffPageData{
+		pageData: pageData{
+			Title:      "Diff",
+			ActivePath: "/diff",
+			NavItems:   buildNav("/diff"),
+		},
+		ActiveTarget: snap.CurrentTarget,
+		HasActive:    snap.CurrentTarget != "",
+		Filter:       filter,
+	}
+
+	// Always populate the target list — used both by the header select
+	// box and the "switch target" link when no CURRENT is set.
+	metas, err := target.List(snap.Root)
+	if err != nil {
+		data.Error = fmt.Sprintf("listing targets: %v", err)
+		s.renderDiff(w, r, data)
+		return
+	}
+	data.Targets = metas
+
+	if snap.CurrentTarget == "" {
+		data.Error = "No active target. Lock one with `archai target lock <id>` or pick one from the Targets view."
+		s.renderDiff(w, r, data)
+		return
+	}
+
+	current, tgt, err := loadDiffSides(ctx, snap.Root, snap.CurrentTarget)
+	if err != nil {
+		data.Error = err.Error()
+		s.renderDiff(w, r, data)
+		return
+	}
+
+	d := diff.Compute(current, tgt)
+	data.Summary = summarize(d)
+	data.Kinds = buildKindFilters(d, filter)
+	data.Groups = buildGroups(d, filter)
+	s.renderDiff(w, r, data)
+}
+
+// renderDiff picks full page vs fragment based on HX-Request.
+func (s *Server) renderDiff(w nethttp.ResponseWriter, r *nethttp.Request, data diffPageData) {
+	if isHTMX(r) {
+		s.renderFragment(w, "diff.html", "diff-fragment", data)
+		return
+	}
+	s.renderPage(w, "diff.html", data)
+}
+
+// handleTargets renders the Targets list page.
+func (s *Server) handleTargets(w nethttp.ResponseWriter, r *nethttp.Request) {
+	snap := s.state.Snapshot()
+	data := targetsPageData{
+		pageData: pageData{
+			Title:      "Targets",
+			ActivePath: "/targets",
+			NavItems:   buildNav("/targets"),
+		},
+		ActiveTarget: snap.CurrentTarget,
+		HasActive:    snap.CurrentTarget != "",
+	}
+
+	metas, err := target.List(snap.Root)
+	if err != nil {
+		data.Error = fmt.Sprintf("listing targets: %v", err)
+		s.renderPage(w, "targets.html", data)
+		return
+	}
+	data.Targets = metas
+
+	if isHTMX(r) {
+		s.renderFragment(w, "targets.html", "targets-fragment", data)
+		return
+	}
+	s.renderPage(w, "targets.html", data)
+}
+
+// handleTargetsUse handles POST /targets/use?id=<id>. It validates the
+// id exists on disk, persists it to .arch/targets/CURRENT, updates the
+// in-memory state, and returns the refreshed targets list fragment
+// (HTMX) or redirects to /targets for non-HTMX callers.
+func (s *Server) handleTargetsUse(w nethttp.ResponseWriter, r *nethttp.Request) {
+	if r.Method != nethttp.MethodPost {
+		nethttp.Error(w, "method not allowed", nethttp.StatusMethodNotAllowed)
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		nethttp.Error(w, "parse form: "+err.Error(), nethttp.StatusBadRequest)
+		return
+	}
+	id := r.FormValue("id")
+	if id == "" {
+		id = r.URL.Query().Get("id")
+	}
+	if id == "" {
+		nethttp.Error(w, "missing id", nethttp.StatusBadRequest)
+		return
+	}
+
+	root := s.state.Root()
+	if err := target.Use(root, id); err != nil {
+		nethttp.Error(w, err.Error(), nethttp.StatusBadRequest)
+		return
+	}
+	if err := s.state.SwitchTarget(id); err != nil {
+		nethttp.Error(w, err.Error(), nethttp.StatusInternalServerError)
+		return
+	}
+
+	// After a switch, re-render the targets fragment so HTMX can swap
+	// the whole list (active indicator moves). Non-HTMX POSTs redirect
+	// back to the list.
+	if !isHTMX(r) {
+		nethttp.Redirect(w, r, "/targets", nethttp.StatusSeeOther)
+		return
+	}
+	// Delegate to handleTargets so we don't duplicate snapshot logic.
+	// We explicitly force a GET for the downstream render by rewriting
+	// the method on a cloned request.
+	getReq := r.Clone(r.Context())
+	getReq.Method = nethttp.MethodGet
+	s.handleTargets(w, getReq)
+}
+
+// handleTargetsCompare handles GET /targets/compare?a=<id>&b=<id>&kind=<kind>.
+// It returns a fragment with a cross-target diff. Used by the compare
+// form on the Targets view (HTMX) and also works as a plain page when
+// loaded directly.
+func (s *Server) handleTargetsCompare(w nethttp.ResponseWriter, r *nethttp.Request) {
+	ctx := r.Context()
+	q := r.URL.Query()
+	a := q.Get("a")
+	b := q.Get("b")
+	filter := q.Get("kind")
+
+	data := comparePageData{
+		A:      a,
+		B:      b,
+		Filter: filter,
+	}
+	if a == "" || b == "" {
+		data.Error = "both a and b must be provided"
+		s.renderFragment(w, "targets.html", "compare-fragment", data)
+		return
+	}
+
+	root := s.state.Root()
+	aModel, err := loadTargetFromDisk(ctx, root, a)
+	if err != nil {
+		data.Error = fmt.Sprintf("loading %q: %v", a, err)
+		s.renderFragment(w, "targets.html", "compare-fragment", data)
+		return
+	}
+	bModel, err := loadTargetFromDisk(ctx, root, b)
+	if err != nil {
+		data.Error = fmt.Sprintf("loading %q: %v", b, err)
+		s.renderFragment(w, "targets.html", "compare-fragment", data)
+		return
+	}
+
+	d := diff.Compute(aModel, bModel)
+	data.Summary = summarize(d)
+	data.Kinds = buildKindFilters(d, filter)
+	data.Groups = buildGroups(d, filter)
+	s.renderFragment(w, "targets.html", "compare-fragment", data)
+}
+
+// --- helpers ---
+
+// isHTMX reports whether the request was issued by HTMX (carries the
+// HX-Request header). We use this to decide between full page renders
+// and partial fragment renders.
+func isHTMX(r *nethttp.Request) bool {
+	return r.Header.Get("HX-Request") == "true"
+}
+
+// summarize tallies add / remove / change counts for the header strip.
+func summarize(d *diff.Diff) diffSummary {
+	var s diffSummary
+	if d == nil {
+		return s
+	}
+	for _, c := range d.Changes {
+		switch c.Op {
+		case diff.OpAdd:
+			s.Additions++
+		case diff.OpRemove:
+			s.Removals++
+		case diff.OpChange:
+			s.Changes++
+		}
+	}
+	s.Total = s.Additions + s.Removals + s.Changes
+	return s
+}
+
+// buildKindFilters produces the sidebar filter list for d, marking the
+// currently-selected entry. The "All" pseudo-filter is injected first.
+func buildKindFilters(d *diff.Diff, selected string) []kindFilter {
+	counts := make(map[diff.Kind]int, len(kindOrder))
+	total := 0
+	if d != nil {
+		for _, c := range d.Changes {
+			counts[c.Kind]++
+			total++
+		}
+	}
+
+	out := make([]kindFilter, 0, len(kindOrder)+1)
+	out = append(out, kindFilter{
+		Kind:     "",
+		Label:    "All",
+		Count:    total,
+		Selected: selected == "",
+	})
+	for _, k := range kindOrder {
+		out = append(out, kindFilter{
+			Kind:     string(k.Kind),
+			Label:    k.Label,
+			Count:    counts[k.Kind],
+			Selected: selected == string(k.Kind),
+		})
+	}
+	return out
+}
+
+// buildGroups arranges d's changes into ordered op-groups suitable for
+// the template. When filter is non-empty, only changes whose Kind
+// matches are included.
+func buildGroups(d *diff.Diff, filter string) []diffGroup {
+	if d == nil {
+		return nil
+	}
+	byOp := make(map[diff.Op][]diffEntry, 3)
+	for _, c := range d.Changes {
+		if filter != "" && string(c.Kind) != filter {
+			continue
+		}
+		byOp[c.Op] = append(byOp[c.Op], diffEntry{
+			Op:     string(c.Op),
+			Kind:   string(c.Kind),
+			Path:   c.Path,
+			Before: formatSide(c.Before),
+			After:  formatSide(c.After),
+		})
+	}
+
+	// Stable sort entries inside each group by path for deterministic
+	// output (Compute already sorts, but filtering preserves only that
+	// relative order; re-sorting here is cheap and defensive).
+	for op := range byOp {
+		sort.SliceStable(byOp[op], func(i, j int) bool {
+			return byOp[op][i].Path < byOp[op][j].Path
+		})
+	}
+
+	out := make([]diffGroup, 0, len(opOrder))
+	for _, o := range opOrder {
+		entries := byOp[o.Op]
+		if len(entries) == 0 {
+			continue
+		}
+		out = append(out, diffGroup{
+			Op:      string(o.Op),
+			Label:   o.Label,
+			CSSTag:  o.CSS,
+			Entries: entries,
+		})
+	}
+	return out
+}
+
+// formatSide renders Before/After values as a short human-readable
+// string. The underlying values are heterogeneous (domain types,
+// map[string]any for package summaries, nil), so we use fmt %v and
+// trim; the primary information in the UI is the path + op + kind.
+func formatSide(v any) string {
+	if v == nil {
+		return ""
+	}
+	s := fmt.Sprintf("%v", v)
+	// Keep tooltips/cells readable.
+	const max = 240
+	if len(s) > max {
+		s = s[:max] + "…"
+	}
+	return s
+}
+
+// loadDiffSides loads current + target models for the Diff page. The
+// "current" side prefers per-package .arch/*.yaml specs if available,
+// falling back to nil (empty model) — the HTTP daemon should not invoke
+// the Go parser on a live user project as part of a page render.
+func loadDiffSides(ctx context.Context, root, targetID string) ([]domain.PackageModel, []domain.PackageModel, error) {
+	current, err := loadCurrentFromDisk(ctx, root)
+	if err != nil {
+		return nil, nil, fmt.Errorf("loading current model: %w", err)
+	}
+	tgt, err := loadTargetFromDisk(ctx, root, targetID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("loading target %q: %w", targetID, err)
+	}
+	return current, tgt, nil
+}
+
+// loadCurrentFromDisk returns the current project model from per-package
+// .arch/*.yaml specs. Returns an empty slice (not an error) when the
+// project has no yaml specs yet — the diff view will then show
+// everything in the target as "add".
+func loadCurrentFromDisk(ctx context.Context, root string) ([]domain.PackageModel, error) {
+	files, err := findProjectYAMLSpecs(root)
+	if err != nil {
+		return nil, err
+	}
+	if len(files) == 0 {
+		return nil, nil
+	}
+	return yamlAdapter.NewReader().Read(ctx, files)
+}
+
+// loadTargetFromDisk loads a locked target's frozen model.
+func loadTargetFromDisk(ctx context.Context, root, id string) ([]domain.PackageModel, error) {
+	if id == "" {
+		return nil, errors.New("empty target id")
+	}
+	meta, _, err := target.Show(root, id)
+	if err != nil {
+		return nil, err
+	}
+	if meta == nil {
+		return nil, fmt.Errorf("target %q missing meta", id)
+	}
+
+	// Walk the target's model/ tree for YAML files and hand them to the
+	// YAML reader. We intentionally duplicate the walker (rather than
+	// export the CLI helper) because adapter packages must not import
+	// cmd/.
+	modelDir := filepath.Join(root, ".arch", "targets", id, "model")
+	files, err := walkYAML(modelDir)
+	if err != nil {
+		return nil, err
+	}
+	if len(files) == 0 {
+		return nil, fmt.Errorf("target %q has no model files", id)
+	}
+	return yamlAdapter.NewReader().Read(ctx, files)
+}
+
+// findProjectYAMLSpecs locates per-package .arch/*.yaml files, skipping
+// the .arch/targets/ subtree. Mirrors the CLI helper in cmd/archai but
+// lives here to keep adapter/http free of a cmd/ dependency.
+func findProjectYAMLSpecs(root string) ([]string, error) {
+	targetsTree := filepath.Join(root, ".arch", "targets")
+	var out []string
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			if path == targetsTree || strings.HasPrefix(path, targetsTree+string(os.PathSeparator)) {
+				return filepath.SkipDir
+			}
+			name := d.Name()
+			if path != root && strings.HasPrefix(name, ".") && name != ".arch" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !hasYAMLExt(path) {
+			return nil
+		}
+		if filepath.Base(filepath.Dir(path)) != ".arch" {
+			return nil
+		}
+		out = append(out, path)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+// walkYAML returns every .yaml/.yml file under root. Returns an empty
+// slice (not an error) if root does not exist.
+func walkYAML(root string) ([]string, error) {
+	if _, err := os.Stat(root); errors.Is(err, fs.ErrNotExist) {
+		return nil, nil
+	}
+	var out []string
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if hasYAMLExt(path) {
+			out = append(out, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+func hasYAMLExt(p string) bool {
+	e := filepath.Ext(p)
+	return e == ".yaml" || e == ".yml"
+}

--- a/internal/adapter/http/diff_targets_test.go
+++ b/internal/adapter/http/diff_targets_test.go
@@ -1,0 +1,489 @@
+package http
+
+import (
+	"io"
+	nethttp "net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kgatilin/archai/internal/diff"
+	"github.com/kgatilin/archai/internal/serve"
+	"github.com/kgatilin/archai/internal/target"
+)
+
+// --- unit tests for summarize / filter / group helpers --------------
+
+func TestSummarize_CountsAddRemoveChange(t *testing.T) {
+	d := &diff.Diff{Changes: []diff.Change{
+		{Op: diff.OpAdd, Kind: diff.KindFunction, Path: "p.F"},
+		{Op: diff.OpAdd, Kind: diff.KindStruct, Path: "p.S"},
+		{Op: diff.OpRemove, Kind: diff.KindInterface, Path: "p.I"},
+		{Op: diff.OpChange, Kind: diff.KindFunction, Path: "p.G"},
+	}}
+	s := summarize(d)
+	if s.Additions != 2 || s.Removals != 1 || s.Changes != 1 || s.Total != 4 {
+		t.Errorf("summary = %+v, want {2,1,1,4}", s)
+	}
+}
+
+func TestSummarize_NilAndEmpty(t *testing.T) {
+	if got := summarize(nil); got.Total != 0 {
+		t.Errorf("nil diff: total = %d, want 0", got.Total)
+	}
+	if got := summarize(&diff.Diff{}); got.Total != 0 {
+		t.Errorf("empty diff: total = %d, want 0", got.Total)
+	}
+}
+
+func TestBuildKindFilters_MarksSelectedAndCounts(t *testing.T) {
+	d := &diff.Diff{Changes: []diff.Change{
+		{Op: diff.OpAdd, Kind: diff.KindFunction, Path: "p.F"},
+		{Op: diff.OpAdd, Kind: diff.KindFunction, Path: "p.G"},
+		{Op: diff.OpRemove, Kind: diff.KindStruct, Path: "p.S"},
+	}}
+
+	filters := buildKindFilters(d, "function")
+	// Expect "All" + one per kindOrder entry.
+	if len(filters) != len(kindOrder)+1 {
+		t.Fatalf("len(filters) = %d, want %d", len(filters), len(kindOrder)+1)
+	}
+	if filters[0].Label != "All" || filters[0].Count != 3 {
+		t.Errorf("all-filter = %+v, want {All,3}", filters[0])
+	}
+
+	// Find the function filter and verify selected + count.
+	var fn *kindFilter
+	for i := range filters {
+		if filters[i].Kind == "function" {
+			fn = &filters[i]
+		}
+	}
+	if fn == nil {
+		t.Fatal("no function filter entry")
+	}
+	if !fn.Selected {
+		t.Error("function filter should be selected")
+	}
+	if fn.Count != 2 {
+		t.Errorf("function count = %d, want 2", fn.Count)
+	}
+	// All-filter must be unselected when a specific kind is chosen.
+	if filters[0].Selected {
+		t.Error("All should not be selected when kind=function")
+	}
+}
+
+func TestBuildKindFilters_DefaultSelectsAll(t *testing.T) {
+	filters := buildKindFilters(&diff.Diff{}, "")
+	if !filters[0].Selected {
+		t.Error("All should be selected when no kind filter set")
+	}
+}
+
+func TestBuildGroups_OrdersAddChangeRemoveAndFilters(t *testing.T) {
+	d := &diff.Diff{Changes: []diff.Change{
+		{Op: diff.OpRemove, Kind: diff.KindFunction, Path: "p.F"},
+		{Op: diff.OpAdd, Kind: diff.KindFunction, Path: "p.G"},
+		{Op: diff.OpChange, Kind: diff.KindStruct, Path: "p.S"},
+	}}
+
+	groups := buildGroups(d, "")
+	if len(groups) != 3 {
+		t.Fatalf("len(groups) = %d, want 3", len(groups))
+	}
+	wantOps := []string{"add", "change", "remove"}
+	for i, w := range wantOps {
+		if groups[i].Op != w {
+			t.Errorf("groups[%d].Op = %s, want %s", i, groups[i].Op, w)
+		}
+	}
+
+	// With a filter, only matching kinds survive.
+	filtered := buildGroups(d, "function")
+	if len(filtered) != 2 {
+		t.Fatalf("filtered groups = %d, want 2 (add+remove of function)", len(filtered))
+	}
+	for _, g := range filtered {
+		for _, e := range g.Entries {
+			if e.Kind != "function" {
+				t.Errorf("filter leaked kind %s", e.Kind)
+			}
+		}
+	}
+}
+
+func TestBuildGroups_CSSTagsMatchOps(t *testing.T) {
+	d := &diff.Diff{Changes: []diff.Change{
+		{Op: diff.OpAdd, Kind: diff.KindFunction, Path: "a"},
+		{Op: diff.OpRemove, Kind: diff.KindFunction, Path: "b"},
+		{Op: diff.OpChange, Kind: diff.KindFunction, Path: "c"},
+	}}
+	groups := buildGroups(d, "")
+	want := map[string]string{"add": "added", "remove": "removed", "change": "changed"}
+	for _, g := range groups {
+		if got, ok := want[g.Op]; !ok || got != g.CSSTag {
+			t.Errorf("group op=%s CSSTag=%q, want %q", g.Op, g.CSSTag, got)
+		}
+	}
+}
+
+// --- handler tests --------------------------------------------------
+
+// newDiffTargetsServer builds an httptest.Server rooted at a temp
+// project directory. The caller receives the project root so tests
+// can seed .arch/targets/ snapshots.
+func newDiffTargetsServer(t *testing.T) (*httptest.Server, string, *serve.State) {
+	t.Helper()
+	root := t.TempDir()
+	state := serve.NewState(root)
+
+	srv, err := NewServer(state)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	mux := nethttp.NewServeMux()
+	srv.routes(mux)
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+	return ts, root, state
+}
+
+// seedTarget creates a minimal locked target on disk with one package
+// containing a single function named fnName. The resulting layout is
+// enough for yamlAdapter.Read to return a non-empty model.
+func seedTarget(t *testing.T, root, id, fnName string) {
+	t.Helper()
+	pkg := "internal/foo"
+	// Seed a per-package .arch so target.Lock has something to freeze.
+	archDir := filepath.Join(root, pkg, ".arch")
+	if err := os.MkdirAll(archDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	spec := `schema: archai/v1
+package: ` + pkg + `
+name: foo
+functions:
+  - name: ` + fnName + `
+    exported: true
+`
+	if err := os.WriteFile(filepath.Join(archDir, "pub.yaml"), []byte(spec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := target.Lock(root, id, target.LockOptions{Description: "test target " + id}); err != nil {
+		t.Fatalf("Lock %s: %v", id, err)
+	}
+	// Remove the temp .arch so subsequent seeds for other targets can
+	// reuse the same package path without false stale data. The target
+	// copy is already snapshotted under .arch/targets/<id>/model/.
+	if err := os.RemoveAll(archDir); err != nil {
+		t.Fatalf("cleanup pkg arch: %v", err)
+	}
+}
+
+func TestTargets_ListRendersTargets(t *testing.T) {
+	ts, root, _ := newDiffTargetsServer(t)
+	seedTarget(t, root, "v1", "Alpha")
+	seedTarget(t, root, "v2", "Beta")
+
+	resp, err := ts.Client().Get(ts.URL + "/targets")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+	body := readBody(t, resp.Body)
+	for _, want := range []string{">v1<", ">v2<", "test target v1", "Use"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %q\n\n%s", want, body)
+		}
+	}
+}
+
+func TestTargets_UseSwitchesActive(t *testing.T) {
+	ts, root, state := newDiffTargetsServer(t)
+	seedTarget(t, root, "v1", "Alpha")
+	seedTarget(t, root, "v2", "Beta")
+	_ = state // state.Load is not required for disk-only tests
+
+	// Post with HX-Request so we get a fragment back.
+	req, _ := nethttp.NewRequest(nethttp.MethodPost, ts.URL+"/targets/use?id=v2", nil)
+	req.Header.Set("HX-Request", "true")
+	resp, err := ts.Client().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d body=%s", resp.StatusCode, string(b))
+	}
+	body := readBody(t, resp.Body)
+	// The returned fragment should mark v2 as active.
+	if !strings.Contains(body, `active-badge`) {
+		t.Errorf("fragment missing active badge: %s", body)
+	}
+
+	// CURRENT on disk must equal v2.
+	got, err := target.Current(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "v2" {
+		t.Errorf("CURRENT = %q, want v2", got)
+	}
+	// In-memory state must also be updated.
+	if snap := state.Snapshot(); snap.CurrentTarget != "v2" {
+		t.Errorf("state.CurrentTarget = %q, want v2", snap.CurrentTarget)
+	}
+}
+
+func TestTargets_UseMissingIDReturns400(t *testing.T) {
+	ts, _, _ := newDiffTargetsServer(t)
+	resp, err := ts.Client().PostForm(ts.URL+"/targets/use", url.Values{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 400 {
+		t.Errorf("status = %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestTargets_UseWrongMethodReturns405(t *testing.T) {
+	ts, _, _ := newDiffTargetsServer(t)
+	resp, err := ts.Client().Get(ts.URL + "/targets/use?id=v1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 405 {
+		t.Errorf("status = %d, want 405", resp.StatusCode)
+	}
+}
+
+func TestDiff_NoActiveTargetShowsBanner(t *testing.T) {
+	ts, _, _ := newDiffTargetsServer(t)
+	resp, err := ts.Client().Get(ts.URL + "/diff")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	body := readBody(t, resp.Body)
+	if resp.StatusCode != 200 {
+		t.Errorf("status = %d", resp.StatusCode)
+	}
+	if !strings.Contains(body, "No active target") {
+		t.Errorf("missing 'No active target' banner:\n%s", body)
+	}
+}
+
+func TestDiff_RendersChangesWithColorCoding(t *testing.T) {
+	ts, root, state := newDiffTargetsServer(t)
+	seedTarget(t, root, "v1", "Alpha")
+	if err := target.Use(root, "v1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SwitchTarget("v1"); err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := ts.Client().Get(ts.URL + "/diff")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d body=%s", resp.StatusCode, string(b))
+	}
+	body := readBody(t, resp.Body)
+
+	// Target v1 contains function "Alpha"; the current project has no
+	// .arch yaml files, so the Alpha function must be flagged as an
+	// addition (target has it, current doesn't).
+	if !strings.Contains(body, "Alpha") {
+		t.Errorf("diff body missing Alpha:\n%s", body)
+	}
+	// Color-coded group class must appear.
+	if !strings.Contains(body, "diff-group added") {
+		t.Errorf("missing 'diff-group added' class — color coding lost:\n%s", body)
+	}
+	// Summary numbers.
+	if !strings.Contains(body, "stat add") {
+		t.Error("missing add stat in summary")
+	}
+}
+
+func TestDiff_KindFilterLimitsRows(t *testing.T) {
+	ts, root, state := newDiffTargetsServer(t)
+	seedTarget(t, root, "v1", "Alpha")
+	if err := target.Use(root, "v1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SwitchTarget("v1"); err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := ts.Client().Get(ts.URL + "/diff?kind=struct")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	body := readBody(t, resp.Body)
+	// Filter is struct but the only change is a function; body must
+	// show the empty-state message for that filter.
+	if !strings.Contains(body, "No <code>struct</code> changes") {
+		t.Errorf("missing filter empty-state: %s", body)
+	}
+}
+
+func TestDiff_HTMXReturnsFragmentWithoutLayout(t *testing.T) {
+	ts, root, state := newDiffTargetsServer(t)
+	seedTarget(t, root, "v1", "Alpha")
+	if err := target.Use(root, "v1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SwitchTarget("v1"); err != nil {
+		t.Fatal(err)
+	}
+	req, _ := nethttp.NewRequest(nethttp.MethodGet, ts.URL+"/diff", nil)
+	req.Header.Set("HX-Request", "true")
+	resp, err := ts.Client().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	body := readBody(t, resp.Body)
+	// HTMX fragment must NOT include the <html> layout.
+	if strings.Contains(body, "<!doctype html>") {
+		t.Errorf("fragment should not include full html doc:\n%s", body)
+	}
+	// But it must include the diff body.
+	if !strings.Contains(body, "diff-page") {
+		t.Errorf("fragment missing diff-page wrapper:\n%s", body)
+	}
+}
+
+func TestTargetsCompare_CrossTargetDiff(t *testing.T) {
+	ts, root, _ := newDiffTargetsServer(t)
+	seedTarget(t, root, "v1", "Alpha")
+	seedTarget(t, root, "v2", "Beta")
+
+	resp, err := ts.Client().Get(ts.URL + "/targets/compare?a=v1&b=v2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d body=%s", resp.StatusCode, string(b))
+	}
+	body := readBody(t, resp.Body)
+	// v1 has Alpha, v2 has Beta → one add + one remove.
+	if !strings.Contains(body, "Alpha") || !strings.Contains(body, "Beta") {
+		t.Errorf("compare body missing Alpha or Beta:\n%s", body)
+	}
+	if !strings.Contains(body, "diff-group added") || !strings.Contains(body, "diff-group removed") {
+		t.Errorf("compare body missing color-coded groups:\n%s", body)
+	}
+}
+
+func TestTargetsCompare_MissingParamsReturnsFragmentBanner(t *testing.T) {
+	ts, _, _ := newDiffTargetsServer(t)
+	resp, err := ts.Client().Get(ts.URL + "/targets/compare?a=v1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Errorf("status = %d, want 200 (banner fragment)", resp.StatusCode)
+	}
+	body := readBody(t, resp.Body)
+	if !strings.Contains(body, "both a and b must be provided") {
+		t.Errorf("missing error banner:\n%s", body)
+	}
+}
+
+func TestTargetsCompare_UnknownTargetReturnsBanner(t *testing.T) {
+	ts, _, _ := newDiffTargetsServer(t)
+	resp, err := ts.Client().Get(ts.URL + "/targets/compare?a=nope&b=alsonope")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	body := readBody(t, resp.Body)
+	if !strings.Contains(body, "not found") {
+		t.Errorf("missing not-found message:\n%s", body)
+	}
+}
+
+func readBody(t *testing.T, r io.Reader) string {
+	t.Helper()
+	b, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	return string(b)
+}
+
+// Guard: make sure the new routes don't silently break the 404 contract
+// for completely unknown paths under /targets.
+func TestTargets_UnknownSubrouteReturns404OrMethodMismatch(t *testing.T) {
+	ts, _, _ := newDiffTargetsServer(t)
+	resp, err := ts.Client().Get(ts.URL + "/targets/does-not-exist")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	// net/http's mux will fall through to / (which 404s unknown paths).
+	// Either 404 or a redirect is acceptable as long as it's not a 200.
+	if resp.StatusCode == 200 {
+		t.Errorf("unknown /targets/* returned 200; expected 404")
+	}
+}
+
+// Sanity: ensure buildKindFilters + buildGroups handle a huge random
+// diff without panicking. This doubles as a smoke test for the filter
+// map allocations.
+func TestBuildGroups_LargeDiffNoPanic(t *testing.T) {
+	d := &diff.Diff{}
+	for i := 0; i < 500; i++ {
+		d.Changes = append(d.Changes, diff.Change{
+			Op:   diff.OpChange,
+			Kind: diff.KindFunction,
+			Path: "p.F",
+		})
+	}
+	_ = buildKindFilters(d, "")
+	_ = buildGroups(d, "")
+}
+
+// Guard against slow renders — the diff template has to execute in
+// well under a second for realistic inputs.
+func TestDiff_RendersQuickly(t *testing.T) {
+	ts, root, state := newDiffTargetsServer(t)
+	seedTarget(t, root, "v1", "Alpha")
+	if err := target.Use(root, "v1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.SwitchTarget("v1"); err != nil {
+		t.Fatal(err)
+	}
+
+	start := time.Now()
+	resp, err := ts.Client().Get(ts.URL + "/diff")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if d := time.Since(start); d > 2*time.Second {
+		t.Errorf("diff render took %v, expected < 2s", d)
+	}
+}

--- a/internal/adapter/http/handlers.go
+++ b/internal/adapter/http/handlers.go
@@ -51,9 +51,11 @@ func (s *Server) routes(mux *nethttp.ServeMux) {
 	mux.HandleFunc("/layers", s.pageHandler("layers.html", "Layers", "/layers"))
 	mux.HandleFunc("/packages", s.pageHandler("packages.html", "Packages", "/packages"))
 	mux.HandleFunc("/configs", s.pageHandler("configs.html", "Configs", "/configs"))
-	mux.HandleFunc("/targets", s.pageHandler("targets.html", "Targets", "/targets"))
-	mux.HandleFunc("/diff", s.pageHandler("diff.html", "Diff", "/diff"))
 	mux.HandleFunc("/search", s.pageHandler("search.html", "Search", "/search"))
+	// M7e: diff + targets handlers replace the placeholder pageHandlers
+	// for /diff and /targets and add sub-routes for target switching +
+	// cross-target comparison.
+	s.registerDiffTargetsRoutes(mux)
 	mux.HandleFunc("/", s.handleIndex)
 }
 
@@ -83,7 +85,13 @@ func (s *Server) pageHandler(tmpl, title, activePath string) nethttp.HandlerFunc
 // renderPage renders the given page template followed by the base
 // layout. We render into a buffer first so template errors produce a
 // 500 instead of a half-written response.
-func (s *Server) renderPage(w nethttp.ResponseWriter, tmpl string, data pageData) {
+//
+// data is declared as `any` because M7e introduces page-specific model
+// structs (diffPageData, targetsPageData) that embed pageData but are
+// not themselves pageData values. The base template only reads the
+// promoted fields (Title, ActivePath, NavItems), so passing the
+// embedding struct works as long as those fields remain exported.
+func (s *Server) renderPage(w nethttp.ResponseWriter, tmpl string, data any) {
 	// Clone so the page template and base template live in their own
 	// namespace — each page file defines its own "content" block and
 	// we don't want successive requests to see a stale definition.
@@ -100,6 +108,29 @@ func (s *Server) renderPage(w nethttp.ResponseWriter, tmpl string, data pageData
 	var buf bytes.Buffer
 	if err := t.ExecuteTemplate(&buf, "base", data); err != nil {
 		nethttp.Error(w, fmt.Sprintf("template execute: %v", err), nethttp.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_, _ = w.Write(buf.Bytes())
+}
+
+// renderFragment renders a single named template from the given
+// template file without the surrounding base layout. It is used by
+// HTMX-driven handlers to return partials that replace an element
+// in-place.
+func (s *Server) renderFragment(w nethttp.ResponseWriter, tmpl, fragment string, data any) {
+	t, err := s.templates.Clone()
+	if err != nil {
+		nethttp.Error(w, fmt.Sprintf("template clone: %v", err), nethttp.StatusInternalServerError)
+		return
+	}
+	if _, err := t.ParseFS(embedded, "templates/"+tmpl); err != nil {
+		nethttp.Error(w, fmt.Sprintf("template parse %s: %v", tmpl, err), nethttp.StatusInternalServerError)
+		return
+	}
+	var buf bytes.Buffer
+	if err := t.ExecuteTemplate(&buf, fragment, data); err != nil {
+		nethttp.Error(w, fmt.Sprintf("template execute %s#%s: %v", tmpl, fragment, err), nethttp.StatusInternalServerError)
 		return
 	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")

--- a/internal/adapter/http/templates/diff.html
+++ b/internal/adapter/http/templates/diff.html
@@ -1,8 +1,95 @@
 {{define "content"}}
 <h1>Diff</h1>
-<p class="lede">Compare current code against the active target.</p>
-<div class="coming-soon">
-    <div class="tag">M7f</div>
-    <p>Diff view is coming in M7f — structured changes, apply patch, validate.</p>
+<p class="lede">Current code vs active target.</p>
+<div id="diff-root">
+    {{template "diff-fragment" .}}
+</div>
+{{end}}
+
+{{define "diff-fragment"}}
+<div class="diff-page">
+    <div class="diff-header">
+        {{if .HasActive}}
+            <div class="diff-target">
+                <span class="label">Target:</span>
+                <code>{{.ActiveTarget}}</code>
+            </div>
+        {{else}}
+            <div class="diff-target muted">No active target</div>
+        {{end}}
+        {{if not .Error}}
+            <div class="diff-summary" role="status" aria-label="diff summary">
+                <span class="stat add" title="{{.Summary.Additions}} additions">+{{.Summary.Additions}}</span>
+                <span class="stat change" title="{{.Summary.Changes}} changes">~{{.Summary.Changes}}</span>
+                <span class="stat remove" title="{{.Summary.Removals}} removals">-{{.Summary.Removals}}</span>
+                <span class="stat total">{{.Summary.Total}} total</span>
+            </div>
+        {{end}}
+    </div>
+
+    {{if .Error}}
+        <div class="banner warning">{{.Error}}</div>
+    {{else}}
+        <div class="diff-body">
+            <aside class="diff-filter" aria-label="Filter by kind">
+                <h3>Filter</h3>
+                <ul>
+                    {{range .Kinds}}
+                        <li>
+                            <a
+                                href="/diff{{if .Kind}}?kind={{.Kind}}{{end}}"
+                                hx-get="/diff{{if .Kind}}?kind={{.Kind}}{{end}}"
+                                hx-target="#diff-root"
+                                hx-swap="innerHTML"
+                                hx-push-url="true"
+                                class="filter-link{{if .Selected}} active{{end}}"
+                            >
+                                <span>{{.Label}}</span>
+                                <span class="badge">{{.Count}}</span>
+                            </a>
+                        </li>
+                    {{end}}
+                </ul>
+            </aside>
+
+            <section class="diff-content" aria-label="Diff entries">
+                {{if not .Groups}}
+                    <div class="diff-empty">
+                        {{if .Filter}}
+                            No <code>{{.Filter}}</code> changes.
+                        {{else}}
+                            No differences — current code matches target.
+                        {{end}}
+                    </div>
+                {{else}}
+                    {{range .Groups}}
+                        <section class="diff-group {{.CSSTag}}" aria-label="{{.Label}}">
+                            <h2>{{.Label}} <span class="muted">({{len .Entries}})</span></h2>
+                            <table class="diff-table">
+                                <thead>
+                                    <tr>
+                                        <th class="col-kind">Kind</th>
+                                        <th class="col-path">Path</th>
+                                        <th class="col-side">Current</th>
+                                        <th class="col-side">Target</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {{range .Entries}}
+                                        <tr class="row-{{.Op}}">
+                                            <td class="col-kind"><span class="kind-tag">{{.Kind}}</span></td>
+                                            <td class="col-path"><code>{{.Path}}</code></td>
+                                            <td class="col-side side-before">{{if .Before}}<code class="trunc">{{.Before}}</code>{{else}}<span class="muted">—</span>{{end}}</td>
+                                            <td class="col-side side-after">{{if .After}}<code class="trunc">{{.After}}</code>{{else}}<span class="muted">—</span>{{end}}</td>
+                                        </tr>
+                                    {{end}}
+                                </tbody>
+                            </table>
+                        </section>
+                    {{end}}
+                {{end}}
+            </section>
+        </div>
+    {{end}}
 </div>
 {{end}}

--- a/internal/adapter/http/templates/targets.html
+++ b/internal/adapter/http/templates/targets.html
@@ -1,8 +1,163 @@
 {{define "content"}}
 <h1>Targets</h1>
-<p class="lede">Locked target snapshots.</p>
-<div class="coming-soon">
-    <div class="tag">M7e</div>
-    <p>Target browser is coming in M7e — list, detail, active target, lock metadata.</p>
+<p class="lede">Locked architecture snapshots.</p>
+<div id="targets-root">
+    {{template "targets-fragment" .}}
 </div>
+<section class="compare-section" aria-label="Compare two targets">
+    <h2>Compare</h2>
+    <p class="muted">Diff between any two locked targets (A = before, B = after).</p>
+    <form
+        class="compare-form"
+        hx-get="/targets/compare"
+        hx-target="#compare-root"
+        hx-swap="innerHTML"
+        hx-trigger="change delay:150ms, submit"
+    >
+        <label>A:
+            <select name="a">
+                <option value="">—</option>
+                {{range .Targets}}
+                    <option value="{{.ID}}">{{.ID}}</option>
+                {{end}}
+            </select>
+        </label>
+        <label>B:
+            <select name="b">
+                <option value="">—</option>
+                {{range .Targets}}
+                    <option value="{{.ID}}">{{.ID}}</option>
+                {{end}}
+            </select>
+        </label>
+        <button type="submit">Compare</button>
+    </form>
+    <div id="compare-root">
+        <p class="muted">Pick two targets to compute a cross-target diff.</p>
+    </div>
+</section>
+{{end}}
+
+{{define "targets-fragment"}}
+{{if .Error}}
+    <div class="banner warning">{{.Error}}</div>
+{{end}}
+{{if not .Targets}}
+    <div class="coming-soon">
+        <p>No locked targets yet. Run <code>archai target lock &lt;id&gt;</code> to create one.</p>
+    </div>
+{{else}}
+    <table class="targets-table">
+        <thead>
+            <tr>
+                <th>ID</th>
+                <th>Created</th>
+                <th>Commit</th>
+                <th>Description</th>
+                <th>Status</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+            {{range .Targets}}
+                <tr class="target-row{{if eq .ID $.ActiveTarget}} active{{end}}">
+                    <td><code>{{.ID}}</code></td>
+                    <td>{{.CreatedAt}}</td>
+                    <td>{{if .BaseCommit}}<code>{{.BaseCommit}}</code>{{else}}<span class="muted">—</span>{{end}}</td>
+                    <td>{{if .Description}}{{.Description}}{{else}}<span class="muted">—</span>{{end}}</td>
+                    <td>
+                        {{if eq .ID $.ActiveTarget}}
+                            <span class="badge active-badge">active</span>
+                        {{else}}
+                            <span class="muted">—</span>
+                        {{end}}
+                    </td>
+                    <td class="actions">
+                        {{if ne .ID $.ActiveTarget}}
+                            <button
+                                type="button"
+                                class="btn btn-primary"
+                                hx-post="/targets/use?id={{.ID}}"
+                                hx-target="#targets-root"
+                                hx-swap="innerHTML"
+                            >Use</button>
+                        {{end}}
+                    </td>
+                </tr>
+            {{end}}
+        </tbody>
+    </table>
+{{end}}
+{{end}}
+
+{{define "compare-fragment"}}
+{{if .Error}}
+    <div class="banner warning">{{.Error}}</div>
+{{else}}
+    <div class="compare-result">
+        <div class="diff-header">
+            <div class="diff-target"><code>{{.A}}</code> <span class="muted">→</span> <code>{{.B}}</code></div>
+            <div class="diff-summary">
+                <span class="stat add">+{{.Summary.Additions}}</span>
+                <span class="stat change">~{{.Summary.Changes}}</span>
+                <span class="stat remove">-{{.Summary.Removals}}</span>
+                <span class="stat total">{{.Summary.Total}} total</span>
+            </div>
+        </div>
+        <div class="diff-body">
+            <aside class="diff-filter" aria-label="Filter by kind">
+                <h3>Filter</h3>
+                <ul>
+                    {{range .Kinds}}
+                        <li>
+                            <a
+                                href="#"
+                                hx-get="/targets/compare?a={{$.A}}&b={{$.B}}{{if .Kind}}&kind={{.Kind}}{{end}}"
+                                hx-target="#compare-root"
+                                hx-swap="innerHTML"
+                                class="filter-link{{if .Selected}} active{{end}}"
+                            >
+                                <span>{{.Label}}</span>
+                                <span class="badge">{{.Count}}</span>
+                            </a>
+                        </li>
+                    {{end}}
+                </ul>
+            </aside>
+            <section class="diff-content" aria-label="Diff entries">
+                {{if not .Groups}}
+                    <div class="diff-empty">
+                        {{if .Filter}}No <code>{{.Filter}}</code> changes.{{else}}Targets match.{{end}}
+                    </div>
+                {{else}}
+                    {{range .Groups}}
+                        <section class="diff-group {{.CSSTag}}">
+                            <h2>{{.Label}} <span class="muted">({{len .Entries}})</span></h2>
+                            <table class="diff-table">
+                                <thead>
+                                    <tr>
+                                        <th>Kind</th>
+                                        <th>Path</th>
+                                        <th>A ({{$.A}})</th>
+                                        <th>B ({{$.B}})</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {{range .Entries}}
+                                        <tr class="row-{{.Op}}">
+                                            <td><span class="kind-tag">{{.Kind}}</span></td>
+                                            <td><code>{{.Path}}</code></td>
+                                            <td>{{if .Before}}<code class="trunc">{{.Before}}</code>{{else}}<span class="muted">—</span>{{end}}</td>
+                                            <td>{{if .After}}<code class="trunc">{{.After}}</code>{{else}}<span class="muted">—</span>{{end}}</td>
+                                        </tr>
+                                    {{end}}
+                                </tbody>
+                            </table>
+                        </section>
+                    {{end}}
+                {{end}}
+            </section>
+        </div>
+    </div>
+{{end}}
 {{end}}


### PR DESCRIPTION
## Summary

Replaces the M7a placeholder Diff and Targets pages with real interactive views:

- **Diff view** (`/diff`): side-by-side current-vs-target table with color-coded rows (green=added, yellow=changed, red=removed), +/~/- summary strip, and a kind-filter sidebar covering every `diff.Kind`. HTMX filter links swap the diff fragment only (no page reload, `hx-push-url=true`). Friendly banners for "no active target" and "no <kind> changes".
- **Targets view** (`/targets`): table of every locked target (id, created_at, commit, description, active badge) with per-row "Use" action that POSTs `/targets/use`, updates `CURRENT` on disk, mutates `serve.State`, and HTMX-swaps the refreshed list. Compare form below lets you pick any A and B → cross-target diff via `/targets/compare` with the same color coding and filter sidebar.

## Implementation notes

- New `internal/adapter/http/diff_targets.go` holds handlers, view-model structs, and the diff-grouping helpers. Routes registered via `registerDiffTargetsRoutes` so `routes()` stays a single table.
- `renderPage` signature widened from `pageData` to `any` so embedding view-models (`diffPageData`, etc.) reuse the base layout. Existing `pageData` call sites still satisfy `any`.
- `renderFragment` added for HTMX partials.
- No `cmd/` import from `adapter/http` — the project-yaml walker is duplicated (small, self-contained) to keep the hex dependency direction clean.
- The daemon never re-invokes the Go parser during a page render; the "current" side loads strictly from per-package `.arch/*.yaml` files.

Closes #25. Depends on #21 (merged).

## Test plan

- [x] `go test ./...` — all green (incl. 17 new tests in `diff_targets_test.go`).
- [x] `go vet ./...` — clean.
- [x] `gofmt -l` — no changes in files I touched.
- [ ] Manual smoke: `archai serve --http :8080` → visit `/diff` and `/targets`, click "Use" on a target, swap to the Diff view, try the kind filters and the A↔B comparator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)