### PR TITLE
feat: M7f global search view (#26)

### DIFF
--- a/internal/adapter/http/assets/styles.css
+++ b/internal/adapter/http/assets/styles.css
@@ -597,6 +597,40 @@ a {
     border-color: var(--accent);
 }
 
+.search-form {
+    display: flex;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+    align-items: center;
+}
+
+.search-form input[type="search"] {
+    flex: 1;
+    padding: 0.5rem 0.75rem;
+    border: 1px solid var(--border);
+    background: var(--bg);
+    color: var(--fg);
+    border-radius: 0.3rem;
+    font-size: 1rem;
+}
+
+.search-form select,
+.search-form button {
+    padding: 0.5rem 0.75rem;
+    border: 1px solid var(--border);
+    background: var(--bg);
+    color: var(--fg);
+    border-radius: 0.3rem;
+    font-size: 0.95rem;
+    cursor: pointer;
+}
+
+.search-form button {
+    background: var(--accent);
+    color: var(--accent-fg);
+    border-color: var(--accent);
+}
+
 .btn-primary:hover {
     opacity: 0.9;
 }
@@ -688,4 +722,48 @@ a {
 .edge-detail code {
     background: transparent;
     padding: 0;
+}
+
+.search-hint,
+.search-empty,
+.search-summary {
+    color: var(--muted);
+    font-size: 0.9rem;
+}
+
+.search-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.search-item {
+    display: flex;
+    gap: 0.75rem;
+    align-items: baseline;
+    padding: 0.4rem 0;
+    border-bottom: 1px solid var(--border);
+}
+
+.search-kind {
+    display: inline-block;
+    min-width: 5rem;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    color: var(--muted);
+    background: var(--code-bg);
+    padding: 0.1rem 0.35rem;
+    border-radius: 0.25rem;
+    text-align: center;
+}
+
+.search-name {
+    font-weight: 500;
+}
+
+.search-pkg,
+.search-file {
+    color: var(--muted);
+    font-size: 0.85rem;
+    font-family: ui-monospace, "SF Mono", Menlo, Monaco, Consolas, monospace;
 }

--- a/internal/adapter/http/handlers.go
+++ b/internal/adapter/http/handlers.go
@@ -35,6 +35,20 @@ type pageData struct {
 	NavItems   []navItem
 }
 
+// searchPageData is the model for the full Search page template. It
+// embeds pageData so base.html sees the same Title/ActivePath/NavItems
+// and also carries the initial form state + (optional) pre-rendered
+// results so a non-HTMX request to /search?q=… returns a useful page
+// for bookmarking/permalinking.
+type searchPageData struct {
+	pageData
+	Query   string
+	Kind    string
+	Kinds   []string
+	Results []searchResult
+	Total   int
+}
+
 // navTemplate is the canonical, ordered nav used for every page.
 var navTemplate = []navItem{
 	{Label: "Dashboard", Href: "/"},
@@ -61,7 +75,11 @@ func (s *Server) routes(mux *nethttp.ServeMux) {
 	mux.HandleFunc("/layers", s.handleLayers)
 	mux.HandleFunc("/packages", s.pageHandler("packages.html", "Packages", "/packages"))
 	mux.HandleFunc("/configs", s.pageHandler("configs.html", "Configs", "/configs"))
-	mux.HandleFunc("/search", s.pageHandler("search.html", "Search", "/search"))
+	// /search/results must be registered before /search so the prefix
+	// mux treats it as a distinct route rather than falling back to the
+	// full page handler.
+	mux.HandleFunc("/search/results", s.handleSearchResults)
+	mux.HandleFunc("/search", s.handleSearch)
 	// M7e: diff + targets handlers replace the placeholder pageHandlers
 	// for /diff and /targets and add sub-routes for target switching +
 	// cross-target comparison.
@@ -90,6 +108,10 @@ func (s *Server) pageHandler(tmpl, title, activePath string) nethttp.HandlerFunc
 // not themselves pageData values. The base template only reads the
 // promoted fields (Title, ActivePath, NavItems), so passing the
 // embedding struct works as long as those fields remain exported.
+//
+// The search page embeds the HTMX fragment template so it can render
+// initial results inline; we parse both files together when the page
+// pulls in the fragment.
 func (s *Server) renderPage(w nethttp.ResponseWriter, tmpl string, data any) {
 	// Clone so the page template and base template live in their own
 	// namespace — each page file defines its own "content" block and
@@ -99,7 +121,11 @@ func (s *Server) renderPage(w nethttp.ResponseWriter, tmpl string, data any) {
 		nethttp.Error(w, fmt.Sprintf("template clone: %v", err), nethttp.StatusInternalServerError)
 		return
 	}
-	if _, err := t.ParseFS(embedded, "templates/"+tmpl); err != nil {
+	files := []string{"templates/" + tmpl}
+	if tmpl == "search.html" {
+		files = append(files, "templates/search_results.html")
+	}
+	if _, err := t.ParseFS(embedded, files...); err != nil {
 		nethttp.Error(w, fmt.Sprintf("template parse %s: %v", tmpl, err), nethttp.StatusInternalServerError)
 		return
 	}
@@ -175,6 +201,79 @@ func (s *Server) handleRender(w nethttp.ResponseWriter, r *nethttp.Request) {
 	}
 	w.Header().Set("Content-Type", "image/svg+xml; charset=utf-8")
 	_, _ = w.Write(svg)
+}
+
+// handleSearch renders the full search page. If a `q` query parameter
+// is present we also run the search and inline the results so
+// ?q=… links are shareable and work without JavaScript. HTMX takes
+// over on subsequent keystrokes by hitting /search/results directly.
+func (s *Server) handleSearch(w nethttp.ResponseWriter, r *nethttp.Request) {
+	q := r.URL.Query().Get("q")
+	kind := r.URL.Query().Get("kind")
+	if !isKnownKind(kind) {
+		kind = ""
+	}
+
+	var results []searchResult
+	if q != "" {
+		snap := s.state.Snapshot()
+		results = runSearch(snap.Packages, q, kind)
+	}
+
+	s.renderPage(w, "search.html", searchPageData{
+		pageData: pageData{
+			Title:      "Search",
+			ActivePath: "/search",
+			NavItems:   buildNav("/search"),
+		},
+		Query:   q,
+		Kind:    kind,
+		Kinds:   searchKinds,
+		Results: results,
+		Total:   len(results),
+	})
+}
+
+// handleSearchResults serves the HTMX fragment used for
+// search-as-you-type. It returns just the results list without the
+// surrounding page chrome so HTMX can swap it into the results
+// container on every keystroke.
+func (s *Server) handleSearchResults(w nethttp.ResponseWriter, r *nethttp.Request) {
+	q := r.URL.Query().Get("q")
+	kind := r.URL.Query().Get("kind")
+	if !isKnownKind(kind) {
+		kind = ""
+	}
+
+	snap := s.state.Snapshot()
+	results := runSearch(snap.Packages, q, kind)
+
+	// Fragment templates don't extend base.html, so we parse them on
+	// their own with Clone() to avoid polluting the shared parsed set.
+	t, err := s.templates.Clone()
+	if err != nil {
+		nethttp.Error(w, fmt.Sprintf("template clone: %v", err), nethttp.StatusInternalServerError)
+		return
+	}
+	if _, err := t.ParseFS(embedded, "templates/search_results.html"); err != nil {
+		nethttp.Error(w, fmt.Sprintf("template parse: %v", err), nethttp.StatusInternalServerError)
+		return
+	}
+
+	data := searchPageData{
+		Query:   q,
+		Kind:    kind,
+		Kinds:   searchKinds,
+		Results: results,
+		Total:   len(results),
+	}
+	var buf bytes.Buffer
+	if err := t.ExecuteTemplate(&buf, "search_results", data); err != nil {
+		nethttp.Error(w, fmt.Sprintf("template execute: %v", err), nethttp.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_, _ = w.Write(buf.Bytes())
 }
 
 // buildNav returns a fresh nav slice with Active set on the item whose

--- a/internal/adapter/http/search.go
+++ b/internal/adapter/http/search.go
@@ -1,0 +1,283 @@
+package http
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/kgatilin/archai/internal/domain"
+)
+
+// searchResult is one entry in the search results list. It identifies a
+// single symbol (package, file, interface, struct, function, type, const,
+// variable, error) and carries the metadata needed to render a link to
+// its detail page.
+type searchResult struct {
+	// Kind is the symbol category used for filtering and display. One of
+	// searchKind* constants below.
+	Kind string
+
+	// Name is the short display name (e.g. "Service" for a struct,
+	// "internal/service" for a package, "reader.go" for a file).
+	Name string
+
+	// Package is the owning package path (empty for package/file kinds
+	// where it would be redundant with Name).
+	Package string
+
+	// File is the source file path (empty for package/file kinds and for
+	// aggregated locations that don't map to a single file).
+	File string
+
+	// Href is the detail-page URL the template should link to. The M7
+	// detail routes are owned by sibling milestones; this handler links
+	// to conventional paths so results navigate once those pages land.
+	Href string
+
+	// score ranks the match quality. Lower scores sort first. Unexported
+	// because it is an implementation detail of ranking.
+	score int
+}
+
+// Search "kind" values. Kept as string constants so templates and URL
+// query parameters can share the same vocabulary.
+const (
+	searchKindPackage   = "package"
+	searchKindFile      = "file"
+	searchKindInterface = "interface"
+	searchKindStruct    = "struct"
+	searchKindFunction  = "function"
+	searchKindType      = "type"
+	searchKindConst     = "const"
+	searchKindVar       = "var"
+	searchKindError     = "error"
+)
+
+// searchKinds is the canonical ordered list of kinds. Used by the UI to
+// render the kind-filter dropdown and to validate incoming `kind` query
+// parameters.
+var searchKinds = []string{
+	searchKindPackage,
+	searchKindFile,
+	searchKindInterface,
+	searchKindStruct,
+	searchKindFunction,
+	searchKindType,
+	searchKindConst,
+	searchKindVar,
+	searchKindError,
+}
+
+// isKnownKind reports whether k is one of the accepted kind filters.
+// The empty string (no filter) is also considered valid.
+func isKnownKind(k string) bool {
+	if k == "" {
+		return true
+	}
+	for _, known := range searchKinds {
+		if known == k {
+			return true
+		}
+	}
+	return false
+}
+
+// searchLimit caps the number of results returned per query. The UI can
+// re-query with a narrower term if it hits the cap; bounded output keeps
+// HTMX fragments small and ranking stable.
+const searchLimit = 50
+
+// runSearch indexes the given packages on the fly and returns up to
+// searchLimit results that match query, restricted to kind when kind is
+// non-empty. Matching is case-insensitive; scoring prefers exact match
+// over prefix over substring over fuzzy subsequence.
+//
+// The index is rebuilt per query rather than cached on State because the
+// model mutates when the daemon reloads packages; per-query indexing
+// also keeps this package independent of serve.State internals.
+func runSearch(pkgs []domain.PackageModel, query, kind string) []searchResult {
+	q := strings.TrimSpace(query)
+	if q == "" {
+		return nil
+	}
+	qLower := strings.ToLower(q)
+
+	var out []searchResult
+	add := func(r searchResult) {
+		if kind != "" && r.Kind != kind {
+			return
+		}
+		score, ok := matchScore(r.Name, qLower)
+		if !ok {
+			// Also check package/file fields so "serve" matches
+			// "internal/serve" as a package search target.
+			altScore, altOk := matchScore(r.Package, qLower)
+			if altOk {
+				score = altScore + 100 // alt-field matches rank below name matches
+			} else {
+				altScore, altOk = matchScore(r.File, qLower)
+				if !altOk {
+					return
+				}
+				score = altScore + 200
+			}
+		}
+		r.score = score
+		out = append(out, r)
+	}
+
+	for _, p := range pkgs {
+		add(searchResult{
+			Kind:    searchKindPackage,
+			Name:    p.Path,
+			Package: p.Path,
+			Href:    "/packages/" + p.Path,
+		})
+		for _, f := range p.SourceFiles() {
+			add(searchResult{
+				Kind:    searchKindFile,
+				Name:    f,
+				Package: p.Path,
+				File:    f,
+				Href:    "/packages/" + p.Path + "#file-" + f,
+			})
+		}
+		for _, iface := range p.Interfaces {
+			add(searchResult{
+				Kind:    searchKindInterface,
+				Name:    iface.Name,
+				Package: p.Path,
+				File:    iface.SourceFile,
+				Href:    "/packages/" + p.Path + "#interface-" + iface.Name,
+			})
+		}
+		for _, s := range p.Structs {
+			add(searchResult{
+				Kind:    searchKindStruct,
+				Name:    s.Name,
+				Package: p.Path,
+				File:    s.SourceFile,
+				Href:    "/packages/" + p.Path + "#struct-" + s.Name,
+			})
+		}
+		for _, fn := range p.Functions {
+			add(searchResult{
+				Kind:    searchKindFunction,
+				Name:    fn.Name,
+				Package: p.Path,
+				File:    fn.SourceFile,
+				Href:    "/packages/" + p.Path + "#function-" + fn.Name,
+			})
+		}
+		for _, td := range p.TypeDefs {
+			add(searchResult{
+				Kind:    searchKindType,
+				Name:    td.Name,
+				Package: p.Path,
+				File:    td.SourceFile,
+				Href:    "/packages/" + p.Path + "#type-" + td.Name,
+			})
+		}
+		for _, c := range p.Constants {
+			add(searchResult{
+				Kind:    searchKindConst,
+				Name:    c.Name,
+				Package: p.Path,
+				File:    c.SourceFile,
+				Href:    "/packages/" + p.Path + "#const-" + c.Name,
+			})
+		}
+		for _, v := range p.Variables {
+			add(searchResult{
+				Kind:    searchKindVar,
+				Name:    v.Name,
+				Package: p.Path,
+				File:    v.SourceFile,
+				Href:    "/packages/" + p.Path + "#var-" + v.Name,
+			})
+		}
+		for _, e := range p.Errors {
+			add(searchResult{
+				Kind:    searchKindError,
+				Name:    e.Name,
+				Package: p.Path,
+				File:    e.SourceFile,
+				Href:    "/packages/" + p.Path + "#error-" + e.Name,
+			})
+		}
+	}
+
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].score != out[j].score {
+			return out[i].score < out[j].score
+		}
+		if out[i].Name != out[j].Name {
+			return out[i].Name < out[j].Name
+		}
+		return out[i].Package < out[j].Package
+	})
+
+	if len(out) > searchLimit {
+		out = out[:searchLimit]
+	}
+	return out
+}
+
+// matchScore reports whether qLower matches target and returns a rank
+// score (lower is better). qLower must already be lowercased by the
+// caller. The scoring tiers are:
+//
+//	0   exact match (case-insensitive)
+//	1   target starts with query (prefix)
+//	2   substring match
+//	3+  fuzzy subsequence match (score grows with the gap size)
+//
+// Non-matches return (0, false).
+func matchScore(target, qLower string) (int, bool) {
+	if target == "" || qLower == "" {
+		return 0, false
+	}
+	tLower := strings.ToLower(target)
+	switch {
+	case tLower == qLower:
+		return 0, true
+	case strings.HasPrefix(tLower, qLower):
+		return 1, true
+	case strings.Contains(tLower, qLower):
+		return 2, true
+	}
+	// Fuzzy subsequence: every character of q must appear in target in
+	// order. Score is 3 + total gap size so tighter matches win.
+	gap, ok := subsequenceGap(tLower, qLower)
+	if !ok {
+		return 0, false
+	}
+	return 3 + gap, true
+}
+
+// subsequenceGap checks whether q occurs as a subsequence in t. If so
+// it returns the number of non-matching characters between the first
+// and last matched position (plus leading offset) as a "tightness"
+// measure.
+func subsequenceGap(t, q string) (int, bool) {
+	if len(q) == 0 {
+		return 0, true
+	}
+	ti, qi := 0, 0
+	firstMatch := -1
+	lastMatch := -1
+	for ti < len(t) && qi < len(q) {
+		if t[ti] == q[qi] {
+			if firstMatch < 0 {
+				firstMatch = ti
+			}
+			lastMatch = ti
+			qi++
+		}
+		ti++
+	}
+	if qi < len(q) {
+		return 0, false
+	}
+	span := lastMatch - firstMatch + 1
+	return firstMatch + (span - len(q)), true
+}

--- a/internal/adapter/http/search_test.go
+++ b/internal/adapter/http/search_test.go
@@ -1,0 +1,204 @@
+package http
+
+import (
+	"testing"
+
+	"github.com/kgatilin/archai/internal/domain"
+)
+
+// fixturePackages builds a small model with every symbol kind the
+// search indexer understands so the tests can exercise each code path
+// without pulling in the Go reader.
+func fixturePackages() []domain.PackageModel {
+	return []domain.PackageModel{
+		{
+			Path: "internal/service",
+			Name: "service",
+			Interfaces: []domain.InterfaceDef{
+				{Name: "ModelReader", IsExported: true, SourceFile: "options.go"},
+				{Name: "ModelWriter", IsExported: true, SourceFile: "options.go"},
+			},
+			Structs: []domain.StructDef{
+				{Name: "Service", IsExported: true, SourceFile: "service.go"},
+			},
+			Functions: []domain.FunctionDef{
+				{Name: "NewService", IsExported: true, SourceFile: "factory.go"},
+			},
+			TypeDefs: []domain.TypeDef{
+				{Name: "GenerateMode", IsExported: true, SourceFile: "generate.go"},
+			},
+			Constants: []domain.ConstDef{
+				{Name: "DefaultMode", IsExported: true, SourceFile: "generate.go"},
+			},
+			Variables: []domain.VarDef{
+				{Name: "Version", IsExported: true, SourceFile: "service.go"},
+			},
+			Errors: []domain.ErrorDef{
+				{Name: "ErrInvalidMode", IsExported: true, SourceFile: "generate.go"},
+			},
+		},
+		{
+			Path: "internal/adapter/golang",
+			Name: "golang",
+			Structs: []domain.StructDef{
+				{Name: "Reader", IsExported: true, SourceFile: "reader.go"},
+			},
+		},
+	}
+}
+
+func TestMatchScore_Tiers(t *testing.T) {
+	cases := []struct {
+		name   string
+		target string
+		query  string
+		want   int
+		ok     bool
+	}{
+		{"exact", "Service", "service", 0, true},
+		{"prefix", "ServiceFactory", "serv", 1, true},
+		{"substring", "NewService", "serv", 2, true},
+		{"fuzzy subsequence", "NewServiceFactory", "nsf", 3, true},
+		{"no match", "Reader", "xyz", 0, false},
+		{"empty target", "", "q", 0, false},
+		{"empty query", "Service", "", 0, false},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := matchScore(tc.target, tc.query)
+			if ok != tc.ok {
+				t.Fatalf("matchScore(%q, %q) ok = %v, want %v", tc.target, tc.query, ok, tc.ok)
+			}
+			if tc.ok && got != tc.want {
+				// Fuzzy tier returns 3+ so allow equality check for lower
+				// tiers only; for fuzzy, just assert it's >= 3.
+				if tc.want >= 3 {
+					if got < 3 {
+						t.Fatalf("fuzzy score = %d, want >= 3", got)
+					}
+				} else {
+					t.Fatalf("matchScore(%q, %q) = %d, want %d", tc.target, tc.query, got, tc.want)
+				}
+			}
+		})
+	}
+}
+
+func TestMatchScore_PrefixBeatsSubstring(t *testing.T) {
+	prefixScore, _ := matchScore("ServiceFactory", "serv")
+	substringScore, _ := matchScore("NewService", "serv")
+	if prefixScore >= substringScore {
+		t.Fatalf("prefix score (%d) should rank before substring (%d)", prefixScore, substringScore)
+	}
+}
+
+func TestRunSearch_EmptyQuery(t *testing.T) {
+	got := runSearch(fixturePackages(), "", "")
+	if len(got) != 0 {
+		t.Fatalf("empty query should return no results, got %d", len(got))
+	}
+}
+
+func TestRunSearch_SymbolByName(t *testing.T) {
+	got := runSearch(fixturePackages(), "Service", "")
+	if len(got) == 0 {
+		t.Fatal("expected matches for 'Service'")
+	}
+	// "Service" should rank the exact-match struct first.
+	if got[0].Name != "Service" || got[0].Kind != searchKindStruct {
+		t.Fatalf("first result = %+v, want Service struct", got[0])
+	}
+}
+
+func TestRunSearch_ByFilePath(t *testing.T) {
+	got := runSearch(fixturePackages(), "factory.go", "")
+	var sawFile bool
+	for _, r := range got {
+		if r.Kind == searchKindFile && r.Name == "factory.go" {
+			sawFile = true
+		}
+	}
+	if !sawFile {
+		t.Fatalf("expected a file result for factory.go, got %d total results", len(got))
+	}
+}
+
+func TestRunSearch_ByPackageName(t *testing.T) {
+	got := runSearch(fixturePackages(), "service", "")
+	var sawPackage bool
+	for _, r := range got {
+		if r.Kind == searchKindPackage && r.Name == "internal/service" {
+			sawPackage = true
+		}
+	}
+	if !sawPackage {
+		t.Fatal("expected a package result for 'service'")
+	}
+}
+
+func TestRunSearch_KindFilter(t *testing.T) {
+	got := runSearch(fixturePackages(), "service", searchKindInterface)
+	if len(got) == 0 {
+		t.Fatal("expected interface matches for 'service'")
+	}
+	for _, r := range got {
+		if r.Kind != searchKindInterface {
+			t.Fatalf("kind filter violated: got %q result", r.Kind)
+		}
+	}
+}
+
+func TestRunSearch_FuzzyMatch(t *testing.T) {
+	// "nsf" should fuzzy-match "NewService" (n-s-… has no 'f') —
+	// pick a query that fails prefix/substring but is a subsequence.
+	got := runSearch(fixturePackages(), "nwsrv", "")
+	var sawFunc bool
+	for _, r := range got {
+		if r.Name == "NewService" {
+			sawFunc = true
+		}
+	}
+	if !sawFunc {
+		t.Fatalf("fuzzy 'nwsrv' should match 'NewService', got %d results", len(got))
+	}
+}
+
+func TestRunSearch_ResultHref(t *testing.T) {
+	got := runSearch(fixturePackages(), "Service", searchKindStruct)
+	if len(got) == 0 {
+		t.Fatal("expected struct results")
+	}
+	want := "/packages/internal/service#struct-Service"
+	if got[0].Href != want {
+		t.Fatalf("Href = %q, want %q", got[0].Href, want)
+	}
+}
+
+func TestRunSearch_LimitResults(t *testing.T) {
+	// Build a big package list so we definitely exceed the cap.
+	pkgs := []domain.PackageModel{{Path: "internal/big", Name: "big"}}
+	for i := 0; i < searchLimit*3; i++ {
+		pkgs[0].Structs = append(pkgs[0].Structs, domain.StructDef{
+			Name:       "SearchableThing",
+			IsExported: true,
+			SourceFile: "things.go",
+		})
+	}
+	got := runSearch(pkgs, "Searchable", "")
+	if len(got) > searchLimit {
+		t.Fatalf("results not capped: got %d, limit %d", len(got), searchLimit)
+	}
+}
+
+func TestIsKnownKind(t *testing.T) {
+	if !isKnownKind("") {
+		t.Fatal("empty kind should be accepted (no filter)")
+	}
+	if !isKnownKind(searchKindStruct) {
+		t.Fatal("struct should be a known kind")
+	}
+	if isKnownKind("bogus") {
+		t.Fatal("bogus kind should not be accepted")
+	}
+}

--- a/internal/adapter/http/server_test.go
+++ b/internal/adapter/http/server_test.go
@@ -6,6 +6,8 @@ import (
 	nethttp "net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -142,6 +144,170 @@ func TestServer_RenderEndpoint_MissingSource(t *testing.T) {
 	defer resp.Body.Close()
 	if resp.StatusCode != nethttp.StatusBadRequest {
 		t.Fatalf("status = %d, want 400", resp.StatusCode)
+	}
+}
+
+// newLoadedTestServer spins up a Server whose State has been Loaded
+// against a tiny fixture module so search handlers have real packages
+// to query. The fixture mirrors the one used by serve/state_test.
+func newLoadedTestServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "go.mod"),
+		[]byte("module example.com/searchfix\n\ngo 1.21\n"), 0o644); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+	pkgDir := filepath.Join(root, "internal", "alpha")
+	if err := os.MkdirAll(pkgDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(pkgDir, "alpha.go"), []byte(`package alpha
+
+// Greeter is an exported interface so the search index has an interface
+// to find.
+type Greeter interface {
+	Greet() string
+}
+
+// Hello is an exported struct so the search index has a struct to find.
+type Hello struct {
+	Name string
+}
+
+// NewHello returns a Hello.
+func NewHello() *Hello { return &Hello{} }
+`), 0o644); err != nil {
+		t.Fatalf("write alpha.go: %v", err)
+	}
+
+	state := serve.NewState(root)
+	if err := state.Load(context.Background()); err != nil {
+		t.Fatalf("state.Load: %v", err)
+	}
+	srv, err := NewServer(state)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	mux := nethttp.NewServeMux()
+	srv.routes(mux)
+	return httptest.NewServer(mux)
+}
+
+func TestServer_SearchPage_RendersFormAndNoResultsWhenEmpty(t *testing.T) {
+	ts := newTestServer(t)
+	defer ts.Close()
+
+	resp, err := ts.Client().Get(ts.URL + "/search")
+	if err != nil {
+		t.Fatalf("GET /search: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != nethttp.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	s := string(body)
+	// Full page must include the search input and the HTMX target.
+	for _, want := range []string{
+		`id="search-q"`,
+		`id="search-kind"`,
+		`hx-get="/search/results"`,
+		`id="search-results"`,
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("search page missing %q", want)
+		}
+	}
+}
+
+func TestServer_SearchPage_InlineResultsForQuery(t *testing.T) {
+	ts := newLoadedTestServer(t)
+	defer ts.Close()
+
+	resp, err := ts.Client().Get(ts.URL + "/search?q=Hello")
+	if err != nil {
+		t.Fatalf("GET /search?q=Hello: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != nethttp.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	s := string(body)
+	if !strings.Contains(s, `>Hello<`) {
+		t.Errorf("expected 'Hello' result in body, got:\n%s", s)
+	}
+	if !strings.Contains(s, `/packages/internal/alpha#struct-Hello`) {
+		t.Error("expected link to struct detail page")
+	}
+}
+
+func TestServer_SearchResults_Fragment(t *testing.T) {
+	ts := newLoadedTestServer(t)
+	defer ts.Close()
+
+	resp, err := ts.Client().Get(ts.URL + "/search/results?q=Greeter")
+	if err != nil {
+		t.Fatalf("GET /search/results: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != nethttp.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	s := string(body)
+
+	// Fragment must NOT contain the base layout chrome.
+	if strings.Contains(s, `<main class="content">`) {
+		t.Error("fragment should not include base layout <main> block")
+	}
+	if strings.Contains(s, `<header class="site-nav">`) {
+		t.Error("fragment should not include site nav")
+	}
+	// But it must include the result.
+	if !strings.Contains(s, "Greeter") {
+		t.Errorf("fragment missing 'Greeter' result, got:\n%s", s)
+	}
+	if !strings.Contains(s, "/packages/internal/alpha#interface-Greeter") {
+		t.Error("fragment missing interface detail href")
+	}
+}
+
+func TestServer_SearchResults_KindFilter(t *testing.T) {
+	ts := newLoadedTestServer(t)
+	defer ts.Close()
+
+	// Kind=struct should not surface the Greeter interface.
+	resp, err := ts.Client().Get(ts.URL + "/search/results?q=Hello&kind=struct")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	s := string(body)
+	if !strings.Contains(s, "Hello") {
+		t.Errorf("expected Hello struct in results, got:\n%s", s)
+	}
+	if strings.Contains(s, "Greeter") {
+		t.Errorf("kind=struct filter leaked interface match: %s", s)
+	}
+}
+
+func TestServer_SearchResults_EmptyQueryHint(t *testing.T) {
+	ts := newTestServer(t)
+	defer ts.Close()
+
+	resp, err := ts.Client().Get(ts.URL + "/search/results?q=")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != nethttp.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "Type to search") {
+		t.Errorf("empty query fragment should show hint, got:\n%s", string(body))
 	}
 }
 

--- a/internal/adapter/http/templates/search.html
+++ b/internal/adapter/http/templates/search.html
@@ -1,8 +1,31 @@
 {{define "content"}}
 <h1>Search</h1>
-<p class="lede">Search across the in-memory model.</p>
-<div class="coming-soon">
-    <div class="tag">M7f</div>
-    <p>Search is coming in M7f — symbol lookup by name, kind, package.</p>
+<p class="lede">Find packages, files, and symbols across the model.</p>
+
+<form class="search-form"
+      hx-get="/search/results"
+      hx-target="#search-results"
+      hx-trigger="keyup changed delay:150ms from:#search-q, change from:#search-kind"
+      hx-push-url="false"
+      action="/search"
+      method="get">
+    <input type="search"
+           id="search-q"
+           name="q"
+           value="{{.Query}}"
+           placeholder="Search symbols, files, packages…"
+           autocomplete="off"
+           autofocus>
+    <select id="search-kind" name="kind">
+        <option value=""{{if eq .Kind ""}} selected{{end}}>All kinds</option>
+        {{range .Kinds}}
+            <option value="{{.}}"{{if eq $.Kind .}} selected{{end}}>{{.}}</option>
+        {{end}}
+    </select>
+    <button type="submit">Search</button>
+</form>
+
+<div id="search-results" class="search-results">
+    {{template "search_results" .}}
 </div>
 {{end}}

--- a/internal/adapter/http/templates/search_results.html
+++ b/internal/adapter/http/templates/search_results.html
@@ -1,0 +1,23 @@
+{{define "search_results"}}
+{{if eq .Query ""}}
+    <p class="search-hint">Type to search across packages, files, and symbols.</p>
+{{else if eq .Total 0}}
+    <p class="search-empty">No matches for <code>{{.Query}}</code>{{if ne .Kind ""}} with kind <code>{{.Kind}}</code>{{end}}.</p>
+{{else}}
+    <p class="search-summary">{{.Total}} result{{if ne .Total 1}}s{{end}} for <code>{{.Query}}</code>{{if ne .Kind ""}} (kind: <code>{{.Kind}}</code>){{end}}</p>
+    <ul class="search-list">
+    {{range .Results}}
+        <li class="search-item">
+            <span class="search-kind search-kind-{{.Kind}}">{{.Kind}}</span>
+            <a class="search-name" href="{{.Href}}">{{.Name}}</a>
+            {{if and .Package (ne .Package .Name)}}
+                <span class="search-pkg">{{.Package}}</span>
+            {{end}}
+            {{if and .File (ne .File .Name)}}
+                <span class="search-file">{{.File}}</span>
+            {{end}}
+        </li>
+    {{end}}
+    </ul>
+{{end}}
+{{end}}


### PR DESCRIPTION
Closes #26. Parent: #7 (M7 browser). Depends on M7a (#21, merged).

## Summary
- Adds a global search UI to the `archai serve` HTTP browser over every
  kind of symbol in the in-memory model (packages, files, interfaces,
  structs, functions, type definitions, constants, variables, sentinel
  errors).
- Ranking: exact > prefix > substring > fuzzy subsequence, case-
  insensitive, capped at 50 results per query for snappy HTMX swaps.
- HTMX-powered incremental results via `/search/results` fragment,
  debounced 150ms on keyup. Full `/search?q=…` page renders the same
  results inline for permalinks and non-JS clients.
- Kind filter as a `<select>` that triggers the same HTMX swap.
- Results link to `/packages/<path>#<kind>-<name>` so they activate as
  soon as M7c/d detail routes land; no coupling to those milestones
  beyond the URL shape.

## Scope
- Stays inside `internal/adapter/http` — no changes to domain, serve,
  or other adapters. No overlap with M7b (dashboard/layers), M7c
  (packages), or M7e (diff/targets).

## Tests
- Unit tests for `matchScore` tiers, kind filter, empty query, result
  cap, and detail-page hrefs.
- Handler tests: full `/search` page (form + HTMX attributes), inline
  results for `?q=`, fragment endpoint (no page chrome), kind-filter
  enforcement, empty-query hint.
- `go test ./...` green (including `-race`), `go vet ./...` clean,
  `gofmt -l internal/adapter/http` clean.

## Test plan
- [ ] `go test ./internal/adapter/http/...`
- [ ] `go build ./... && ./archai serve` → visit `/search`, type in the
      box, confirm results swap in and navigate to `/packages/…`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)