### PR TITLE
feat: M9 parallel worktrees — per-worktree state + port allocation (#49)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@
 # Binary
 /archai
 /bin/
+
+# Per-worktree runtime state (M9): CURRENT pointer + serve.json record
+# live here so parallel worktrees don't collide on ports or target ids.
+.arch/.worktree/

--- a/cmd/archai/main.go
+++ b/cmd/archai/main.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/kgatilin/archai/internal/adapter/d2"
 	"github.com/kgatilin/archai/internal/adapter/golang"
@@ -27,6 +28,7 @@ import (
 	"github.com/kgatilin/archai/internal/serve"
 	"github.com/kgatilin/archai/internal/service"
 	"github.com/kgatilin/archai/internal/target"
+	"github.com/kgatilin/archai/internal/worktree"
 	"github.com/spf13/cobra"
 	yamlv3 "gopkg.in/yaml.v3"
 )
@@ -307,9 +309,36 @@ manual verification and as a base for future features.`,
 	}
 	serveCmd.Flags().String("root", ".", "Project root directory")
 	serveCmd.Flags().Bool("mcp-stdio", false, "Enable MCP stdio transport")
-	serveCmd.Flags().String("http", "", "HTTP transport address, e.g. :8080")
+	// Default to port 0 so parallel worktrees don't fight over a fixed
+	// port; the bound address is recorded in .arch/.worktree/<name>/serve.json
+	// for `archai where` / `archai list-daemons` to discover.
+	serveCmd.Flags().String("http", ":0", "HTTP transport address (\"\" disables HTTP; default :0 picks a free port)")
 	serveCmd.Flags().Bool("debug", false, "Verbose per-event logging")
 	rootCmd.AddCommand(serveCmd)
+
+	// where — print this worktree's active serve URL (if any).
+	whereCmd := &cobra.Command{
+		Use:   "where",
+		Short: "Print this worktree's running serve URL",
+		Long: `Read .arch/.worktree/<name>/serve.json and print the URL of the
+daemon currently serving this worktree. Exits non-zero when no
+daemon is running.`,
+		Args: cobra.NoArgs,
+		RunE: runWhere,
+	}
+	rootCmd.AddCommand(whereCmd)
+
+	// list-daemons — scan all worktrees under this repo for live daemons.
+	listDaemonsCmd := &cobra.Command{
+		Use:   "list-daemons",
+		Short: "List live archai serve daemons across all worktrees",
+		Long: `Scan .arch/.worktree/*/serve.json under the current project root
+and print one row per live daemon (worktree name, PID, URL, uptime).
+Stale records (processes that have exited) are skipped.`,
+		Args: cobra.NoArgs,
+		RunE: runListDaemons,
+	}
+	rootCmd.AddCommand(listDaemonsCmd)
 
 	// Sequence command (M6b)
 	sequenceCmd := &cobra.Command{
@@ -1236,6 +1265,85 @@ func validatePatch(d *diff.Diff) error {
 		}
 	}
 	return nil
+}
+
+// runWhere handles `archai where`. It prints the URL of the daemon
+// currently serving this worktree (if any) and exits non-zero when no
+// daemon is recorded or the record is stale.
+func runWhere(cmd *cobra.Command, args []string) error {
+	projectRoot, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("resolving cwd: %w", err)
+	}
+	name := worktree.Name(projectRoot)
+	rec, err := worktree.ReadServe(projectRoot, name)
+	if err != nil {
+		return fmt.Errorf("reading serve.json: %w", err)
+	}
+	if rec == nil {
+		return fmt.Errorf("no daemon running in worktree %q (run `archai serve`)", name)
+	}
+	if !worktree.PIDAlive(rec.PID) {
+		return fmt.Errorf("stale serve.json for worktree %q (pid %d not alive)", name, rec.PID)
+	}
+	fmt.Printf("http://%s\n", rec.HTTPAddr)
+	return nil
+}
+
+// runListDaemons handles `archai list-daemons`. It prints a small
+// table of live daemons keyed by worktree name.
+func runListDaemons(cmd *cobra.Command, args []string) error {
+	projectRoot, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("resolving cwd: %w", err)
+	}
+	daemons, err := worktree.ListDaemons(projectRoot)
+	if err != nil {
+		return err
+	}
+	if len(daemons) == 0 {
+		fmt.Println("No live daemons.")
+		return nil
+	}
+	fmt.Printf("%-20s  %-7s  %-22s  %s\n", "WORKTREE", "PID", "URL", "UPTIME")
+	now := time.Now().UTC()
+	for _, d := range daemons {
+		uptime := "?"
+		if !d.StartedAt.IsZero() {
+			uptime = formatUptime(now.Sub(d.StartedAt))
+		}
+		fmt.Printf("%-20s  %-7d  %-22s  %s\n",
+			d.Worktree, d.Record.PID, "http://"+d.Record.HTTPAddr, uptime)
+	}
+	return nil
+}
+
+// formatUptime renders a duration as a short human-readable string
+// (e.g. "3m", "2h14m", "5d3h"). Precision is intentionally coarse.
+func formatUptime(d time.Duration) string {
+	if d < time.Second {
+		return "<1s"
+	}
+	if d < time.Minute {
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	}
+	if d < time.Hour {
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	}
+	if d < 24*time.Hour {
+		h := int(d.Hours())
+		m := int(d.Minutes()) - 60*h
+		if m == 0 {
+			return fmt.Sprintf("%dh", h)
+		}
+		return fmt.Sprintf("%dh%dm", h, m)
+	}
+	days := int(d.Hours()) / 24
+	h := int(d.Hours()) - 24*days
+	if h == 0 {
+		return fmt.Sprintf("%dd", days)
+	}
+	return fmt.Sprintf("%dd%dh", days, h)
 }
 
 // writeTargetModels overwrites the target snapshot's model/ tree with the

--- a/internal/adapter/http/server.go
+++ b/internal/adapter/http/server.go
@@ -61,9 +61,11 @@ func NewServer(state *serve.State) (*Server, error) {
 
 // Serve listens on addr and serves HTTP requests until ctx is
 // cancelled. It returns nil on a graceful shutdown and the underlying
-// error otherwise. Callers are expected to bridge SIGINT/SIGTERM into
-// ctx.
-func (s *Server) Serve(ctx context.Context, addr string) error {
+// error otherwise. ready — when non-nil — is invoked exactly once
+// after the listener binds successfully, with the actual bound
+// address (useful when addr uses port 0). Callers are expected to
+// bridge SIGINT/SIGTERM into ctx.
+func (s *Server) Serve(ctx context.Context, addr string, ready func(boundAddr string)) error {
 	mux := nethttp.NewServeMux()
 	s.routes(mux)
 
@@ -78,6 +80,10 @@ func (s *Server) Serve(ctx context.Context, addr string) error {
 	ln, err := net.Listen("tcp", addr)
 	if err != nil {
 		return fmt.Errorf("http: listen %s: %w", addr, err)
+	}
+
+	if ready != nil {
+		ready(ln.Addr().String())
 	}
 
 	serveErr := make(chan error, 1)

--- a/internal/adapter/http/server_test.go
+++ b/internal/adapter/http/server_test.go
@@ -311,6 +311,52 @@ func TestServer_SearchResults_EmptyQueryHint(t *testing.T) {
 	}
 }
 
+// TestServer_Serve_ReadyCallback verifies that Serve invokes the
+// ready callback with the actual bound address when addr uses port 0.
+func TestServer_Serve_ReadyCallback(t *testing.T) {
+	state := serve.NewState(t.TempDir())
+	srv, err := NewServer(state)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	addrCh := make(chan string, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- srv.Serve(ctx, "127.0.0.1:0", func(addr string) { addrCh <- addr })
+	}()
+
+	select {
+	case addr := <-addrCh:
+		if !strings.HasPrefix(addr, "127.0.0.1:") {
+			t.Fatalf("bound addr = %q, want 127.0.0.1:<port>", addr)
+		}
+		// Hit the server to confirm it's actually up.
+		resp, err := nethttp.Get("http://" + addr + "/")
+		if err != nil {
+			t.Fatalf("GET /: %v", err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != nethttp.StatusOK {
+			t.Fatalf("GET /: status = %d", resp.StatusCode)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("ready callback not invoked within 2s")
+	}
+
+	cancel()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("Serve returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Serve did not return within 2s of cancel")
+	}
+}
+
 // TestServer_Serve_ContextCancel verifies that Serve returns cleanly
 // when its context is cancelled while listening.
 func TestServer_Serve_ContextCancel(t *testing.T) {
@@ -322,7 +368,7 @@ func TestServer_Serve_ContextCancel(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	errCh := make(chan error, 1)
-	go func() { errCh <- srv.Serve(ctx, "127.0.0.1:0") }()
+	go func() { errCh <- srv.Serve(ctx, "127.0.0.1:0", nil) }()
 
 	// Give the server a moment to bind, then cancel.
 	time.Sleep(50 * time.Millisecond)

--- a/internal/adapter/http/server_worktree_test.go
+++ b/internal/adapter/http/server_worktree_test.go
@@ -1,0 +1,97 @@
+package http
+
+import (
+	"context"
+	"io"
+	nethttp "net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/kgatilin/archai/internal/serve"
+	"github.com/kgatilin/archai/internal/worktree"
+)
+
+// TestServe_Lifecycle_WithServeJSON drives the full daemon lifecycle:
+// start serve on :0, read the bound URL from serve.json, hit "/" (no
+// /healthz route exists), then cancel and verify serve.json is gone.
+func TestServe_Lifecycle_WithServeJSON(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "go.mod"),
+		[]byte("module example.com/m9lifecycle\n\ngo 1.21\n"), 0o644); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+
+	opts := serve.Options{
+		Root:     root,
+		HTTPAddr: "127.0.0.1:0",
+		HTTPServerFactory: func(state *serve.State) (serve.HTTPTransport, error) {
+			return NewServer(state)
+		},
+		LogOut: io.Discard,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- serve.Serve(ctx, opts) }()
+
+	// Poll serve.json until it appears.
+	name := worktree.Name(root)
+	servePath := worktree.ServePath(root, name)
+
+	var rec *worktree.ServeRecord
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		r, err := worktree.ReadServe(root, name)
+		if err != nil {
+			t.Fatalf("ReadServe: %v", err)
+		}
+		if r != nil {
+			rec = r
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if rec == nil {
+		t.Fatalf("serve.json never appeared at %s", servePath)
+	}
+
+	// Hit the server using the discovered address.
+	resp, err := nethttp.Get("http://" + rec.HTTPAddr + "/")
+	if err != nil {
+		t.Fatalf("GET /: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != nethttp.StatusOK {
+		t.Fatalf("GET /: status = %d, body=%s", resp.StatusCode, string(body))
+	}
+
+	// Shutdown and wait for Serve to return.
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Serve returned error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Serve did not return within 5s of cancel")
+	}
+
+	// serve.json must be removed.
+	if _, err := os.Stat(servePath); !os.IsNotExist(err) {
+		t.Errorf("serve.json still exists after shutdown: err=%v", err)
+	}
+
+	// And ListDaemons must return empty.
+	daemons, err := worktree.ListDaemons(root)
+	if err != nil {
+		t.Fatalf("ListDaemons: %v", err)
+	}
+	if len(daemons) != 0 {
+		t.Errorf("expected 0 live daemons, got %d: %+v", len(daemons), daemons)
+	}
+}

--- a/internal/serve/daemon.go
+++ b/internal/serve/daemon.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/kgatilin/archai/internal/worktree"
 )
 
 // Options configures the Serve entry point.
@@ -51,10 +53,13 @@ type Options struct {
 }
 
 // HTTPTransport is the minimal contract the serve daemon needs from an
-// HTTP transport: serve on addr until ctx is cancelled, return nil on a
-// graceful shutdown. Implemented by internal/adapter/http.Server.
+// HTTP transport: bind to addr, invoke ready(boundAddr) once the
+// listener is up, then serve until ctx is cancelled. Returns nil on a
+// graceful shutdown. The ready callback is how callers learn the real
+// bound address when addr uses port 0. Implemented by
+// internal/adapter/http.Server.
 type HTTPTransport interface {
-	Serve(ctx context.Context, addr string) error
+	Serve(ctx context.Context, addr string, ready func(boundAddr string)) error
 }
 
 // Serve runs the daemon: it builds the in-memory model, starts the
@@ -93,23 +98,51 @@ func Serve(ctx context.Context, opts Options) error {
 	// factory are provided. If the caller set the address but didn't
 	// wire a factory we keep the old stub log so operators aren't
 	// silently ignored.
+	//
+	// When a transport comes up we record a serve.json for this
+	// worktree so `archai where` / `archai list-daemons` can find us.
+	// The record is removed on graceful shutdown below.
 	httpErrCh := make(chan error, 1)
 	var httpStarted bool
+	var serveRecorded bool
+	wtName := worktree.Name(absRoot)
 	if opts.HTTPAddr != "" {
 		if opts.HTTPServerFactory != nil {
 			srv, err := opts.HTTPServerFactory(state)
 			if err != nil {
 				return fmt.Errorf("serve: building HTTP transport: %w", err)
 			}
-			fmt.Fprintf(logOut, "serve: HTTP transport listening on %s\n", opts.HTTPAddr)
+			fmt.Fprintf(logOut, "serve: HTTP transport binding %s (worktree=%q)\n", opts.HTTPAddr, wtName)
 			httpStarted = true
+			ready := func(boundAddr string) {
+				rec := worktree.ServeRecord{
+					PID:       os.Getpid(),
+					HTTPAddr:  boundAddr,
+					StartedAt: time.Now().UTC().Format(time.RFC3339),
+				}
+				if err := worktree.WriteServe(absRoot, wtName, rec); err != nil {
+					fmt.Fprintf(logOut, "serve: write serve.json: %v\n", err)
+					return
+				}
+				serveRecorded = true
+				fmt.Fprintf(logOut, "serve: HTTP transport listening on %s\n", boundAddr)
+			}
 			go func() {
-				httpErrCh <- srv.Serve(ctx, opts.HTTPAddr)
+				httpErrCh <- srv.Serve(ctx, opts.HTTPAddr, ready)
 			}()
 		} else {
 			fmt.Fprintf(logOut, "serve: HTTP transport requested on %s — no transport wired (stub)\n", opts.HTTPAddr)
 		}
 	}
+	// Always remove serve.json on return so a killed process doesn't
+	// leave a dangling record when the shutdown path is taken.
+	defer func() {
+		if serveRecorded {
+			if err := worktree.RemoveServe(absRoot, wtName); err != nil {
+				fmt.Fprintf(logOut, "serve: remove serve.json: %v\n", err)
+			}
+		}
+	}()
 
 	watcher, err := NewWatcher(absRoot, opts.Debounce)
 	if err != nil {
@@ -199,6 +232,11 @@ func buildHandler(ctx context.Context, state *State, logOut io.Writer, debug boo
 			case rel == "archai.yaml":
 				overlayDirty = true
 			case rel == ".arch/targets/CURRENT":
+				// Legacy pre-M9 location. Retained for compatibility
+				// so a manually-edited legacy pointer still triggers a
+				// reload; the per-worktree equivalent is handled next.
+				currentDirty = true
+			case strings.HasPrefix(rel, ".arch/.worktree/") && strings.HasSuffix(rel, "/CURRENT"):
 				currentDirty = true
 			case strings.HasSuffix(abs, ".go"):
 				if pkg := state.FindOwningPackage(abs); pkg != "" {
@@ -226,7 +264,8 @@ func buildHandler(ctx context.Context, state *State, logOut io.Writer, debug boo
 		}
 
 		if currentDirty {
-			id, err := readCurrent(filepath.Join(root, ".arch", "targets", "CURRENT"))
+			name := worktree.Name(root)
+			id, _, err := worktree.ReadCurrent(root, name)
 			if err != nil {
 				fmt.Fprintf(logOut, "serve: read CURRENT: %v\n", err)
 			} else if err := state.SwitchTarget(id); err != nil {
@@ -236,17 +275,4 @@ func buildHandler(ctx context.Context, state *State, logOut io.Writer, debug boo
 			}
 		}
 	}
-}
-
-// readCurrent reads the single-line CURRENT pointer. Missing file is
-// treated as an empty id (no active target).
-func readCurrent(path string) (string, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return "", nil
-		}
-		return "", err
-	}
-	return strings.TrimSpace(string(data)), nil
 }

--- a/internal/serve/daemon_worktree_test.go
+++ b/internal/serve/daemon_worktree_test.go
@@ -1,0 +1,105 @@
+package serve
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/kgatilin/archai/internal/worktree"
+)
+
+// fakeHTTPTransport is a minimal HTTPTransport used to exercise the
+// serve.json lifecycle without pulling in the real http adapter (which
+// would create an import cycle in this package).
+type fakeHTTPTransport struct {
+	boundAddr string
+}
+
+func (f *fakeHTTPTransport) Serve(ctx context.Context, addr string, ready func(boundAddr string)) error {
+	// Simulate a port-0 bind by picking a synthetic addr.
+	bound := f.boundAddr
+	if bound == "" {
+		bound = "127.0.0.1:12345"
+	}
+	if ready != nil {
+		ready(bound)
+	}
+	<-ctx.Done()
+	return nil
+}
+
+// TestServe_WritesAndRemovesServeJSON drives Serve with a fake HTTP
+// transport and verifies that serve.json appears on startup and is
+// removed on graceful shutdown.
+func TestServe_WritesAndRemovesServeJSON(t *testing.T) {
+	root := t.TempDir()
+	// Seed a tiny go.mod so state.Load has something to chew on.
+	if err := os.WriteFile(filepath.Join(root, "go.mod"),
+		[]byte("module example.com/m9\n\ngo 1.21\n"), 0o644); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+
+	fake := &fakeHTTPTransport{boundAddr: "127.0.0.1:55555"}
+	opts := Options{
+		Root:     root,
+		HTTPAddr: ":0",
+		HTTPServerFactory: func(*State) (HTTPTransport, error) {
+			return fake, nil
+		},
+		LogOut: io.Discard,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- Serve(ctx, opts) }()
+
+	// Wait for serve.json to appear.
+	name := worktree.Name(root)
+	servePath := worktree.ServePath(root, name)
+	deadline := time.Now().Add(2 * time.Second)
+	var rec *worktree.ServeRecord
+	for time.Now().Before(deadline) {
+		r, err := worktree.ReadServe(root, name)
+		if err != nil {
+			t.Fatalf("ReadServe: %v", err)
+		}
+		if r != nil {
+			rec = r
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if rec == nil {
+		t.Fatalf("serve.json never appeared at %s", servePath)
+	}
+	if rec.PID != os.Getpid() {
+		t.Errorf("PID = %d, want %d", rec.PID, os.Getpid())
+	}
+	if rec.HTTPAddr != "127.0.0.1:55555" {
+		t.Errorf("HTTPAddr = %q, want %q", rec.HTTPAddr, "127.0.0.1:55555")
+	}
+	if rec.StartedAt == "" {
+		t.Errorf("StartedAt empty, want RFC3339 timestamp")
+	}
+
+	// Trigger shutdown and wait for Serve to return.
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Serve returned error: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("Serve did not return within 3s of cancel")
+	}
+
+	// serve.json must be gone.
+	if _, err := os.Stat(servePath); !os.IsNotExist(err) {
+		t.Errorf("serve.json still exists after shutdown: err=%v", err)
+	}
+}

--- a/internal/target/storage.go
+++ b/internal/target/storage.go
@@ -9,22 +9,24 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
+	"github.com/kgatilin/archai/internal/worktree"
 	yamlv3 "gopkg.in/yaml.v3"
 )
 
 // Directory/file name constants used throughout the storage layout.
 const (
-	archDirName      = ".arch"
-	targetsDirName   = "targets"
-	currentFileName  = "CURRENT"
-	metaFileName     = "meta.yaml"
-	overlayFileName  = "overlay.yaml"
-	overlaySource    = "archai.yaml"
-	modelDirName     = "model"
-	pubYAMLFileName  = "pub.yaml"
-	intYAMLFileName  = "internal.yaml"
+	archDirName     = ".arch"
+	targetsDirName  = "targets"
+	currentFileName = "CURRENT"
+	metaFileName    = "meta.yaml"
+	overlayFileName = "overlay.yaml"
+	overlaySource   = "archai.yaml"
+	modelDirName    = "model"
+	pubYAMLFileName = "pub.yaml"
+	intYAMLFileName = "internal.yaml"
 )
 
 // LockOptions configures a Lock call.
@@ -171,8 +173,9 @@ func Show(projectRoot, id string) (*TargetMeta, []string, error) {
 	return &meta, pkgs, nil
 }
 
-// Use marks <id> as the active target by writing it to .arch/targets/CURRENT.
-// It errors if the target directory does not exist.
+// Use marks <id> as the active target for this worktree by writing it
+// to .arch/.worktree/<name>/CURRENT. It errors if the target directory
+// does not exist.
 func Use(projectRoot, id string) error {
 	targetDir := filepath.Join(projectRoot, archDirName, targetsDirName, id)
 	if _, err := os.Stat(targetDir); err != nil {
@@ -181,19 +184,16 @@ func Use(projectRoot, id string) error {
 		}
 		return fmt.Errorf("target: stat %s: %w", targetDir, err)
 	}
-
-	currentPath := filepath.Join(projectRoot, archDirName, targetsDirName, currentFileName)
-	if err := os.MkdirAll(filepath.Dir(currentPath), 0o755); err != nil {
-		return fmt.Errorf("target: create targets dir: %w", err)
-	}
-	if err := os.WriteFile(currentPath, []byte(id), 0o644); err != nil {
+	name := worktree.Name(projectRoot)
+	if err := worktree.WriteCurrent(projectRoot, name, id); err != nil {
 		return fmt.Errorf("target: write CURRENT: %w", err)
 	}
 	return nil
 }
 
-// Delete removes .arch/targets/<id>/. If <id> is the active target (CURRENT),
-// Delete fails unless force is true; when forced, CURRENT is also removed.
+// Delete removes .arch/targets/<id>/. If <id> is the active target
+// for this worktree, Delete fails unless force is true; when forced,
+// the per-worktree CURRENT pointer is also removed.
 func Delete(projectRoot, id string, force bool) error {
 	targetDir := filepath.Join(projectRoot, archDirName, targetsDirName, id)
 	if _, err := os.Stat(targetDir); err != nil {
@@ -211,23 +211,40 @@ func Delete(projectRoot, id string, force bool) error {
 		return fmt.Errorf("target: remove %s: %w", targetDir, err)
 	}
 	if cur == id {
-		_ = os.Remove(filepath.Join(projectRoot, archDirName, targetsDirName, currentFileName))
+		name := worktree.Name(projectRoot)
+		_ = worktree.RemoveCurrent(projectRoot, name)
+		// Best-effort removal of the legacy shared pointer too, so
+		// the next Current() read doesn't pick up a stale id.
+		_ = os.Remove(worktree.LegacyCurrentPath(projectRoot))
 	}
 	return nil
 }
 
-// Current returns the active target id from .arch/targets/CURRENT,
-// or an empty string if no CURRENT file exists.
+// legacyCurrentWarned tracks whether the per-process deprecation
+// notice for reading the pre-M9 .arch/targets/CURRENT path has
+// already been emitted. It keeps the warning out of scripted output
+// on every invocation while still surfacing it to operators.
+var legacyCurrentWarned sync.Once
+
+// Current returns the active target id for this worktree. Read order:
+//  1. .arch/.worktree/<name>/CURRENT (M9 layout)
+//  2. .arch/targets/CURRENT          (pre-M9 layout — deprecated)
+//
+// A missing pointer returns an empty id and no error. When the legacy
+// path is used, a deprecation warning is logged once per process.
 func Current(projectRoot string) (string, error) {
-	path := filepath.Join(projectRoot, archDirName, targetsDirName, currentFileName)
-	data, err := os.ReadFile(path)
+	name := worktree.Name(projectRoot)
+	id, fromLegacy, err := worktree.ReadCurrent(projectRoot, name)
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return "", nil
-		}
 		return "", fmt.Errorf("target: read CURRENT: %w", err)
 	}
-	return strings.TrimSpace(string(data)), nil
+	if fromLegacy {
+		legacyCurrentWarned.Do(func() {
+			fmt.Fprintln(os.Stderr,
+				"warning: reading legacy .arch/targets/CURRENT; run `archai target use <id>` to migrate to per-worktree state")
+		})
+	}
+	return id, nil
 }
 
 // --- helpers ---

--- a/internal/target/storage_test.go
+++ b/internal/target/storage_test.go
@@ -215,7 +215,16 @@ func TestUse_WritesCURRENT(t *testing.T) {
 		t.Fatalf("Use: %v", err)
 	}
 
-	data, err := os.ReadFile(filepath.Join(root, ".arch", "targets", "CURRENT"))
+	// Per-worktree CURRENT lives under .arch/.worktree/<name>/CURRENT.
+	wtDir := filepath.Join(root, ".arch", ".worktree")
+	entries, err := os.ReadDir(wtDir)
+	if err != nil {
+		t.Fatalf("read %s: %v", wtDir, err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected exactly one worktree dir under %s, got %d", wtDir, len(entries))
+	}
+	data, err := os.ReadFile(filepath.Join(wtDir, entries[0].Name(), "CURRENT"))
 	if err != nil {
 		t.Fatalf("read CURRENT: %v", err)
 	}
@@ -282,9 +291,9 @@ func TestDelete_CurrentRequiresForce(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(root, ".arch", "targets", "v1")); !os.IsNotExist(err) {
 		t.Errorf("expected target dir removed, got err=%v", err)
 	}
-	// CURRENT file should also be cleared.
-	if _, err := os.Stat(filepath.Join(root, ".arch", "targets", "CURRENT")); !os.IsNotExist(err) {
-		t.Errorf("expected CURRENT cleared, got err=%v", err)
+	// Current() must now return empty (per-worktree CURRENT cleared).
+	if cur, _ := Current(root); cur != "" {
+		t.Errorf("expected Current() empty after forced delete, got %q", cur)
 	}
 }
 

--- a/internal/worktree/signal_unix.go
+++ b/internal/worktree/signal_unix.go
@@ -1,0 +1,11 @@
+//go:build !windows
+
+package worktree
+
+import "syscall"
+
+// syscallZero is the "probe" signal used by PIDAlive. Sending signal 0
+// does not deliver anything but returns the same errors a real signal
+// would (ESRCH for a non-existent pid, EPERM for a pid owned by
+// another user). On Windows this file is replaced by a stub.
+var syscallZero syscall.Signal = 0

--- a/internal/worktree/signal_windows.go
+++ b/internal/worktree/signal_windows.go
@@ -1,0 +1,10 @@
+//go:build windows
+
+package worktree
+
+import "syscall"
+
+// syscallZero is unused on Windows (os.Process.Signal is not
+// meaningfully implemented there) — PIDAlive always returns true for
+// positive pids to avoid false negatives on an untested platform.
+var syscallZero syscall.Signal = 0

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -1,0 +1,280 @@
+// Package worktree provides per-worktree state management for the archai
+// daemon. Multiple git worktrees of the same project share the committed
+// .arch/targets/ tree but maintain independent runtime state (active
+// target pointer, running-daemon record) under .arch/.worktree/<name>/.
+//
+// Layout:
+//
+//	.arch/targets/<id>/                 (shared, committed)
+//	.arch/archai.yaml                   (shared, committed — if present)
+//	.arch/.worktree/<name>/CURRENT      (per-worktree, gitignored)
+//	.arch/.worktree/<name>/serve.json   (per-worktree, gitignored)
+//
+// The worktree <name> is derived from filepath.Base of `git rev-parse
+// --show-toplevel`; callers that are not in a git repo fall back to the
+// base name of the project root.
+package worktree
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Directory/file name constants.
+const (
+	archDirName      = ".arch"
+	worktreeDirName  = ".worktree"
+	currentFileName  = "CURRENT"
+	serveFileName    = "serve.json"
+	legacyTargetsDir = "targets" // .arch/targets/CURRENT migration path
+)
+
+// Name returns the worktree name for projectRoot. It invokes
+// `git -C <projectRoot> rev-parse --show-toplevel` and takes the base
+// name; when git is unavailable or the directory is not a git repo, it
+// falls back to filepath.Base(projectRoot).
+func Name(projectRoot string) string {
+	if top, ok := gitTopLevel(projectRoot); ok {
+		return filepath.Base(top)
+	}
+	abs, err := filepath.Abs(projectRoot)
+	if err != nil {
+		return filepath.Base(projectRoot)
+	}
+	return filepath.Base(abs)
+}
+
+// Dir returns the per-worktree state directory
+// (.arch/.worktree/<name>/) under projectRoot. The directory is NOT
+// created by this function.
+func Dir(projectRoot, name string) string {
+	return filepath.Join(projectRoot, archDirName, worktreeDirName, name)
+}
+
+// CurrentPath returns the absolute path to this worktree's CURRENT
+// pointer.
+func CurrentPath(projectRoot, name string) string {
+	return filepath.Join(Dir(projectRoot, name), currentFileName)
+}
+
+// ServePath returns the absolute path to this worktree's serve.json.
+func ServePath(projectRoot, name string) string {
+	return filepath.Join(Dir(projectRoot, name), serveFileName)
+}
+
+// LegacyCurrentPath returns the pre-M9 CURRENT location under
+// .arch/targets/CURRENT. Kept as a migration fallback.
+func LegacyCurrentPath(projectRoot string) string {
+	return filepath.Join(projectRoot, archDirName, legacyTargetsDir, currentFileName)
+}
+
+// ReadCurrent reads the active target id for the given worktree. When
+// .arch/.worktree/<name>/CURRENT is missing, it falls back to the
+// legacy .arch/targets/CURRENT location; when neither exists, it
+// returns an empty id and no error. The second return value is true
+// when the legacy path was used (callers log a deprecation warning on
+// the first such read).
+func ReadCurrent(projectRoot, name string) (id string, fromLegacy bool, err error) {
+	primary := CurrentPath(projectRoot, name)
+	data, err := os.ReadFile(primary)
+	if err == nil {
+		return strings.TrimSpace(string(data)), false, nil
+	}
+	if !errors.Is(err, fs.ErrNotExist) {
+		return "", false, fmt.Errorf("worktree: read %s: %w", primary, err)
+	}
+
+	// Fallback: legacy shared CURRENT file.
+	legacy := LegacyCurrentPath(projectRoot)
+	data, err = os.ReadFile(legacy)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return "", false, nil
+		}
+		return "", false, fmt.Errorf("worktree: read %s: %w", legacy, err)
+	}
+	return strings.TrimSpace(string(data)), true, nil
+}
+
+// WriteCurrent sets the active target id for the given worktree. The
+// file is written atomically (temp file + rename).
+func WriteCurrent(projectRoot, name, id string) error {
+	if err := os.MkdirAll(Dir(projectRoot, name), 0o755); err != nil {
+		return fmt.Errorf("worktree: create %s: %w", Dir(projectRoot, name), err)
+	}
+	return atomicWrite(CurrentPath(projectRoot, name), []byte(id), 0o644)
+}
+
+// RemoveCurrent deletes the per-worktree CURRENT pointer. A missing
+// file is not an error.
+func RemoveCurrent(projectRoot, name string) error {
+	err := os.Remove(CurrentPath(projectRoot, name))
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return err
+	}
+	return nil
+}
+
+// ServeRecord is the JSON payload written to serve.json by a running
+// daemon so peer tools (`archai where`, `archai list-daemons`) can
+// discover live daemons without probing ports.
+type ServeRecord struct {
+	PID       int    `json:"pid"`
+	HTTPAddr  string `json:"http_addr"`
+	StartedAt string `json:"started_at"` // RFC3339
+}
+
+// WriteServe writes rec to .arch/.worktree/<name>/serve.json atomically.
+// The containing directory is created if necessary.
+func WriteServe(projectRoot, name string, rec ServeRecord) error {
+	if err := os.MkdirAll(Dir(projectRoot, name), 0o755); err != nil {
+		return fmt.Errorf("worktree: create %s: %w", Dir(projectRoot, name), err)
+	}
+	data, err := json.MarshalIndent(rec, "", "  ")
+	if err != nil {
+		return fmt.Errorf("worktree: marshal serve.json: %w", err)
+	}
+	return atomicWrite(ServePath(projectRoot, name), data, 0o644)
+}
+
+// ReadServe reads this worktree's serve.json. Returns (nil, nil) when
+// the file does not exist.
+func ReadServe(projectRoot, name string) (*ServeRecord, error) {
+	return readServeFile(ServePath(projectRoot, name))
+}
+
+// RemoveServe deletes this worktree's serve.json. A missing file is
+// not an error.
+func RemoveServe(projectRoot, name string) error {
+	err := os.Remove(ServePath(projectRoot, name))
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return err
+	}
+	return nil
+}
+
+// LiveDaemon pairs a worktree name with the decoded serve.json record
+// and its mtime (used as a best-effort uptime source). Only daemons
+// whose PID responds to signal 0 (i.e. the process exists) are
+// returned by ListDaemons.
+type LiveDaemon struct {
+	Worktree  string
+	Record    ServeRecord
+	StartedAt time.Time // parsed from Record.StartedAt when valid
+}
+
+// ListDaemons scans .arch/.worktree/*/serve.json under projectRoot and
+// returns records whose PID still refers to a live process. Stale
+// records (process exited without cleanup) are skipped. The result is
+// sorted by worktree name.
+func ListDaemons(projectRoot string) ([]LiveDaemon, error) {
+	root := filepath.Join(projectRoot, archDirName, worktreeDirName)
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("worktree: read %s: %w", root, err)
+	}
+
+	var out []LiveDaemon
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		wt := e.Name()
+		rec, err := readServeFile(filepath.Join(root, wt, serveFileName))
+		if err != nil || rec == nil {
+			continue
+		}
+		if !PIDAlive(rec.PID) {
+			continue
+		}
+		started, _ := time.Parse(time.RFC3339, rec.StartedAt)
+		out = append(out, LiveDaemon{
+			Worktree:  wt,
+			Record:    *rec,
+			StartedAt: started,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Worktree < out[j].Worktree })
+	return out, nil
+}
+
+// PIDAlive reports whether pid refers to a process we can signal (i.e.
+// the process exists and is visible to this user). A zero/negative pid
+// is treated as dead.
+func PIDAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	// On Unix, FindProcess always succeeds; signal 0 probes existence.
+	if err := proc.Signal(syscallZero); err != nil {
+		return false
+	}
+	return true
+}
+
+// --- helpers ---
+
+// atomicWrite writes data to path via <path>.tmp + rename so readers
+// never see a half-written file. The parent directory is assumed to
+// exist.
+func atomicWrite(path string, data []byte, perm os.FileMode) error {
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, perm); err != nil {
+		return fmt.Errorf("worktree: write %s: %w", tmp, err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("worktree: rename %s -> %s: %w", tmp, path, err)
+	}
+	return nil
+}
+
+// gitTopLevel returns the output of `git -C dir rev-parse
+// --show-toplevel`, trimmed. The second return value is false when git
+// is unavailable or dir is not inside a git worktree.
+func gitTopLevel(dir string) (string, bool) {
+	cmd := exec.Command("git", "-C", dir, "rev-parse", "--show-toplevel")
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	if err := cmd.Run(); err != nil {
+		return "", false
+	}
+	out := strings.TrimSpace(buf.String())
+	if out == "" {
+		return "", false
+	}
+	return out, true
+}
+
+// readServeFile decodes a serve.json record from path, tolerating
+// missing files (returns nil, nil) and surfaces other errors.
+func readServeFile(path string) (*ServeRecord, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("worktree: read %s: %w", path, err)
+	}
+	var rec ServeRecord
+	if err := json.Unmarshal(data, &rec); err != nil {
+		return nil, fmt.Errorf("worktree: parse %s: %w", path, err)
+	}
+	return &rec, nil
+}

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -1,0 +1,215 @@
+package worktree
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestName_FallbackToProjectRootBasename(t *testing.T) {
+	root := t.TempDir()
+	// No git repo: Name must fall back to filepath.Base.
+	got := Name(root)
+	if got != filepath.Base(root) {
+		t.Errorf("Name(%q) = %q, want %q", root, got, filepath.Base(root))
+	}
+}
+
+func TestName_UsesGitTopLevelBasename(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	root := t.TempDir()
+	wt := filepath.Join(root, "myproj")
+	if err := os.MkdirAll(wt, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if out, err := exec.Command("git", "-C", wt, "init").CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v: %s", err, out)
+	}
+
+	// Inside the repo, Name should return "myproj".
+	if got := Name(wt); got != "myproj" {
+		t.Errorf("Name inside repo = %q, want %q", got, "myproj")
+	}
+	// From a sub-directory, Name should still return the top-level basename.
+	sub := filepath.Join(wt, "internal")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatalf("mkdir sub: %v", err)
+	}
+	if got := Name(sub); got != "myproj" {
+		t.Errorf("Name in sub = %q, want %q", got, "myproj")
+	}
+}
+
+func TestCurrent_RoundTrip(t *testing.T) {
+	root := t.TempDir()
+	name := "wt1"
+
+	// Missing file -> empty, not-from-legacy, no error.
+	got, fromLegacy, err := ReadCurrent(root, name)
+	if err != nil {
+		t.Fatalf("ReadCurrent: %v", err)
+	}
+	if got != "" || fromLegacy {
+		t.Fatalf("missing file: got (%q, %v), want (\"\", false)", got, fromLegacy)
+	}
+
+	if err := WriteCurrent(root, name, "v1"); err != nil {
+		t.Fatalf("WriteCurrent: %v", err)
+	}
+	got, fromLegacy, err = ReadCurrent(root, name)
+	if err != nil {
+		t.Fatalf("ReadCurrent: %v", err)
+	}
+	if got != "v1" || fromLegacy {
+		t.Fatalf("after write: got (%q, %v), want (\"v1\", false)", got, fromLegacy)
+	}
+
+	if err := RemoveCurrent(root, name); err != nil {
+		t.Fatalf("RemoveCurrent: %v", err)
+	}
+	got, _, err = ReadCurrent(root, name)
+	if err != nil {
+		t.Fatalf("ReadCurrent post-remove: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("after remove: got %q, want empty", got)
+	}
+}
+
+func TestCurrent_LegacyFallback(t *testing.T) {
+	root := t.TempDir()
+	// Seed the pre-M9 location.
+	legacyDir := filepath.Join(root, ".arch", "targets")
+	if err := os.MkdirAll(legacyDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(legacyDir, "CURRENT"), []byte("legacy-v1\n"), 0o644); err != nil {
+		t.Fatalf("seed legacy: %v", err)
+	}
+
+	got, fromLegacy, err := ReadCurrent(root, "wt1")
+	if err != nil {
+		t.Fatalf("ReadCurrent: %v", err)
+	}
+	if got != "legacy-v1" {
+		t.Fatalf("id = %q, want %q", got, "legacy-v1")
+	}
+	if !fromLegacy {
+		t.Fatalf("fromLegacy = false, want true")
+	}
+
+	// After WriteCurrent, the new location takes precedence and the
+	// legacy flag is no longer reported.
+	if err := WriteCurrent(root, "wt1", "new-v2"); err != nil {
+		t.Fatalf("WriteCurrent: %v", err)
+	}
+	got, fromLegacy, err = ReadCurrent(root, "wt1")
+	if err != nil {
+		t.Fatalf("ReadCurrent: %v", err)
+	}
+	if got != "new-v2" || fromLegacy {
+		t.Fatalf("after new write: (%q, %v), want (\"new-v2\", false)", got, fromLegacy)
+	}
+}
+
+func TestServe_RoundTrip(t *testing.T) {
+	root := t.TempDir()
+	name := "wt1"
+
+	rec := ServeRecord{
+		PID:       os.Getpid(),
+		HTTPAddr:  "127.0.0.1:54321",
+		StartedAt: time.Now().UTC().Format(time.RFC3339),
+	}
+	if err := WriteServe(root, name, rec); err != nil {
+		t.Fatalf("WriteServe: %v", err)
+	}
+
+	got, err := ReadServe(root, name)
+	if err != nil {
+		t.Fatalf("ReadServe: %v", err)
+	}
+	if got == nil {
+		t.Fatal("ReadServe returned nil")
+	}
+	if got.PID != rec.PID || got.HTTPAddr != rec.HTTPAddr || got.StartedAt != rec.StartedAt {
+		t.Fatalf("round-trip mismatch: got %+v, want %+v", *got, rec)
+	}
+
+	if err := RemoveServe(root, name); err != nil {
+		t.Fatalf("RemoveServe: %v", err)
+	}
+	got, err = ReadServe(root, name)
+	if err != nil {
+		t.Fatalf("ReadServe post-remove: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil after remove, got %+v", got)
+	}
+}
+
+func TestPIDAlive(t *testing.T) {
+	if !PIDAlive(os.Getpid()) {
+		t.Error("PIDAlive(self) = false, want true")
+	}
+	if PIDAlive(0) {
+		t.Error("PIDAlive(0) = true, want false")
+	}
+	if PIDAlive(-1) {
+		t.Error("PIDAlive(-1) = true, want false")
+	}
+	// An extremely high pid is almost certainly free.
+	if PIDAlive(0x7fff_fffe) {
+		t.Error("PIDAlive(huge) = true, want false")
+	}
+}
+
+func TestListDaemons_FiltersStale(t *testing.T) {
+	root := t.TempDir()
+
+	live := ServeRecord{PID: os.Getpid(), HTTPAddr: "127.0.0.1:1111", StartedAt: time.Now().UTC().Format(time.RFC3339)}
+	if err := WriteServe(root, "alive", live); err != nil {
+		t.Fatalf("WriteServe alive: %v", err)
+	}
+
+	// Write a stale record with a very high pid to ensure it doesn't
+	// refer to a live process on the test host.
+	stale := ServeRecord{PID: 0x7fff_fffe, HTTPAddr: "127.0.0.1:2222", StartedAt: time.Now().UTC().Format(time.RFC3339)}
+	if err := WriteServe(root, "stale", stale); err != nil {
+		t.Fatalf("WriteServe stale: %v", err)
+	}
+
+	// A directory without serve.json should be silently skipped.
+	if err := os.MkdirAll(filepath.Join(root, ".arch", ".worktree", "empty"), 0o755); err != nil {
+		t.Fatalf("mkdir empty: %v", err)
+	}
+
+	daemons, err := ListDaemons(root)
+	if err != nil {
+		t.Fatalf("ListDaemons: %v", err)
+	}
+	if len(daemons) != 1 {
+		t.Fatalf("got %d live daemons, want 1: %+v", len(daemons), daemons)
+	}
+	if daemons[0].Worktree != "alive" {
+		t.Errorf("Worktree = %q, want %q", daemons[0].Worktree, "alive")
+	}
+	if daemons[0].Record.PID != os.Getpid() {
+		t.Errorf("PID = %d, want %d", daemons[0].Record.PID, os.Getpid())
+	}
+}
+
+func TestListDaemons_MissingRoot(t *testing.T) {
+	root := t.TempDir()
+	daemons, err := ListDaemons(root)
+	if err != nil {
+		t.Fatalf("ListDaemons: %v", err)
+	}
+	if len(daemons) != 0 {
+		t.Fatalf("got %d daemons, want 0", len(daemons))
+	}
+}


### PR DESCRIPTION
Closes #49.

## Summary

Let multiple git worktrees of the same project run `archai serve` in parallel without port or `CURRENT`-pointer collisions.

## Acceptance criteria

- [x] **Split `.arch/` layout** — shared `.arch/targets/<id>/` + `.arch/archai.yaml` stay committed; per-worktree runtime state moves to `.arch/.worktree/<name>/{CURRENT,serve.json}`.
- [x] **Worktree-name resolver** — `filepath.Base(git rev-parse --show-toplevel)` with a fallback to `filepath.Base(projectRoot)` when git is unavailable / the dir isn't a worktree.
- [x] **Per-worktree CURRENT** — `target.Use` writes `.arch/.worktree/<name>/CURRENT`; `target.Current` reads it, falling back to legacy `.arch/targets/CURRENT` and emitting a one-shot deprecation warning so old layouts keep working during migration.
- [x] **`--http` default `:0`** — parallel worktrees never fight over a fixed port; explicit `--http :8080` still works.
- [x] **serve.json lifecycle** — written atomically (temp + rename) on successful bind; removed on graceful shutdown. Contents: `{pid, http_addr, started_at}`.
- [x] **`archai where`** — prints `http://<addr>` of this worktree's live daemon; errors when no daemon is running or the recorded PID is stale.
- [x] **`archai list-daemons`** — scans `.arch/.worktree/*/serve.json`, filters via signal-0 PID probe, prints a worktree / PID / URL / uptime table.
- [x] **`.gitignore`** — adds `.arch/.worktree/` entry.

## Implementation notes

- `HTTPTransport.Serve` grew a `ready(boundAddr string)` callback so the daemon learns the real port assigned by the kernel when `--http=:0`. The `internal/adapter/http` transport calls it right after `net.Listen` succeeds.
- `internal/worktree` is a leaf package (no archai imports) so `serve` and `target` can both depend on it without cycles.
- PID-alive check uses `os.Process.Signal(syscall.Signal(0))` on Unix; Windows build-tags keep the package portable.

## Out of scope (per ticket)

- myhome wrapper integration.
- Cross-host worktrees.
- Multi-serve-in-same-worktree locking.

## Downstream dependencies

Both **#50** (M10) and **#51** (M11) build on `serve.json` as the discovery mechanism for peer daemons; this PR establishes that contract.

## Test plan

- [x] `go test ./...` — all packages green.
- [x] `go vet ./...` — clean.
- [x] `gofmt -l` — clean on touched files.
- [x] New unit tests:
  - `internal/worktree` — name resolver (git + fallback), CURRENT round-trip + legacy fallback, serve.json round-trip, `PIDAlive`, `ListDaemons` live/stale filtering.
  - `internal/serve` — full `Serve` lifecycle with a fake HTTP transport; verifies `serve.json` appears with correct `pid`/`http_addr`/`started_at` and is removed on cancel.
  - `internal/adapter/http` — `ready` callback receives the real bound addr; full end-to-end lifecycle serves on `:0`, reads the URL from `serve.json`, hits `/`, then shuts down and asserts `serve.json` is gone.
  - `internal/target` — updated tests assert the new per-worktree CURRENT path.