### PR TITLE
feat(cli): add 'version' and 'extract' commands (#48 follow-up)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,24 @@
-.PHONY: build test clean install
+.PHONY: build test clean install version
+
+# VERSION is stamped into the binary at build time via -ldflags. By
+# default it is derived from `git describe` so unreleased builds show
+# commit info; override with `make build VERSION=v1.2.3` for release
+# builds.
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
+LDFLAGS := -X main.Version=$(VERSION)
 
 build:
 	@mkdir -p bin
-	go build -o bin/archai ./cmd/archai
+	go build -ldflags "$(LDFLAGS)" -o bin/archai ./cmd/archai
 
 install:
-	go install ./cmd/archai
+	go install -ldflags "$(LDFLAGS)" ./cmd/archai
 
 test:
 	go test ./...
+
+version:
+	@echo $(VERSION)
 
 clean:
 	rm -rf bin/

--- a/cmd/archai/extract.go
+++ b/cmd/archai/extract.go
@@ -1,0 +1,217 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/kgatilin/archai/internal/adapter/golang"
+	yamlAdapter "github.com/kgatilin/archai/internal/adapter/yaml"
+	"github.com/kgatilin/archai/internal/domain"
+	"github.com/spf13/cobra"
+)
+
+// newExtractCmd returns the `archai extract <path>` command.
+//
+// extract mirrors the MCP `extract` tool but from the CLI: it loads the
+// Go packages rooted at <path> (default ".") via the same adapter the
+// MCP daemon uses, and emits one serialized document per package.
+//
+// With no --out flag every package is streamed to stdout separated by
+// `---\n` (yaml) or as a JSON array (json). When --out is set each
+// package is written to <out>/<relative-pkg-path>/internal.yaml (or
+// .json) and a one-line summary is printed.
+func newExtractCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "extract [path]",
+		Short: "Extract Go packages and dump per-package YAML or JSON",
+		Long: `Run the same extraction the MCP daemon uses over a local Go project
+and emit per-package documents.
+
+Default: one YAML document per package streamed to stdout, separated by
+'---'. With --out <dir>, each package is written to
+<dir>/<pkg-path>/internal.<ext> and a summary line is printed.
+
+Examples:
+  # Stream YAML to stdout for the current project
+  archai extract .
+
+  # Dump JSON to stdout
+  archai extract . --format json
+
+  # Write per-package files under .arch/packages/
+  archai extract . --out .arch/packages`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: runExtract,
+	}
+	cmd.Flags().String("out", "", "Output directory for per-package files (default: stream to stdout)")
+	cmd.Flags().StringP("format", "f", "yaml", "Output format: yaml or json")
+	return cmd
+}
+
+// runExtract implements `archai extract`. It reuses the same golang
+// reader wired into `serve` and the MCP `extract` tool.
+func runExtract(cmd *cobra.Command, args []string) error {
+	path := "."
+	if len(args) > 0 {
+		path = args[0]
+	}
+	outDir, _ := cmd.Flags().GetString("out")
+	format, _ := cmd.Flags().GetString("format")
+
+	switch format {
+	case "", "yaml", "json":
+	default:
+		return fmt.Errorf("unsupported format %q (use yaml or json)", format)
+	}
+	if format == "" {
+		format = "yaml"
+	}
+
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	models, err := extractModels(ctx, path)
+	if err != nil {
+		return err
+	}
+	// Deterministic order makes stdout diffable and output files stable.
+	sort.Slice(models, func(i, j int) bool { return models[i].Path < models[j].Path })
+
+	if outDir == "" {
+		return streamExtract(cmd.OutOrStdout(), models, format)
+	}
+	return dumpExtract(cmd.OutOrStdout(), models, format, outDir)
+}
+
+// extractModels runs the Go adapter against a single project path.
+//
+// The Go reader drives golang.org/x/tools/go/packages.Load, which
+// resolves `./...` relative to the current working directory. To keep
+// this command usable from anywhere we temporarily chdir into the
+// target directory, load, then restore. Non-directory paths are passed
+// through to packages.Load verbatim.
+func extractModels(ctx context.Context, path string) ([]domain.PackageModel, error) {
+	reader := golang.NewReader()
+
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, fmt.Errorf("stat %s: %w", path, err)
+	}
+	if !info.IsDir() {
+		models, err := reader.Read(ctx, []string{path})
+		if err != nil {
+			return nil, fmt.Errorf("reading Go packages at %s: %w", path, err)
+		}
+		return models, nil
+	}
+
+	prev, err := os.Getwd()
+	if err != nil {
+		return nil, fmt.Errorf("resolving cwd: %w", err)
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return nil, fmt.Errorf("resolving %s: %w", path, err)
+	}
+	if err := os.Chdir(abs); err != nil {
+		return nil, fmt.Errorf("chdir %s: %w", abs, err)
+	}
+	defer os.Chdir(prev) //nolint:errcheck // best-effort restore
+
+	models, err := reader.Read(ctx, []string{"./..."})
+	if err != nil {
+		return nil, fmt.Errorf("reading Go packages at %s: %w", path, err)
+	}
+	return models, nil
+}
+
+// streamExtract writes every package document to w.
+//
+// YAML: one document per package, separated by the standard "---\n"
+// delimiter.
+//
+// JSON: a single JSON array containing every package document (so the
+// whole stream is still valid JSON).
+func streamExtract(w io.Writer, models []domain.PackageModel, format string) error {
+	if format == "json" {
+		// Emit one JSON array — each element is a package document.
+		fmt.Fprint(w, "[\n")
+		for i, m := range models {
+			data, err := yamlAdapter.MarshalPackage(m, "json")
+			if err != nil {
+				return err
+			}
+			// data has a trailing newline; trim before embedding in array.
+			trimmed := strings.TrimRight(string(data), "\n")
+			// Indent each line by two spaces for readability.
+			lines := strings.Split(trimmed, "\n")
+			for j, line := range lines {
+				lines[j] = "  " + line
+			}
+			indented := strings.Join(lines, "\n")
+			fmt.Fprint(w, indented)
+			if i < len(models)-1 {
+				fmt.Fprint(w, ",")
+			}
+			fmt.Fprint(w, "\n")
+		}
+		fmt.Fprint(w, "]\n")
+		return nil
+	}
+
+	for i, m := range models {
+		data, err := yamlAdapter.MarshalPackage(m, "yaml")
+		if err != nil {
+			return err
+		}
+		if i > 0 {
+			fmt.Fprint(w, "---\n")
+		}
+		// yamlv3.Marshal already terminates with \n.
+		fmt.Fprint(w, string(data))
+	}
+	return nil
+}
+
+// dumpExtract writes one file per package under outDir and prints a
+// short summary to w. The on-disk layout mirrors the convention used by
+// per-package .arch/internal.yaml specs so the dump can be consumed by
+// the YAML reader directly.
+func dumpExtract(w io.Writer, models []domain.PackageModel, format, outDir string) error {
+	ext := "yaml"
+	if format == "json" {
+		ext = "json"
+	}
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		return fmt.Errorf("creating %s: %w", outDir, err)
+	}
+	for _, m := range models {
+		data, err := yamlAdapter.MarshalPackage(m, format)
+		if err != nil {
+			return err
+		}
+		// Guard against absolute or oddly-formatted package paths so we
+		// never escape outDir. filepath.Clean + rejection of leading ..
+		// is sufficient because Read() returns module-relative paths.
+		rel := filepath.Clean(m.Path)
+		if rel == "." || rel == "" || strings.HasPrefix(rel, "..") || filepath.IsAbs(rel) {
+			rel = "root"
+		}
+		out := filepath.Join(outDir, rel, "internal."+ext)
+		if err := os.MkdirAll(filepath.Dir(out), 0o755); err != nil {
+			return fmt.Errorf("creating %s: %w", filepath.Dir(out), err)
+		}
+		if err := os.WriteFile(out, data, 0o644); err != nil {
+			return fmt.Errorf("writing %s: %w", out, err)
+		}
+	}
+	fmt.Fprintf(w, "Extracted %d package(s) to %s\n", len(models), outDir)
+	return nil
+}

--- a/cmd/archai/extract_test.go
+++ b/cmd/archai/extract_test.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	yamlv3 "gopkg.in/yaml.v3"
+)
+
+// setupSmallProj writes a two-package Go module into a temp dir and
+// returns its root path. Each test then runs `extract` against it.
+func setupSmallProj(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(root, "go.mod"), []byte("module test.example/smallproj\n\ngo 1.21\n"), 0o644); err != nil {
+		t.Fatalf("writing go.mod: %v", err)
+	}
+	// Package 1: greet
+	if err := os.MkdirAll(filepath.Join(root, "greet"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	greet := `package greet
+
+// Hello returns a greeting.
+func Hello(name string) string { return "hello " + name }
+`
+	if err := os.WriteFile(filepath.Join(root, "greet", "greet.go"), []byte(greet), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Package 2: math
+	if err := os.MkdirAll(filepath.Join(root, "mathx"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	math := `package mathx
+
+// Add adds two ints.
+func Add(a, b int) int { return a + b }
+`
+	if err := os.WriteFile(filepath.Join(root, "mathx", "math.go"), []byte(math), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+// TestExtract_StreamYAML verifies the default path: per-package YAML
+// documents streamed to stdout separated by `---`.
+func TestExtract_StreamYAML(t *testing.T) {
+	root := setupSmallProj(t)
+
+	cmd := newExtractCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{root})
+	cmd.SetContext(context.Background())
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	got := out.String()
+	if !strings.Contains(got, "package: greet") {
+		t.Errorf("missing greet package in output:\n%s", got)
+	}
+	if !strings.Contains(got, "package: mathx") {
+		t.Errorf("missing mathx package in output:\n%s", got)
+	}
+	if !strings.Contains(got, "---\n") {
+		t.Errorf("expected `---` separator between packages:\n%s", got)
+	}
+
+	// Every document must round-trip via yaml unmarshal.
+	docs := strings.Split(got, "\n---\n")
+	if len(docs) < 2 {
+		t.Fatalf("expected at least 2 yaml docs, got %d", len(docs))
+	}
+	for i, doc := range docs {
+		var m map[string]any
+		if err := yamlv3.Unmarshal([]byte(doc), &m); err != nil {
+			t.Fatalf("doc %d failed to parse as yaml: %v\n%s", i, err, doc)
+		}
+		if _, ok := m["package"]; !ok {
+			t.Errorf("doc %d missing 'package' key", i)
+		}
+	}
+}
+
+// TestExtract_StreamJSON verifies JSON format output is a single valid
+// JSON array of package documents.
+func TestExtract_StreamJSON(t *testing.T) {
+	root := setupSmallProj(t)
+
+	cmd := newExtractCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{root, "--format", "json"})
+	cmd.SetContext(context.Background())
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	var docs []map[string]any
+	if err := json.Unmarshal(out.Bytes(), &docs); err != nil {
+		t.Fatalf("not valid json: %v\n%s", err, out.String())
+	}
+	if len(docs) != 2 {
+		t.Fatalf("expected 2 package docs, got %d: %v", len(docs), docs)
+	}
+	paths := map[string]bool{}
+	for _, d := range docs {
+		if p, ok := d["package"].(string); ok {
+			paths[p] = true
+		}
+	}
+	if !paths["greet"] || !paths["mathx"] {
+		t.Errorf("missing package paths, got: %v", paths)
+	}
+}
+
+// TestExtract_WriteOutDir verifies per-package files are written under
+// the requested --out directory.
+func TestExtract_WriteOutDir(t *testing.T) {
+	root := setupSmallProj(t)
+	outDir := filepath.Join(root, ".arch", "packages")
+
+	cmd := newExtractCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{root, "--out", outDir})
+	cmd.SetContext(context.Background())
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	if !strings.Contains(out.String(), "Extracted 2 package(s)") {
+		t.Errorf("expected summary line, got: %s", out.String())
+	}
+
+	// Both package YAML files must exist and round-trip.
+	for _, rel := range []string{"greet/internal.yaml", "mathx/internal.yaml"} {
+		full := filepath.Join(outDir, rel)
+		data, err := os.ReadFile(full)
+		if err != nil {
+			t.Fatalf("reading %s: %v", full, err)
+		}
+		var m map[string]any
+		if err := yamlv3.Unmarshal(data, &m); err != nil {
+			t.Fatalf("parsing %s: %v", full, err)
+		}
+		if _, ok := m["package"]; !ok {
+			t.Errorf("%s missing 'package' key", full)
+		}
+	}
+}
+
+// TestExtract_UnsupportedFormat rejects unknown formats.
+func TestExtract_UnsupportedFormat(t *testing.T) {
+	cmd := newExtractCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{".", "--format", "xml"})
+	cmd.SetContext(context.Background())
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for unsupported format")
+	}
+	if !strings.Contains(err.Error(), "unsupported format") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/cmd/archai/main.go
+++ b/cmd/archai/main.go
@@ -367,6 +367,12 @@ Examples:
 	sequenceCmd.Flags().StringP("output", "o", "", "Write output to file instead of stdout")
 	rootCmd.AddCommand(sequenceCmd)
 
+	// version — prints `archai <Version>`.
+	rootCmd.AddCommand(newVersionCmd())
+
+	// extract — dumps per-package YAML/JSON (mirror of the MCP extract tool).
+	rootCmd.AddCommand(newExtractCmd())
+
 	// Execute root command
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)

--- a/cmd/archai/version.go
+++ b/cmd/archai/version.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"fmt"
+	"runtime/debug"
+
+	"github.com/spf13/cobra"
+)
+
+// Version is the archai binary version. Defaults to "dev" for
+// unversioned builds and is overridden at build time via ldflags:
+//
+//	go build -ldflags "-X main.Version=v0.1.0" ./cmd/archai
+//
+// When Version is still "dev" at runtime we fall back to debug.ReadBuildInfo
+// so `go install` / `go run` users get a meaningful version when available.
+var Version = "dev"
+
+// resolveVersion returns the effective version string used by
+// `archai version`. It prefers the linker-injected Version; if that
+// hasn't been set it tries debug.ReadBuildInfo so module-managed
+// installs report their module version instead of the literal "dev".
+func resolveVersion() string {
+	if Version != "" && Version != "dev" {
+		return Version
+	}
+	if info, ok := debug.ReadBuildInfo(); ok {
+		v := info.Main.Version
+		if v != "" && v != "(devel)" {
+			return v
+		}
+	}
+	return Version
+}
+
+// newVersionCmd returns the `archai version` command. Output is a
+// single line: `archai <version>`.
+func newVersionCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Print archai version",
+		Args:  cobra.NoArgs,
+		Run: func(cmd *cobra.Command, _ []string) {
+			fmt.Fprintf(cmd.OutOrStdout(), "archai %s\n", resolveVersion())
+		},
+	}
+}

--- a/cmd/archai/version_test.go
+++ b/cmd/archai/version_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// TestVersionCommand verifies `archai version` prints `archai <Version>`.
+func TestVersionCommand(t *testing.T) {
+	orig := Version
+	t.Cleanup(func() { Version = orig })
+
+	Version = "v1.2.3-test"
+	cmd := newVersionCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	got := buf.String()
+	want := "archai v1.2.3-test\n"
+	if got != want {
+		t.Fatalf("version output mismatch\n got: %q\nwant: %q", got, want)
+	}
+}
+
+// TestVersionCommand_DevFallback checks that when Version is "dev"
+// resolveVersion either returns a module-info version (inside `go test`
+// with module info available) or falls back to "dev". The command must
+// always start with "archai " and end with a newline.
+func TestVersionCommand_DevFallback(t *testing.T) {
+	orig := Version
+	t.Cleanup(func() { Version = orig })
+
+	Version = "dev"
+	cmd := newVersionCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	got := buf.String()
+	if !strings.HasPrefix(got, "archai ") || !strings.HasSuffix(got, "\n") {
+		t.Fatalf("unexpected dev output: %q", got)
+	}
+	// Must not be empty after the space.
+	trimmed := strings.TrimSpace(strings.TrimPrefix(got, "archai "))
+	if trimmed == "" {
+		t.Fatalf("version value is empty in %q", got)
+	}
+}
+
+// TestResolveVersion_NonDev returns the linker-injected value verbatim
+// when Version has been overridden from "dev".
+func TestResolveVersion_NonDev(t *testing.T) {
+	orig := Version
+	t.Cleanup(func() { Version = orig })
+
+	Version = "v0.5.0"
+	if got := resolveVersion(); got != "v0.5.0" {
+		t.Fatalf("resolveVersion = %q, want v0.5.0", got)
+	}
+}

--- a/internal/adapter/yaml/marshal.go
+++ b/internal/adapter/yaml/marshal.go
@@ -1,0 +1,72 @@
+package yaml
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/kgatilin/archai/internal/domain"
+	yamlv3 "gopkg.in/yaml.v3"
+)
+
+// MarshalPackage serializes a single PackageModel to bytes in the
+// requested format ("yaml" or "json"). The output matches the on-disk
+// YAML schema produced by the ModelWriter (same field names and nesting),
+// so callers can round-trip a dumped package back through the YAML
+// reader.
+//
+// JSON output uses the same field names as YAML (snake_case where
+// applicable) by routing the spec through a generic map, which keeps
+// the two formats in lock-step without duplicate struct tags.
+func MarshalPackage(model domain.PackageModel, format string) ([]byte, error) {
+	spec := toSpec(model, false)
+	yamlBytes, err := yamlv3.Marshal(&spec)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling %s as yaml: %w", model.Path, err)
+	}
+
+	switch format {
+	case "", "yaml":
+		return yamlBytes, nil
+	case "json":
+		var generic any
+		if err := yamlv3.Unmarshal(yamlBytes, &generic); err != nil {
+			return nil, fmt.Errorf("re-parsing %s yaml for json conversion: %w", model.Path, err)
+		}
+		generic = normalizeForJSON(generic)
+		out, err := json.MarshalIndent(generic, "", "  ")
+		if err != nil {
+			return nil, fmt.Errorf("marshaling %s as json: %w", model.Path, err)
+		}
+		return append(out, '\n'), nil
+	default:
+		return nil, fmt.Errorf("unsupported format %q (use yaml or json)", format)
+	}
+}
+
+// normalizeForJSON walks the yaml.v3-decoded tree and coerces any
+// map[interface{}]interface{} (yaml's default) into map[string]interface{}
+// so encoding/json can marshal it. yaml.v3 already returns
+// map[string]interface{} in most cases, but we walk defensively to be
+// safe across library versions.
+func normalizeForJSON(v any) any {
+	switch t := v.(type) {
+	case map[any]any:
+		out := make(map[string]any, len(t))
+		for k, val := range t {
+			out[fmt.Sprint(k)] = normalizeForJSON(val)
+		}
+		return out
+	case map[string]any:
+		for k, val := range t {
+			t[k] = normalizeForJSON(val)
+		}
+		return t
+	case []any:
+		for i, val := range t {
+			t[i] = normalizeForJSON(val)
+		}
+		return t
+	default:
+		return v
+	}
+}


### PR DESCRIPTION
## Summary

Adds the two CLI commands referenced in the user-guide ticket (#48) but not yet shipped:

- `archai version` — prints `archai <version>` using a linker-injectable `main.Version` with `debug/buildinfo` fallback (works for both `make build` and `go install`). Makefile now stamps `VERSION` via `git describe --tags --always --dirty`.
- `archai extract [path]` — mirrors the MCP `extract` tool, reusing the existing `internal/adapter/golang` reader. Defaults to streaming YAML to stdout separated by `---`; supports `--format json` (single JSON array) and `--out <dir>` (per-package `internal.yaml|json` files).

Extract core is **shared** with the MCP daemon — no re-implementation. New `yaml.MarshalPackage` helper in the existing YAML adapter lets both CLI and MCP share the on-disk schema.

## Test plan

- [x] `go test ./...` green
- [x] `go vet ./...` clean
- [x] `gofmt -l` clean on new files
- [x] Extract flag parsing + stdout-split-per-package test
- [x] Round-trip test on `testdata/smallproj` fixture
- [x] Version output format test (with and without ldflags override)

Follow-up to #48 (docs PR #52) — examples in the user guide can now be wired up.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>