### PR TITLE
feat: M10 multi-worktree serve mode (#50)

### DIFF
--- a/cmd/archai/main.go
+++ b/cmd/archai/main.go
@@ -313,6 +313,10 @@ manual verification and as a base for future features.`,
 	// port; the bound address is recorded in .arch/.worktree/<name>/serve.json
 	// for `archai where` / `archai list-daemons` to discover.
 	serveCmd.Flags().String("http", ":0", "HTTP transport address (\"\" disables HTTP; default :0 picks a free port)")
+	// M10: --multi discovers every git worktree of the project and
+	// exposes each under /w/{name}/ so a single daemon can drive them
+	// all. Omit the flag to keep the classic single-worktree behaviour.
+	serveCmd.Flags().Bool("multi", false, "Serve every git worktree under /w/{name}/* (multi-worktree mode)")
 	serveCmd.Flags().Bool("debug", false, "Verbose per-event logging")
 	rootCmd.AddCommand(serveCmd)
 
@@ -386,6 +390,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 	mcpStdio, _ := cmd.Flags().GetBool("mcp-stdio")
 	httpAddr, _ := cmd.Flags().GetString("http")
 	debug, _ := cmd.Flags().GetBool("debug")
+	multi, _ := cmd.Flags().GetBool("multi")
 
 	parent := cmd.Context()
 	if parent == nil {
@@ -394,18 +399,42 @@ func runServe(cmd *cobra.Command, args []string) error {
 	ctx, stop := signal.NotifyContext(parent, os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	return serve.Serve(ctx, serve.Options{
+	opts := serve.Options{
 		Root:     root,
 		MCPStdio: mcpStdio,
 		MCPServe: func(ctx context.Context, state *serve.State) error {
 			return mcp.Serve(ctx, state)
 		},
 		HTTPAddr: httpAddr,
-		HTTPServerFactory: func(state *serve.State) (serve.HTTPTransport, error) {
+		Debug:    debug,
+	}
+
+	if multi {
+		if mcpStdio {
+			return fmt.Errorf("--multi is not compatible with --mcp-stdio")
+		}
+		// Discover worktrees up-front. The MultiState is shared with
+		// the HTTP server so lazy-loads of individual worktree models
+		// happen on first request.
+		absRoot := root
+		if absRoot == "" {
+			absRoot = "."
+		}
+		multiState := serve.NewMultiState(absRoot, serve.DefaultStateLoader)
+		if err := multiState.Refresh(); err != nil {
+			return fmt.Errorf("serve: refresh worktrees: %w", err)
+		}
+		opts.MultiState = multiState
+		opts.HTTPServerFactory = func(_ *serve.State) (serve.HTTPTransport, error) {
+			return httpAdapter.NewMultiServer(multiState)
+		}
+	} else {
+		opts.HTTPServerFactory = func(state *serve.State) (serve.HTTPTransport, error) {
 			return httpAdapter.NewServer(state)
-		},
-		Debug: debug,
-	})
+		}
+	}
+
+	return serve.Serve(ctx, opts)
 }
 
 // runSequence handles `archai sequence <target>`. It parses the target,

--- a/internal/adapter/http/configs.go
+++ b/internal/adapter/http/configs.go
@@ -47,13 +47,14 @@ type configField struct {
 // overlay just shows the empty-state, missing overlay entries are
 // listed under "Unresolved" so the user knows what to fix.
 func (s *Server) handleConfigs(w nethttp.ResponseWriter, r *nethttp.Request) {
-	snap := s.state.Snapshot()
+	state := s.stateFor(r)
+	if state == nil {
+		nethttp.Error(w, "no state available", nethttp.StatusServiceUnavailable)
+		return
+	}
+	snap := state.Snapshot()
 	data := configPageData{
-		pageData: pageData{
-			Title:      "Configs",
-			ActivePath: "/configs",
-			NavItems:   buildNav("/configs"),
-		},
+		pageData: s.basePageData(r, "Configs", "/configs"),
 	}
 
 	if snap.Overlay != nil {

--- a/internal/adapter/http/dashboard.go
+++ b/internal/adapter/http/dashboard.go
@@ -51,13 +51,14 @@ func (s *Server) handleDashboard(w nethttp.ResponseWriter, r *nethttp.Request) {
 		return
 	}
 
-	snap := s.state.Snapshot()
+	state := s.stateFor(r)
+	if state == nil {
+		nethttp.Error(w, "no state available", nethttp.StatusServiceUnavailable)
+		return
+	}
+	snap := state.Snapshot()
 	data := dashboardData{
-		pageData: pageData{
-			Title:      "Dashboard",
-			ActivePath: "/",
-			NavItems:   buildNav("/"),
-		},
+		pageData: s.basePageData(r, "Dashboard", "/"),
 	}
 
 	// Module + Go version from go.mod (best-effort — empty on failure).

--- a/internal/adapter/http/diff_targets.go
+++ b/internal/adapter/http/diff_targets.go
@@ -147,15 +147,16 @@ func (s *Server) registerDiffTargetsRoutes(mux *nethttp.ServeMux) {
 // fragment (no nav, no layout).
 func (s *Server) handleDiff(w nethttp.ResponseWriter, r *nethttp.Request) {
 	ctx := r.Context()
-	snap := s.state.Snapshot()
+	state := s.stateFor(r)
+	if state == nil {
+		nethttp.Error(w, "no state available", nethttp.StatusServiceUnavailable)
+		return
+	}
+	snap := state.Snapshot()
 	filter := r.URL.Query().Get("kind")
 
 	data := diffPageData{
-		pageData: pageData{
-			Title:      "Diff",
-			ActivePath: "/diff",
-			NavItems:   buildNav("/diff"),
-		},
+		pageData:     s.basePageData(r, "Diff", "/diff"),
 		ActiveTarget: snap.CurrentTarget,
 		HasActive:    snap.CurrentTarget != "",
 		Filter:       filter,
@@ -202,13 +203,14 @@ func (s *Server) renderDiff(w nethttp.ResponseWriter, r *nethttp.Request, data d
 
 // handleTargets renders the Targets list page.
 func (s *Server) handleTargets(w nethttp.ResponseWriter, r *nethttp.Request) {
-	snap := s.state.Snapshot()
+	state := s.stateFor(r)
+	if state == nil {
+		nethttp.Error(w, "no state available", nethttp.StatusServiceUnavailable)
+		return
+	}
+	snap := state.Snapshot()
 	data := targetsPageData{
-		pageData: pageData{
-			Title:      "Targets",
-			ActivePath: "/targets",
-			NavItems:   buildNav("/targets"),
-		},
+		pageData:     s.basePageData(r, "Targets", "/targets"),
 		ActiveTarget: snap.CurrentTarget,
 		HasActive:    snap.CurrentTarget != "",
 	}
@@ -250,12 +252,17 @@ func (s *Server) handleTargetsUse(w nethttp.ResponseWriter, r *nethttp.Request) 
 		return
 	}
 
-	root := s.state.Root()
+	state := s.stateFor(r)
+	if state == nil {
+		nethttp.Error(w, "no state available", nethttp.StatusServiceUnavailable)
+		return
+	}
+	root := state.Root()
 	if err := target.Use(root, id); err != nil {
 		nethttp.Error(w, err.Error(), nethttp.StatusBadRequest)
 		return
 	}
-	if err := s.state.SwitchTarget(id); err != nil {
+	if err := state.SwitchTarget(id); err != nil {
 		nethttp.Error(w, err.Error(), nethttp.StatusInternalServerError)
 		return
 	}
@@ -264,7 +271,7 @@ func (s *Server) handleTargetsUse(w nethttp.ResponseWriter, r *nethttp.Request) 
 	// the whole list (active indicator moves). Non-HTMX POSTs redirect
 	// back to the list.
 	if !isHTMX(r) {
-		nethttp.Redirect(w, r, "/targets", nethttp.StatusSeeOther)
+		nethttp.Redirect(w, r, s.navPrefix(r)+"/targets", nethttp.StatusSeeOther)
 		return
 	}
 	// Delegate to handleTargets so we don't duplicate snapshot logic.
@@ -297,7 +304,12 @@ func (s *Server) handleTargetsCompare(w nethttp.ResponseWriter, r *nethttp.Reque
 		return
 	}
 
-	root := s.state.Root()
+	state := s.stateFor(r)
+	if state == nil {
+		nethttp.Error(w, "no state available", nethttp.StatusServiceUnavailable)
+		return
+	}
+	root := state.Root()
 	aModel, err := loadTargetFromDisk(ctx, root, a)
 	if err != nil {
 		data.Error = fmt.Sprintf("loading %q: %v", a, err)

--- a/internal/adapter/http/handlers.go
+++ b/internal/adapter/http/handlers.go
@@ -41,10 +41,21 @@ type navItem struct {
 // pageData is the model passed to every page template (which all wrap
 // templates/base.html). Handlers populate Title, ActivePath, and
 // (optionally) content-specific fields.
+//
+// NavPrefix is "/w/<name>" in multi-worktree mode and "" in
+// single-worktree mode; templates prepend it to internal links so the
+// current worktree stays selected when the user clicks around.
+// Worktrees is populated only in multi mode and drives the switcher
+// dropdown in base.html.
 type pageData struct {
-	Title      string
-	ActivePath string
-	NavItems   []navItem
+	Title       string
+	ActivePath  string
+	NavItems    []navItem
+	NavPrefix   string
+	Worktree    string
+	MultiMode   bool
+	Worktrees   []worktreeOption
+	CurrentPath string // original request path (used by the switcher form)
 }
 
 // searchPageData is the model for the full Search page template. It
@@ -72,9 +83,15 @@ var navTemplate = []navItem{
 	{Label: "Search", Href: "/search"},
 }
 
-// routes registers every handler on mux. Kept in one place so the
-// route table is easy to scan.
+// routes registers every handler on mux. In single-worktree mode it
+// installs the familiar top-level routes; in multi-worktree mode it
+// delegates to registerMultiRoutes which re-scopes content under
+// /w/{name}/* and adds legacy redirects.
 func (s *Server) routes(mux *nethttp.ServeMux) {
+	if s.multiMode() {
+		s.registerMultiRoutes(mux)
+		return
+	}
 	// Static assets (CSS, htmx.min.js). Served from the embedded FS.
 	mux.Handle("/assets/", nethttp.StripPrefix("/assets/", nethttp.FileServer(nethttp.FS(s.assets))))
 
@@ -82,8 +99,16 @@ func (s *Server) routes(mux *nethttp.ServeMux) {
 	// diagrams; accepts POST with a `d2` form field or raw text body.
 	mux.HandleFunc("/render", s.handleRender)
 
-	// Nav pages. The root handler must stay last so it doesn't shadow
-	// more-specific routes.
+	// Content routes at their historical top-level paths.
+	s.routesContent(mux)
+	mux.HandleFunc("/", s.handleDashboard)
+}
+
+// routesContent registers just the content pages onto mux without the
+// static-asset or /render handlers. Shared between single-mode (where
+// they live at the root) and multi-mode (where they live under
+// /w/{name}/* via dispatchWorktree).
+func (s *Server) routesContent(mux *nethttp.ServeMux) {
 	mux.HandleFunc("/layers", s.handleLayers)
 	mux.HandleFunc("/packages", s.handlePackagesList)
 	mux.HandleFunc("/packages/", s.handlePackageDetail)
@@ -107,19 +132,42 @@ func (s *Server) routes(mux *nethttp.ServeMux) {
 	// Packages, and Diff views (#46). Registered before the catch-all
 	// "/" dashboard route so prefix matches resolve correctly.
 	s.registerGraphRoutes(mux)
-	mux.HandleFunc("/", s.handleDashboard)
+	// In multi mode, the root of a worktree ("/w/{name}/") is served
+	// by the content mux at "/" after dispatchWorktree rewrites the
+	// URL. In single mode the root is registered directly by routes()
+	// so the handler precedence is identical (and duplicate
+	// registration would panic).
+	if s.multiMode() {
+		mux.HandleFunc("/", s.handleDashboard)
+	}
 }
 
 // pageHandler returns a handler that renders the named template inside
 // the base layout with the given title and active-path marker.
 func (s *Server) pageHandler(tmpl, title, activePath string) nethttp.HandlerFunc {
 	return func(w nethttp.ResponseWriter, r *nethttp.Request) {
-		s.renderPage(w, tmpl, pageData{
-			Title:      title,
-			ActivePath: activePath,
-			NavItems:   buildNav(activePath),
-		})
+		s.renderPage(w, tmpl, s.basePageData(r, title, activePath))
 	}
+}
+
+// basePageData fills the shared pageData fields (title, active nav,
+// worktree context) for a request. Handlers that build domain-specific
+// page models should embed its return value.
+func (s *Server) basePageData(r *nethttp.Request, title, activePath string) pageData {
+	prefix := s.navPrefix(r)
+	pd := pageData{
+		Title:       title,
+		ActivePath:  activePath,
+		NavItems:    buildNavWithPrefix(activePath, prefix),
+		NavPrefix:   prefix,
+		MultiMode:   s.multiMode(),
+		Worktree:    s.currentWorktree(r),
+		CurrentPath: r.URL.Path,
+	}
+	if s.multiMode() {
+		pd.Worktrees = s.buildWorktreeList(r)
+	}
+	return pd
 }
 
 // renderPage renders the given page template followed by the base
@@ -239,21 +287,20 @@ func (s *Server) handleSearch(w nethttp.ResponseWriter, r *nethttp.Request) {
 
 	var results []searchResult
 	if q != "" {
-		snap := s.state.Snapshot()
-		results = runSearch(snap.Packages, q, kind)
+		state := s.stateFor(r)
+		if state != nil {
+			snap := state.Snapshot()
+			results = runSearch(snap.Packages, q, kind)
+		}
 	}
 
 	s.renderPage(w, "search.html", searchPageData{
-		pageData: pageData{
-			Title:      "Search",
-			ActivePath: "/search",
-			NavItems:   buildNav("/search"),
-		},
-		Query:   q,
-		Kind:    kind,
-		Kinds:   searchKinds,
-		Results: results,
-		Total:   len(results),
+		pageData: s.basePageData(r, "Search", "/search"),
+		Query:    q,
+		Kind:     kind,
+		Kinds:    searchKinds,
+		Results:  results,
+		Total:    len(results),
 	})
 }
 
@@ -268,8 +315,12 @@ func (s *Server) handleSearchResults(w nethttp.ResponseWriter, r *nethttp.Reques
 		kind = ""
 	}
 
-	snap := s.state.Snapshot()
-	results := runSearch(snap.Packages, q, kind)
+	state := s.stateFor(r)
+	var results []searchResult
+	if state != nil {
+		snap := state.Snapshot()
+		results = runSearch(snap.Packages, q, kind)
+	}
 
 	// Fragment templates don't extend base.html, so we parse them on
 	// their own with Clone() to avoid polluting the shared parsed set.
@@ -299,12 +350,28 @@ func (s *Server) handleSearchResults(w nethttp.ResponseWriter, r *nethttp.Reques
 	_, _ = w.Write(buf.Bytes())
 }
 
-// buildNav returns a fresh nav slice with Active set on the item whose
-// Href matches activePath. The source navTemplate is never mutated.
+// buildNav returns a fresh nav slice with Active set on the item
+// whose Href matches activePath. The source navTemplate is never
+// mutated. Single-mode callers use this wrapper; multi-mode callers
+// go through buildNavWithPrefix.
 func buildNav(activePath string) []navItem {
+	return buildNavWithPrefix(activePath, "")
+}
+
+// buildNavWithPrefix is like buildNav but rewrites each Href to
+// <prefix><original-href> so multi-mode nav links stay inside the
+// current worktree. "/" becomes "<prefix>/" rather than "<prefix>".
+func buildNavWithPrefix(activePath, prefix string) []navItem {
 	out := make([]navItem, len(navTemplate))
 	for i, n := range navTemplate {
 		n.Active = n.Href == activePath
+		if prefix != "" {
+			if n.Href == "/" {
+				n.Href = prefix + "/"
+			} else {
+				n.Href = prefix + n.Href
+			}
+		}
 		out[i] = n
 	}
 	return out

--- a/internal/adapter/http/layers.go
+++ b/internal/adapter/http/layers.go
@@ -54,13 +54,14 @@ type edgeView struct {
 // state and derives layer membership, allowed/violating edges, and a
 // D2 diagram from the overlay config.
 func (s *Server) handleLayers(w nethttp.ResponseWriter, r *nethttp.Request) {
-	snap := s.state.Snapshot()
+	state := s.stateFor(r)
+	if state == nil {
+		nethttp.Error(w, "no state available", nethttp.StatusServiceUnavailable)
+		return
+	}
+	snap := state.Snapshot()
 	data := layersData{
-		pageData: pageData{
-			Title:      "Layers",
-			ActivePath: "/layers",
-			NavItems:   buildNav("/layers"),
-		},
+		pageData: s.basePageData(r, "Layers", "/layers"),
 	}
 
 	if snap.Overlay == nil || len(snap.Overlay.Layers) == 0 {

--- a/internal/adapter/http/multi.go
+++ b/internal/adapter/http/multi.go
@@ -1,0 +1,226 @@
+package http
+
+import (
+	"context"
+	"fmt"
+	nethttp "net/http"
+	"sort"
+	"strings"
+)
+
+// registerMultiRoutes installs the multi-worktree routing shell on
+// mux. All content routes are re-scoped under /w/{name}/*; legacy top
+// paths redirect to the current worktree; a small /worktree API lets
+// the switcher dropdown set the cookie without JS heavy-lifting.
+//
+// Static assets (/assets/), /render, and the switcher endpoint stay
+// at the top level because they do not depend on the active worktree.
+func (s *Server) registerMultiRoutes(mux *nethttp.ServeMux) {
+	mux.Handle("/assets/", nethttp.StripPrefix("/assets/", nethttp.FileServer(nethttp.FS(s.assets))))
+	mux.HandleFunc("/render", s.handleRender)
+	mux.HandleFunc("/worktree/select", s.handleWorktreeSelect)
+
+	// All /w/... URLs are dispatched through dispatchWorktree, which
+	// strips the /w/<name> prefix, resolves the State, and hands off
+	// to the content mux built by routesMux.
+	contentMux := nethttp.NewServeMux()
+	s.routesContent(contentMux)
+	mux.Handle("/w/", s.dispatchWorktree(contentMux))
+
+	// Legacy roots — redirect to the current worktree. We enumerate
+	// them explicitly so unknown paths still 404 (rather than getting
+	// silently rewritten).
+	legacyRoots := []string{
+		"/",
+		"/layers",
+		"/packages",
+		"/packages/",
+		"/configs",
+		"/diff",
+		"/diff/",
+		"/targets",
+		"/targets/",
+		"/search",
+		"/search/results",
+		"/types/",
+		"/api/types/",
+	}
+	for _, p := range legacyRoots {
+		path := p
+		mux.HandleFunc(path, func(w nethttp.ResponseWriter, r *nethttp.Request) {
+			s.redirectToWorktree(w, r)
+		})
+	}
+}
+
+// redirectToWorktree rewrites the request URL to its /w/{name}
+// variant and issues a 302. When there are no discovered worktrees
+// (should not happen post-Refresh), it returns a 503.
+func (s *Server) redirectToWorktree(w nethttp.ResponseWriter, r *nethttp.Request) {
+	name := s.selectedWorktree(r)
+	if name == "" {
+		nethttp.Error(w, "no worktrees discovered", nethttp.StatusServiceUnavailable)
+		return
+	}
+	target := "/w/" + name + r.URL.Path
+	// "/" becomes "/w/name/" — trim trailing slash for aesthetics.
+	if r.URL.Path == "/" {
+		target = "/w/" + name + "/"
+	}
+	if r.URL.RawQuery != "" {
+		target += "?" + r.URL.RawQuery
+	}
+	nethttp.Redirect(w, r, target, nethttp.StatusFound)
+}
+
+// dispatchWorktree wraps the given content mux so that requests to
+// /w/{name}/... are routed to the state for {name}. Unknown worktrees
+// return 404. The resolved State and worktree name are stashed on the
+// request context so downstream handlers can use stateFor/currentWorktree.
+func (s *Server) dispatchWorktree(next nethttp.Handler) nethttp.Handler {
+	return nethttp.HandlerFunc(func(w nethttp.ResponseWriter, r *nethttp.Request) {
+		name, rest := stripWorktreePrefix(r.URL.Path)
+		if name == "" {
+			nethttp.NotFound(w, r)
+			return
+		}
+		if !s.multi.Has(name) {
+			nethttp.Error(w, "unknown worktree: "+name, nethttp.StatusNotFound)
+			return
+		}
+
+		state, err := s.multi.Get(r.Context(), name)
+		if err != nil {
+			nethttp.Error(w, "load worktree: "+err.Error(), nethttp.StatusInternalServerError)
+			return
+		}
+
+		// Rewrite the URL so the content mux sees /layers instead of
+		// /w/foo/layers. We clone the URL so the original request is
+		// unchanged (useful for logging/debugging middleware).
+		r2 := r.Clone(r.Context())
+		u := *r.URL
+		u.Path = rest
+		r2.URL = &u
+
+		ctx := context.WithValue(r.Context(), ctxWorktreeName, name)
+		ctx = context.WithValue(ctx, ctxWorktreeState, state)
+		r2 = r2.WithContext(ctx)
+
+		next.ServeHTTP(w, r2)
+	})
+}
+
+// handleWorktreeSelect accepts POST /worktree/select with a `name`
+// field and sets the archai_worktree cookie. The response redirects
+// (303) to /w/{name}/<path> when the `redirect` field is a valid
+// legacy-style path; otherwise it redirects to /w/{name}/.
+//
+// HTMX clients can set HX-Request and the handler swaps the whole
+// content body by redirecting with HX-Redirect.
+func (s *Server) handleWorktreeSelect(w nethttp.ResponseWriter, r *nethttp.Request) {
+	if r.Method != nethttp.MethodPost {
+		nethttp.Error(w, "method not allowed", nethttp.StatusMethodNotAllowed)
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		nethttp.Error(w, "parse form: "+err.Error(), nethttp.StatusBadRequest)
+		return
+	}
+	name := r.FormValue("name")
+	if name == "" {
+		nethttp.Error(w, "missing name", nethttp.StatusBadRequest)
+		return
+	}
+	if s.multi == nil || !s.multi.Has(name) {
+		nethttp.Error(w, "unknown worktree: "+name, nethttp.StatusNotFound)
+		return
+	}
+
+	nethttp.SetCookie(w, &nethttp.Cookie{
+		Name:     cookieName,
+		Value:    name,
+		Path:     "/",
+		HttpOnly: true,
+		SameSite: nethttp.SameSiteLaxMode,
+	})
+
+	// Determine a redirect destination. Callers may pass "redirect"
+	// to preserve the current page within the new worktree.
+	redirect := r.FormValue("redirect")
+	target := "/w/" + name + "/"
+	if redirect != "" {
+		target = rewriteForWorktree(redirect, name)
+	}
+
+	if r.Header.Get("HX-Request") == "true" {
+		w.Header().Set("HX-Redirect", target)
+		w.WriteHeader(nethttp.StatusOK)
+		return
+	}
+	nethttp.Redirect(w, r, target, nethttp.StatusSeeOther)
+}
+
+// rewriteForWorktree rewrites a canonical (legacy) path into its
+// /w/{name}/<path> form. Paths already under /w/<other>/ are
+// re-anchored to /w/{name}/. Absolute URLs (http://…) are ignored to
+// prevent open redirects.
+func rewriteForWorktree(redirect, name string) string {
+	// Defensive: don't honor off-site redirects.
+	if strings.Contains(redirect, "://") || strings.HasPrefix(redirect, "//") {
+		return "/w/" + name + "/"
+	}
+	if redirect == "" || redirect == "/" {
+		return "/w/" + name + "/"
+	}
+	if strings.HasPrefix(redirect, "/w/") {
+		// Re-anchor to the new worktree.
+		_, rest := stripWorktreePrefix(redirect)
+		if rest == "" || rest == "/" {
+			return "/w/" + name + "/"
+		}
+		return "/w/" + name + rest
+	}
+	if strings.HasPrefix(redirect, "/") {
+		return "/w/" + name + redirect
+	}
+	return "/w/" + name + "/" + redirect
+}
+
+// buildWorktreeList returns the switcher metadata (names + current
+// selection) for the top-bar dropdown. The caller passes r so the
+// current selection comes from context (inside dispatchWorktree) or
+// cookie/default (top-level legacy handlers, which redirect anyway).
+func (s *Server) buildWorktreeList(r *nethttp.Request) []worktreeOption {
+	if s.multi == nil {
+		return nil
+	}
+	cur := s.currentWorktree(r)
+	entries := s.multi.Worktrees()
+	out := make([]worktreeOption, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, worktreeOption{
+			Name:    e.Name,
+			Branch:  e.Branch,
+			Current: e.Name == cur,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+// worktreeOption is one entry in the switcher dropdown.
+type worktreeOption struct {
+	Name    string
+	Branch  string
+	Current bool
+}
+
+// worktreeSwitcherLabel renders a compact label for the dropdown:
+// "name (branch)" when Branch is set, else just the name.
+func (o worktreeOption) Label() string {
+	if o.Branch == "" {
+		return o.Name
+	}
+	return fmt.Sprintf("%s (%s)", o.Name, o.Branch)
+}

--- a/internal/adapter/http/multi_test.go
+++ b/internal/adapter/http/multi_test.go
@@ -1,0 +1,420 @@
+package http
+
+import (
+	"context"
+	"io"
+	nethttp "net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/kgatilin/archai/internal/serve"
+	"github.com/kgatilin/archai/internal/worktree"
+)
+
+func TestStripWorktreePrefix(t *testing.T) {
+	cases := []struct {
+		in       string
+		wantName string
+		wantRest string
+	}{
+		{"/w/foo/", "foo", "/"},
+		{"/w/foo/layers", "foo", "/layers"},
+		{"/w/foo-bar/packages/x/y", "foo-bar", "/packages/x/y"},
+		{"/w/foo", "foo", "/"},
+		{"/layers", "", "/layers"},
+		{"/", "", "/"},
+	}
+	for _, c := range cases {
+		gotName, gotRest := stripWorktreePrefix(c.in)
+		if gotName != c.wantName || gotRest != c.wantRest {
+			t.Errorf("stripWorktreePrefix(%q) = (%q, %q), want (%q, %q)",
+				c.in, gotName, gotRest, c.wantName, c.wantRest)
+		}
+	}
+}
+
+func TestRewriteForWorktree(t *testing.T) {
+	cases := []struct {
+		redirect string
+		name     string
+		want     string
+	}{
+		{"/layers", "foo", "/w/foo/layers"},
+		{"/", "foo", "/w/foo/"},
+		{"", "foo", "/w/foo/"},
+		{"/w/other/packages", "foo", "/w/foo/packages"},
+		{"/w/other/", "foo", "/w/foo/"},
+		{"http://evil.example/hack", "foo", "/w/foo/"},
+		{"//evil.example/hack", "foo", "/w/foo/"},
+		{"relative", "foo", "/w/foo/relative"},
+	}
+	for _, c := range cases {
+		got := rewriteForWorktree(c.redirect, c.name)
+		if got != c.want {
+			t.Errorf("rewriteForWorktree(%q, %q) = %q, want %q", c.redirect, c.name, got, c.want)
+		}
+	}
+}
+
+// gitRun runs git -C root with args or t.Fatal()s.
+func gitRun(t *testing.T, root string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", root}, args...)...)
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=t@e",
+		"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=t@e",
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}
+
+// buildTwoWorktreeRepo creates a git repo with two worktrees named
+// "alpha" (the primary checkout) and "beta" (a linked worktree on a
+// feat/x branch). Returns the primary worktree path. The parent
+// directory is reused so `git worktree add ../beta` resolves to a
+// sibling of alpha.
+func buildTwoWorktreeRepo(t *testing.T) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+	parent := t.TempDir()
+	alpha := filepath.Join(parent, "alpha")
+	if err := os.MkdirAll(alpha, 0o755); err != nil {
+		t.Fatalf("mkdir alpha: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(alpha, "go.mod"),
+		[]byte("module example.com/multi\n\ngo 1.21\n"), 0o644); err != nil {
+		t.Fatalf("go.mod: %v", err)
+	}
+	gitRun(t, alpha, "init", "-q", "-b", "main")
+	gitRun(t, alpha, "add", ".")
+	gitRun(t, alpha, "commit", "-qm", "init")
+	beta := filepath.Join(parent, "beta")
+	gitRun(t, alpha, "worktree", "add", "-b", "feat/x", beta)
+	return alpha
+}
+
+// buildMultiServer returns a Server in multi mode backed by a real
+// two-worktree repo. The state loader is a stub that counts invocations
+// so tests can assert lazy-load behaviour without running the Go reader.
+func buildMultiServer(t *testing.T) (*Server, *serve.MultiState, *int64) {
+	t.Helper()
+	primary := buildTwoWorktreeRepo(t)
+
+	var loadCount int64
+	loader := func(ctx context.Context, name, path string) (*serve.State, error) {
+		atomic.AddInt64(&loadCount, 1)
+		return serve.NewState(path), nil
+	}
+	multi := serve.NewMultiState(primary, loader)
+	if err := multi.Refresh(); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+
+	// Sanity: Refresh should have discovered both worktrees by their
+	// directory basenames.
+	names := multi.Names()
+	if len(names) != 2 || names[0] != "alpha" || names[1] != "beta" {
+		t.Fatalf("expected [alpha beta], got %v", names)
+	}
+
+	srv, err := NewMultiServer(multi)
+	if err != nil {
+		t.Fatalf("NewMultiServer: %v", err)
+	}
+	return srv, multi, &loadCount
+}
+
+func TestMultiServer_LegacyRedirect(t *testing.T) {
+	srv, _, _ := buildMultiServer(t)
+
+	mux := nethttp.NewServeMux()
+	srv.routes(mux)
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	// No cookie -> redirects to first alphabetical worktree.
+	client := &nethttp.Client{
+		CheckRedirect: func(req *nethttp.Request, via []*nethttp.Request) error {
+			return nethttp.ErrUseLastResponse
+		},
+	}
+	resp, err := client.Get(ts.URL + "/layers")
+	if err != nil {
+		t.Fatalf("GET /layers: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != nethttp.StatusFound {
+		t.Fatalf("status = %d, want 302", resp.StatusCode)
+	}
+	loc := resp.Header.Get("Location")
+	if loc != "/w/alpha/layers" {
+		t.Errorf("Location = %q, want /w/alpha/layers", loc)
+	}
+
+	// With cookie -> redirects to the chosen worktree.
+	req, _ := nethttp.NewRequest(nethttp.MethodGet, ts.URL+"/layers", nil)
+	req.AddCookie(&nethttp.Cookie{Name: cookieName, Value: "beta"})
+	resp2, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("GET /layers with cookie: %v", err)
+	}
+	defer resp2.Body.Close()
+	if resp2.Header.Get("Location") != "/w/beta/layers" {
+		t.Errorf("Location with cookie = %q", resp2.Header.Get("Location"))
+	}
+}
+
+func TestMultiServer_WorktreeDispatch(t *testing.T) {
+	srv, _, _ := buildMultiServer(t)
+	mux := nethttp.NewServeMux()
+	srv.routes(mux)
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	// /w/alpha/ should render the dashboard with status 200.
+	resp, err := nethttp.Get(ts.URL + "/w/alpha/")
+	if err != nil {
+		t.Fatalf("GET /w/alpha/: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != nethttp.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, body=%s", resp.StatusCode, string(body))
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "Dashboard") {
+		t.Errorf("dashboard body missing Dashboard title: %s", string(body))
+	}
+	// Nav links should be scoped to /w/alpha/.
+	if !strings.Contains(string(body), `href="/w/alpha/layers"`) {
+		t.Errorf("nav links not prefixed with worktree: %s", string(body))
+	}
+}
+
+func TestMultiServer_UnknownWorktree(t *testing.T) {
+	srv, _, _ := buildMultiServer(t)
+	mux := nethttp.NewServeMux()
+	srv.routes(mux)
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	resp, err := nethttp.Get(ts.URL + "/w/nope/layers")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != nethttp.StatusNotFound {
+		t.Errorf("status = %d, want 404", resp.StatusCode)
+	}
+}
+
+func TestMultiServer_SelectSetsCookie(t *testing.T) {
+	srv, _, _ := buildMultiServer(t)
+	mux := nethttp.NewServeMux()
+	srv.routes(mux)
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	client := &nethttp.Client{
+		CheckRedirect: func(req *nethttp.Request, via []*nethttp.Request) error {
+			return nethttp.ErrUseLastResponse
+		},
+	}
+	form := url.Values{}
+	form.Set("name", "beta")
+	form.Set("redirect", "/layers")
+	resp, err := client.PostForm(ts.URL+"/worktree/select", form)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != nethttp.StatusSeeOther {
+		t.Fatalf("status = %d, want 303", resp.StatusCode)
+	}
+	if loc := resp.Header.Get("Location"); loc != "/w/beta/layers" {
+		t.Errorf("Location = %q, want /w/beta/layers", loc)
+	}
+	found := false
+	for _, c := range resp.Cookies() {
+		if c.Name == cookieName && c.Value == "beta" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("cookie not set")
+	}
+}
+
+func TestMultiServer_LazyLoadCached(t *testing.T) {
+	srv, _, count := buildMultiServer(t)
+	mux := nethttp.NewServeMux()
+	srv.routes(mux)
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	mustGet := func(path string) {
+		resp, err := nethttp.Get(ts.URL + path)
+		if err != nil {
+			t.Fatalf("GET %s: %v", path, err)
+		}
+		resp.Body.Close()
+	}
+	if atomic.LoadInt64(count) != 0 {
+		t.Fatalf("load count before hits = %d, want 0", *count)
+	}
+	mustGet("/w/alpha/layers")
+	if atomic.LoadInt64(count) != 1 {
+		t.Errorf("load count after first hit = %d, want 1", *count)
+	}
+	// Second hit to the same worktree must reuse the cached State.
+	mustGet("/w/alpha/packages")
+	if atomic.LoadInt64(count) != 1 {
+		t.Errorf("load count after second hit = %d, want 1 (cache miss)", *count)
+	}
+	// Touching a different worktree triggers another load.
+	mustGet("/w/beta/layers")
+	if atomic.LoadInt64(count) != 2 {
+		t.Errorf("load count after beta hit = %d, want 2", *count)
+	}
+}
+
+func TestMultiServer_SelectUnknownWorktree(t *testing.T) {
+	srv, _, _ := buildMultiServer(t)
+	mux := nethttp.NewServeMux()
+	srv.routes(mux)
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	form := url.Values{}
+	form.Set("name", "ghost")
+	resp, err := nethttp.PostForm(ts.URL+"/worktree/select", form)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != nethttp.StatusNotFound {
+		t.Errorf("status = %d, want 404", resp.StatusCode)
+	}
+}
+
+// TestMultiServer_SelectHTMXRedirect verifies HX-Request receives an
+// HX-Redirect header so client-side HTMX swaps the whole content.
+func TestMultiServer_SelectHTMXRedirect(t *testing.T) {
+	srv, _, _ := buildMultiServer(t)
+	mux := nethttp.NewServeMux()
+	srv.routes(mux)
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	form := url.Values{}
+	form.Set("name", "alpha")
+	form.Set("redirect", "/packages")
+	req, _ := nethttp.NewRequest(nethttp.MethodPost, ts.URL+"/worktree/select",
+		strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("HX-Request", "true")
+	resp, err := nethttp.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != nethttp.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+	if hr := resp.Header.Get("HX-Redirect"); hr != "/w/alpha/packages" {
+		t.Errorf("HX-Redirect = %q, want /w/alpha/packages", hr)
+	}
+}
+
+// TestSingleServer_NoMultiRoutes ensures the classic single-mode
+// routes are unchanged — no /w/* handlers, and /layers returns 200
+// without redirecting.
+func TestSingleServer_NoMultiRoutes(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "go.mod"),
+		[]byte("module example.com/single\n\ngo 1.21\n"), 0o644); err != nil {
+		t.Fatalf("go.mod: %v", err)
+	}
+	state := serve.NewState(root)
+	if err := state.Load(context.Background()); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	srv, err := NewServer(state)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	mux := nethttp.NewServeMux()
+	srv.routes(mux)
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	resp, err := nethttp.Get(ts.URL + "/layers")
+	if err != nil {
+		t.Fatalf("GET /layers: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != nethttp.StatusOK {
+		t.Errorf("single mode /layers status = %d, want 200 (no redirect expected)", resp.StatusCode)
+	}
+
+	// /w/foo/ should 404 in single mode (no prefix routes installed).
+	resp2, err := nethttp.Get(ts.URL + "/w/foo/")
+	if err != nil {
+		t.Fatalf("GET /w/foo/: %v", err)
+	}
+	defer resp2.Body.Close()
+	if resp2.StatusCode == nethttp.StatusOK {
+		body, _ := io.ReadAll(resp2.Body)
+		if strings.Contains(string(body), "Dashboard") {
+			t.Errorf("single mode served dashboard at /w/foo/: %s", body)
+		}
+	}
+}
+
+// TestDiscover_GitFallback exercises worktree.Discover when run
+// outside a git repo (fallback returns a single synthetic entry).
+func TestDiscover_GitFallback(t *testing.T) {
+	root := t.TempDir()
+	entries, err := worktree.Discover(root)
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("want 1 entry, got %d", len(entries))
+	}
+	if entries[0].Path == "" {
+		t.Errorf("entry path empty: %+v", entries[0])
+	}
+}
+
+// TestDiscover_RealRepo creates a minimal git repo and ensures
+// Discover returns its single worktree.
+func TestDiscover_RealRepo(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "README"), []byte("x\n"), 0o644); err != nil {
+		t.Fatalf("README: %v", err)
+	}
+	gitRun(t, root, "init", "-q", "-b", "main")
+	gitRun(t, root, "add", ".")
+	gitRun(t, root, "commit", "-qm", "init")
+
+	entries, err := worktree.Discover(root)
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("want 1 entry, got %d: %+v", len(entries), entries)
+	}
+}

--- a/internal/adapter/http/packages_handler.go
+++ b/internal/adapter/http/packages_handler.go
@@ -20,7 +20,12 @@ import (
 // the tree fragment so HTMX can swap it into the existing page without
 // reloading the filter bar or triggering scroll reset.
 func (s *Server) handlePackagesList(w nethttp.ResponseWriter, r *nethttp.Request) {
-	snap := s.state.Snapshot()
+	state := s.stateFor(r)
+	if state == nil {
+		nethttp.Error(w, "no state available", nethttp.StatusServiceUnavailable)
+		return
+	}
+	snap := state.Snapshot()
 	pkgs := applyOverlay(snap.Packages, snap.Overlay)
 
 	filter := packageFilter{
@@ -33,11 +38,7 @@ func (s *Server) handlePackagesList(w nethttp.ResponseWriter, r *nethttp.Request
 	tree := buildPackageTree(summaries)
 
 	data := packageListData{
-		pageData: pageData{
-			Title:      "Packages",
-			ActivePath: "/packages",
-			NavItems:   buildNav("/packages"),
-		},
+		pageData:       s.basePageData(r, "Packages", "/packages"),
 		Filter:         filter,
 		Packages:       summaries,
 		Tree:           tree,
@@ -71,7 +72,12 @@ func (s *Server) handlePackageDetail(w nethttp.ResponseWriter, r *nethttp.Reques
 		return
 	}
 
-	snap := s.state.Snapshot()
+	state := s.stateFor(r)
+	if state == nil {
+		nethttp.Error(w, "no state available", nethttp.StatusServiceUnavailable)
+		return
+	}
+	snap := state.Snapshot()
 	pkgs := applyOverlay(snap.Packages, snap.Overlay)
 
 	pkg, ok := findPackage(pkgs, pkgPath)
@@ -87,11 +93,7 @@ func (s *Server) handlePackageDetail(w nethttp.ResponseWriter, r *nethttp.Reques
 	}
 
 	data := buildPackageDetail(active, pkg, pkgs, snap.Overlay, modulePath)
-	data.pageData = pageData{
-		Title:      "Package " + pkg.Path,
-		ActivePath: "/packages",
-		NavItems:   buildNav("/packages"),
-	}
+	data.pageData = s.basePageData(r, "Package "+pkg.Path, "/packages")
 	data.Partial = isHTMX(r)
 
 	// M8 (#46): Overview no longer emits server-rendered D2→SVG.

--- a/internal/adapter/http/server.go
+++ b/internal/adapter/http/server.go
@@ -6,6 +6,14 @@
 //
 // All templates and static assets are embedded at compile time via
 // //go:embed so the compiled binary is fully self-contained.
+//
+// The transport supports two serving modes (M10):
+//
+//   - Single-worktree (default): NewServer(state) serves the familiar
+//     routes (/, /layers, /packages, …) backed by one *serve.State.
+//   - Multi-worktree: NewMultiServer(multi) serves the same routes
+//     re-scoped under /w/{name}/* and adds redirects + a switcher so
+//     one HTTP port can expose every discovered worktree at once.
 package http
 
 import (
@@ -17,6 +25,7 @@ import (
 	"io/fs"
 	"net"
 	nethttp "net/http"
+	"strings"
 	"time"
 
 	"github.com/kgatilin/archai/internal/serve"
@@ -26,37 +35,67 @@ import (
 var embedded embed.FS
 
 // Server is the HTTP transport. It wraps a net/http.Server and holds
-// a reference to the shared serve.State so handlers can render
-// snapshots without reloading the model.
+// a reference to the shared serve.State (single mode) or a
+// serve.MultiState (multi mode) so handlers can render snapshots
+// without reloading the model.
 type Server struct {
 	state     *serve.State
+	multi     *serve.MultiState
 	templates *template.Template
 	assets    fs.FS
 }
 
-// NewServer constructs a Server backed by the given state. Templates
-// are parsed eagerly so malformed templates fail at construction time
-// rather than on the first request.
+// NewServer constructs a single-worktree Server backed by the given
+// state. Templates are parsed eagerly so malformed templates fail at
+// construction time rather than on the first request. This is the
+// Mode A constructor: routes stay at their historical paths (/,
+// /layers, …).
 func NewServer(state *serve.State) (*Server, error) {
 	if state == nil {
 		return nil, errors.New("http: nil state")
 	}
-
-	tmpls, err := template.New("").Funcs(templateFuncs()).ParseFS(embedded, "templates/*.html")
+	tmpls, assets, err := parseEmbedded()
 	if err != nil {
-		return nil, fmt.Errorf("http: parse templates: %w", err)
+		return nil, err
 	}
-
-	assets, err := fs.Sub(embedded, "assets")
-	if err != nil {
-		return nil, fmt.Errorf("http: assets sub-fs: %w", err)
-	}
-
 	return &Server{
 		state:     state,
 		templates: tmpls,
 		assets:    assets,
 	}, nil
+}
+
+// NewMultiServer constructs a multi-worktree Server backed by the
+// given MultiState. All content routes are served under /w/{name}/*;
+// legacy roots redirect to the cookie-selected (or first alphabetical)
+// worktree so existing bookmarks still resolve.
+func NewMultiServer(multi *serve.MultiState) (*Server, error) {
+	if multi == nil {
+		return nil, errors.New("http: nil multi-state")
+	}
+	tmpls, assets, err := parseEmbedded()
+	if err != nil {
+		return nil, err
+	}
+	return &Server{
+		multi:     multi,
+		templates: tmpls,
+		assets:    assets,
+	}, nil
+}
+
+// parseEmbedded reads the embedded templates and assets FS. Shared
+// between the single- and multi-mode constructors.
+func parseEmbedded() (*template.Template, fs.FS, error) {
+	tmpls, err := template.New("").Funcs(templateFuncs()).ParseFS(embedded, "templates/*.html")
+	if err != nil {
+		return nil, nil, fmt.Errorf("http: parse templates: %w", err)
+	}
+	assets, err := fs.Sub(embedded, "assets")
+	if err != nil {
+		return nil, nil, fmt.Errorf("http: assets sub-fs: %w", err)
+	}
+	return tmpls, assets, nil
 }
 
 // Serve listens on addr and serves HTTP requests until ctx is
@@ -104,4 +143,106 @@ func (s *Server) Serve(ctx context.Context, addr string, ready func(boundAddr st
 	case err := <-serveErr:
 		return err
 	}
+}
+
+// multiMode reports whether this Server is serving multiple worktrees.
+func (s *Server) multiMode() bool { return s.multi != nil }
+
+// cookieName is the HTTP cookie storing the selected worktree in
+// multi mode. Cleared on an invalid value.
+const cookieName = "archai_worktree"
+
+// ctxKey is the unexported type for request-context keys so other
+// packages can't collide with ours.
+type ctxKey int
+
+const (
+	ctxWorktreeName ctxKey = iota
+	ctxWorktreeState
+)
+
+// stateFor returns the *serve.State that should answer r. In single
+// mode it returns the fixed state; in multi mode it reads the state
+// cached on the request context (populated by the /w/{name} dispatch
+// middleware). When no context state is present it falls back to the
+// default worktree's state so out-of-band handlers (e.g. /render)
+// still work.
+func (s *Server) stateFor(r *nethttp.Request) *serve.State {
+	if s.state != nil {
+		return s.state
+	}
+	if v := r.Context().Value(ctxWorktreeState); v != nil {
+		if st, ok := v.(*serve.State); ok {
+			return st
+		}
+	}
+	// Fall back to the default worktree. This keeps top-level routes
+	// like /render usable without forcing them through a worktree
+	// dispatch.
+	name := s.multi.Default()
+	if name == "" {
+		return nil
+	}
+	st, err := s.multi.Get(r.Context(), name)
+	if err != nil {
+		return nil
+	}
+	return st
+}
+
+// currentWorktree returns the worktree name in effect for r (empty in
+// single mode).
+func (s *Server) currentWorktree(r *nethttp.Request) string {
+	if s.state != nil {
+		return ""
+	}
+	if v := r.Context().Value(ctxWorktreeName); v != nil {
+		if n, ok := v.(string); ok {
+			return n
+		}
+	}
+	return s.selectedWorktree(r)
+}
+
+// selectedWorktree returns the worktree the client has currently
+// chosen: cookie value when valid, otherwise the default
+// (first-alphabetical) worktree. Returns "" only when the MultiState
+// has no worktrees at all.
+func (s *Server) selectedWorktree(r *nethttp.Request) string {
+	if s.multi == nil {
+		return ""
+	}
+	if c, err := r.Cookie(cookieName); err == nil && c != nil {
+		if s.multi.Has(c.Value) {
+			return c.Value
+		}
+	}
+	return s.multi.Default()
+}
+
+// navPrefix returns the URL prefix to prepend to internal links so
+// they stay inside the active worktree. In single mode it returns "".
+// In multi mode it returns "/w/<name>" (no trailing slash).
+func (s *Server) navPrefix(r *nethttp.Request) string {
+	name := s.currentWorktree(r)
+	if name == "" {
+		return ""
+	}
+	return "/w/" + name
+}
+
+// stripWorktreePrefix removes the "/w/<name>" prefix from path when
+// present, returning (name, remainder). When path does not start with
+// /w/, returns ("", path) unchanged.
+func stripWorktreePrefix(path string) (name, rest string) {
+	if !strings.HasPrefix(path, "/w/") {
+		return "", path
+	}
+	trimmed := strings.TrimPrefix(path, "/w/")
+	// Name runs up to the next "/" (or end of string).
+	slash := strings.IndexByte(trimmed, '/')
+	if slash < 0 {
+		return trimmed, "/"
+	}
+	return trimmed[:slash], trimmed[slash:]
 }

--- a/internal/adapter/http/templates/base.html
+++ b/internal/adapter/http/templates/base.html
@@ -9,12 +9,24 @@
 </head>
 <body>
 <header class="site-nav">
-    <a href="/" class="brand">archai</a>
+    <a href="{{if .NavPrefix}}{{.NavPrefix}}/{{else}}/{{end}}" class="brand">archai</a>
     <nav>
         {{range .NavItems}}
             <a href="{{.Href}}"{{if .Active}} class="active"{{end}}>{{.Label}}</a>
         {{end}}
     </nav>
+    {{if .MultiMode}}
+    <form class="worktree-switcher" method="post" action="/worktree/select">
+        <label for="worktree-select">Worktree:</label>
+        <select id="worktree-select" name="name" onchange="this.form.submit()">
+            {{range .Worktrees}}
+                <option value="{{.Name}}"{{if .Current}} selected{{end}}>{{.Label}}</option>
+            {{end}}
+        </select>
+        <input type="hidden" name="redirect" value="{{.CurrentPath}}">
+        <noscript><button type="submit">Go</button></noscript>
+    </form>
+    {{end}}
 </header>
 <main class="content">
     {{template "content" .}}

--- a/internal/adapter/http/types.go
+++ b/internal/adapter/http/types.go
@@ -170,17 +170,18 @@ func (s *Server) handleType(w nethttp.ResponseWriter, r *nethttp.Request) {
 		return
 	}
 
-	snap := s.state.Snapshot()
+	state := s.stateFor(r)
+	if state == nil {
+		nethttp.Error(w, "no state available", nethttp.StatusServiceUnavailable)
+		return
+	}
+	snap := state.Snapshot()
 	data, found := buildTypePage(snap.Packages, ref)
 	if !found {
 		nethttp.NotFound(w, r)
 		return
 	}
-	data.pageData = pageData{
-		Title:      ref.Name + " — Types",
-		ActivePath: "/packages",
-		NavItems:   buildNav("/packages"),
-	}
+	data.pageData = s.basePageData(r, ref.Name+" — Types", "/packages")
 
 	s.renderPage(w, "type_detail.html", data)
 }
@@ -198,7 +199,12 @@ func (s *Server) handleTypeGraph(w nethttp.ResponseWriter, r *nethttp.Request) {
 		return
 	}
 
-	snap := s.state.Snapshot()
+	state := s.stateFor(r)
+	if state == nil {
+		nethttp.Error(w, "no state available", nethttp.StatusServiceUnavailable)
+		return
+	}
+	snap := state.Snapshot()
 	data, found := buildTypePage(snap.Packages, ref)
 	if !found {
 		nethttp.NotFound(w, r)

--- a/internal/serve/daemon.go
+++ b/internal/serve/daemon.go
@@ -40,6 +40,15 @@ type Options struct {
 	// back).
 	HTTPServerFactory func(*State) (HTTPTransport, error)
 
+	// MultiState, when non-nil, switches the daemon into multi-worktree
+	// mode: instead of a single State, the transport (typically the
+	// HTTP server constructed by HTTPServerFactory, which in this mode
+	// receives nil) manages one State per discovered worktree via
+	// MultiState. The watcher is still run against Root so changes in
+	// the host worktree refresh its model; per-worktree fsnotify is a
+	// future enhancement.
+	MultiState *MultiState
+
 	// Debug enables verbose per-event logging.
 	Debug bool
 
@@ -85,14 +94,24 @@ func Serve(ctx context.Context, opts Options) error {
 		logOut = os.Stderr
 	}
 
-	fmt.Fprintf(logOut, "serve: loading model from %s\n", absRoot)
-	state := NewState(absRoot)
-	if err := state.Load(ctx); err != nil {
-		return err
+	// In multi-worktree mode we defer per-worktree loads to the
+	// MultiState; there is no shared State. The HTTP factory receives
+	// nil because the http.Server handles multi dispatch itself.
+	var state *State
+	if opts.MultiState == nil {
+		fmt.Fprintf(logOut, "serve: loading model from %s\n", absRoot)
+		state = NewState(absRoot)
+		if err := state.Load(ctx); err != nil {
+			return err
+		}
+		snap := state.Snapshot()
+		fmt.Fprintf(logOut, "serve: loaded %d package(s), overlay=%v, target=%q\n",
+			len(snap.Packages), snap.Overlay != nil, snap.CurrentTarget)
+	} else {
+		names := opts.MultiState.Names()
+		fmt.Fprintf(logOut, "serve: multi-worktree mode, %d worktree(s) discovered: %v\n",
+			len(names), names)
 	}
-	snap := state.Snapshot()
-	fmt.Fprintf(logOut, "serve: loaded %d package(s), overlay=%v, target=%q\n",
-		len(snap.Packages), snap.Overlay != nil, snap.CurrentTarget)
 
 	// HTTP transport: start in a goroutine when both an address and a
 	// factory are provided. If the caller set the address but didn't
@@ -144,13 +163,20 @@ func Serve(ctx context.Context, opts Options) error {
 		}
 	}()
 
-	watcher, err := NewWatcher(absRoot, opts.Debounce)
-	if err != nil {
-		return err
+	// The fsnotify watcher is only meaningful against a single State;
+	// in multi mode we skip it and rely on manual refreshes (future:
+	// per-worktree watchers keyed by MultiState entries).
+	var handler EventHandler
+	var watcher *Watcher
+	if state != nil {
+		w, err := NewWatcher(absRoot, opts.Debounce)
+		if err != nil {
+			return err
+		}
+		watcher = w
+		defer func() { _ = watcher.Close() }()
+		handler = buildHandler(ctx, state, logOut, opts.Debug)
 	}
-	defer func() { _ = watcher.Close() }()
-
-	handler := buildHandler(ctx, state, logOut, opts.Debug)
 
 	// When the MCP stdio transport is requested, it owns the process's
 	// stdin/stdout and drives shutdown: we run the watcher loop in a
@@ -159,6 +185,9 @@ func Serve(ctx context.Context, opts Options) error {
 	if opts.MCPStdio {
 		if opts.MCPServe == nil {
 			return fmt.Errorf("serve: --mcp-stdio set but MCPServe is nil")
+		}
+		if watcher == nil {
+			return fmt.Errorf("serve: --mcp-stdio is not compatible with multi-worktree mode")
 		}
 
 		childCtx, cancel := context.WithCancel(ctx)
@@ -184,10 +213,17 @@ func Serve(ctx context.Context, opts Options) error {
 		return nil
 	}
 
-	fmt.Fprintln(logOut, "serve: watching for changes (Ctrl-C to stop)")
-	watchErr := watcher.Run(ctx, handler)
-	if watchErr != nil && !errors.Is(watchErr, context.Canceled) {
-		return watchErr
+	if watcher != nil {
+		fmt.Fprintln(logOut, "serve: watching for changes (Ctrl-C to stop)")
+		watchErr := watcher.Run(ctx, handler)
+		if watchErr != nil && !errors.Is(watchErr, context.Canceled) {
+			return watchErr
+		}
+	} else {
+		// Multi mode: no single-state watcher; block on ctx so HTTP
+		// stays alive until Ctrl-C.
+		fmt.Fprintln(logOut, "serve: multi-worktree mode (Ctrl-C to stop)")
+		<-ctx.Done()
 	}
 
 	// Wait for the HTTP goroutine to unwind (if one was started) so we

--- a/internal/serve/daemon.go
+++ b/internal/serve/daemon.go
@@ -44,9 +44,8 @@ type Options struct {
 	// mode: instead of a single State, the transport (typically the
 	// HTTP server constructed by HTTPServerFactory, which in this mode
 	// receives nil) manages one State per discovered worktree via
-	// MultiState. The watcher is still run against Root so changes in
-	// the host worktree refresh its model; per-worktree fsnotify is a
-	// future enhancement.
+	// MultiState. Per-worktree fsnotify watchers are installed lazily
+	// as each State is loaded (one watcher per loaded worktree).
 	MultiState *MultiState
 
 	// Debug enables verbose per-event logging.
@@ -111,6 +110,11 @@ func Serve(ctx context.Context, opts Options) error {
 		names := opts.MultiState.Names()
 		fmt.Fprintf(logOut, "serve: multi-worktree mode, %d worktree(s) discovered: %v\n",
 			len(names), names)
+		// Install a per-worktree fsnotify hook: each State gets its own
+		// watcher the first time it is loaded. The watchers are closed
+		// when Refresh drops a worktree or when the daemon shuts down.
+		opts.MultiState.SetWatcherHook(multiWatcherHook(ctx, opts.Debounce, logOut, opts.Debug))
+		defer func() { _ = opts.MultiState.Close() }()
 	}
 
 	// HTTP transport: start in a goroutine when both an address and a
@@ -220,8 +224,10 @@ func Serve(ctx context.Context, opts Options) error {
 			return watchErr
 		}
 	} else {
-		// Multi mode: no single-state watcher; block on ctx so HTTP
-		// stays alive until Ctrl-C.
+		// Multi mode: per-worktree watchers are spun up lazily as each
+		// State is loaded (see multiWatcherHook). We just block on ctx
+		// here so HTTP stays alive until Ctrl-C; the deferred
+		// MultiState.Close stops every registered watcher on exit.
 		fmt.Fprintln(logOut, "serve: multi-worktree mode (Ctrl-C to stop)")
 		<-ctx.Done()
 	}
@@ -235,6 +241,60 @@ func Serve(ctx context.Context, opts Options) error {
 	}
 
 	fmt.Fprintln(logOut, "serve: shutdown complete")
+	return nil
+}
+
+// multiWatcherHook returns a WatcherHook that installs one fsnotify
+// watcher per loaded worktree State, reusing buildHandler so the
+// event-dispatch logic matches single-mode exactly. The returned
+// io.Closer cancels the watcher goroutine and closes the underlying
+// fsnotify watcher; MultiState invokes it on Refresh-drop / Close.
+func multiWatcherHook(parent context.Context, debounce time.Duration, logOut io.Writer, debug bool) WatcherHook {
+	return func(_ context.Context, name string, state *State) (io.Closer, error) {
+		w, err := NewWatcher(state.Root(), debounce)
+		if err != nil {
+			return nil, err
+		}
+		childCtx, cancel := context.WithCancel(parent)
+		handler := buildHandler(childCtx, state, logOut, debug)
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			if rerr := w.Run(childCtx, handler); rerr != nil && !errors.Is(rerr, context.Canceled) {
+				fmt.Fprintf(logOut, "serve: watcher for %q: %v\n", name, rerr)
+			}
+		}()
+		if debug {
+			fmt.Fprintf(logOut, "serve: watcher started for worktree %q at %s\n", name, state.Root())
+		}
+		return &watcherCloser{cancel: cancel, watcher: w, done: done}, nil
+	}
+}
+
+// watcherCloser bundles the goroutine cancellation and the fsnotify
+// watcher's own Close so MultiState can release both with a single
+// io.Closer handle.
+type watcherCloser struct {
+	cancel  context.CancelFunc
+	watcher *Watcher
+	done    chan struct{}
+}
+
+// Close cancels the watcher goroutine, waits for it to unwind, and
+// closes the underlying fsnotify watcher. Idempotent.
+func (c *watcherCloser) Close() error {
+	if c == nil {
+		return nil
+	}
+	if c.cancel != nil {
+		c.cancel()
+	}
+	if c.done != nil {
+		<-c.done
+	}
+	if c.watcher != nil {
+		return c.watcher.Close()
+	}
 	return nil
 }
 

--- a/internal/serve/multistate.go
+++ b/internal/serve/multistate.go
@@ -1,0 +1,195 @@
+package serve
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+
+	"github.com/kgatilin/archai/internal/worktree"
+)
+
+// StateLoader builds a fresh State for a newly-discovered worktree.
+// It is invoked the first time a worktree's State is requested from a
+// MultiState; subsequent requests hit the per-worktree cache. The
+// default production loader is DefaultStateLoader, which calls
+// NewState(path).Load(ctx).
+type StateLoader func(ctx context.Context, name, path string) (*State, error)
+
+// DefaultStateLoader is the production StateLoader used when
+// NewMultiState is called without one. It builds a fresh State
+// anchored at path and loads the full Go + overlay + target model.
+func DefaultStateLoader(ctx context.Context, _, path string) (*State, error) {
+	state := NewState(path)
+	if err := state.Load(ctx); err != nil {
+		return nil, err
+	}
+	return state, nil
+}
+
+// MultiState holds one State per discovered worktree and lazy-loads
+// each State on first access. The set of worktrees is fixed at
+// construction but can be refreshed by calling Refresh() again — this
+// is intended for SIGHUP or a periodic poller.
+//
+// MultiState is safe for concurrent use.
+type MultiState struct {
+	mu sync.Mutex
+
+	// root is the project root (one of the discovered worktrees, used
+	// as the anchor for git worktree list).
+	root string
+
+	// entries is the current list of known worktrees, keyed by Name.
+	entries map[string]worktree.Entry
+
+	// order is the lexical list of names (matches entries).
+	order []string
+
+	// states is the lazy-loaded State for each worktree name.
+	states map[string]*State
+
+	// loader is the factory that builds a fresh State for a worktree.
+	loader StateLoader
+}
+
+// NewMultiState constructs a MultiState rooted at projectRoot, using
+// loader to materialize per-worktree States on first access. Pass
+// DefaultStateLoader for normal daemon use; lightweight alternatives
+// are useful for transport-level tests that want to assert lazy
+// behaviour without invoking the Go reader.
+//
+// The initial worktree list is populated by Refresh(); callers are
+// expected to invoke Refresh() once before serving requests.
+func NewMultiState(projectRoot string, loader StateLoader) *MultiState {
+	if loader == nil {
+		loader = DefaultStateLoader
+	}
+	return &MultiState{
+		root:    projectRoot,
+		entries: make(map[string]worktree.Entry),
+		states:  make(map[string]*State),
+		loader:  loader,
+	}
+}
+
+// Refresh re-discovers worktrees via `git worktree list --porcelain`
+// and replaces the internal entry set. Previously-loaded States for
+// worktrees that still exist are retained (so lazy caches survive a
+// refresh); States for removed worktrees are dropped.
+func (m *MultiState) Refresh() error {
+	entries, err := worktree.Discover(m.root)
+	if err != nil {
+		return fmt.Errorf("serve: discover worktrees: %w", err)
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	next := make(map[string]worktree.Entry, len(entries))
+	order := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if e.Name == "" {
+			continue
+		}
+		if _, dup := next[e.Name]; dup {
+			// Disambiguate duplicate leaf names by suffixing the branch
+			// (rare — two worktrees at paths sharing basename).
+			alt := e.Name + "@" + e.Branch
+			e.Name = alt
+		}
+		next[e.Name] = e
+		order = append(order, e.Name)
+	}
+	sort.Strings(order)
+	m.entries = next
+	m.order = order
+
+	// Drop cached states whose worktrees have disappeared.
+	for name := range m.states {
+		if _, ok := next[name]; !ok {
+			delete(m.states, name)
+		}
+	}
+	return nil
+}
+
+// Worktrees returns the discovered entries in lexical order.
+func (m *MultiState) Worktrees() []worktree.Entry {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]worktree.Entry, 0, len(m.order))
+	for _, n := range m.order {
+		out = append(out, m.entries[n])
+	}
+	return out
+}
+
+// Names returns the discovered worktree names in lexical order.
+func (m *MultiState) Names() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]string, len(m.order))
+	copy(out, m.order)
+	return out
+}
+
+// Has reports whether name is a known worktree.
+func (m *MultiState) Has(name string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	_, ok := m.entries[name]
+	return ok
+}
+
+// Default returns the first worktree name in lexical order, or ""
+// when no worktrees have been discovered.
+func (m *MultiState) Default() string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if len(m.order) == 0 {
+		return ""
+	}
+	return m.order[0]
+}
+
+// Get returns (and lazy-loads) the State for the given worktree name.
+// Returns an error when name is unknown or when the underlying load
+// fails. Subsequent calls return the cached State.
+func (m *MultiState) Get(ctx context.Context, name string) (*State, error) {
+	m.mu.Lock()
+	entry, ok := m.entries[name]
+	if !ok {
+		m.mu.Unlock()
+		return nil, fmt.Errorf("serve: unknown worktree %q", name)
+	}
+	if s, ok := m.states[name]; ok {
+		m.mu.Unlock()
+		return s, nil
+	}
+	m.mu.Unlock()
+
+	// Load outside the lock so concurrent Get calls for different
+	// worktrees don't serialize. We re-check the cache after loading
+	// so only one State is ever cached per name.
+	loaded, err := m.loader(ctx, name, entry.Path)
+	if err != nil {
+		return nil, err
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if existing, ok := m.states[name]; ok {
+		return existing, nil
+	}
+	m.states[name] = loaded
+	return loaded, nil
+}
+
+// Entry returns the Entry for the named worktree (path, branch, …).
+// Returns false when name is unknown.
+func (m *MultiState) Entry(name string) (worktree.Entry, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	e, ok := m.entries[name]
+	return e, ok
+}

--- a/internal/serve/multistate.go
+++ b/internal/serve/multistate.go
@@ -3,6 +3,7 @@ package serve
 import (
 	"context"
 	"fmt"
+	"io"
 	"sort"
 	"sync"
 
@@ -15,6 +16,15 @@ import (
 // default production loader is DefaultStateLoader, which calls
 // NewState(path).Load(ctx).
 type StateLoader func(ctx context.Context, name, path string) (*State, error)
+
+// WatcherHook is invoked by MultiState the first time a worktree's
+// State is loaded. Implementations typically spin up a per-worktree
+// fsnotify watcher whose handler re-extracts the loaded State on file
+// changes. The returned io.Closer is tracked by MultiState and closed
+// when the worktree is dropped from a Refresh or when Close is called.
+// A nil hook disables per-worktree watching (used by lightweight tests
+// and by callers that prefer manual refreshes).
+type WatcherHook func(ctx context.Context, name string, state *State) (io.Closer, error)
 
 // DefaultStateLoader is the production StateLoader used when
 // NewMultiState is called without one. It builds a fresh State
@@ -51,6 +61,14 @@ type MultiState struct {
 
 	// loader is the factory that builds a fresh State for a worktree.
 	loader StateLoader
+
+	// watcherHook, when non-nil, is invoked the first time a State is
+	// loaded for a worktree. The returned closer is tracked in
+	// watchers and released on Refresh-drop / Close.
+	watcherHook WatcherHook
+
+	// watchers tracks per-worktree closers registered by watcherHook.
+	watchers map[string]io.Closer
 }
 
 // NewMultiState constructs a MultiState rooted at projectRoot, using
@@ -66,24 +84,39 @@ func NewMultiState(projectRoot string, loader StateLoader) *MultiState {
 		loader = DefaultStateLoader
 	}
 	return &MultiState{
-		root:    projectRoot,
-		entries: make(map[string]worktree.Entry),
-		states:  make(map[string]*State),
-		loader:  loader,
+		root:     projectRoot,
+		entries:  make(map[string]worktree.Entry),
+		states:   make(map[string]*State),
+		loader:   loader,
+		watchers: make(map[string]io.Closer),
 	}
+}
+
+// SetWatcherHook installs a WatcherHook that will be invoked the next
+// time a worktree's State is loaded. It is safe to call before Refresh;
+// already-loaded states are not retroactively watched.
+func (m *MultiState) SetWatcherHook(hook WatcherHook) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.watcherHook = hook
 }
 
 // Refresh re-discovers worktrees via `git worktree list --porcelain`
 // and replaces the internal entry set. Previously-loaded States for
 // worktrees that still exist are retained (so lazy caches survive a
-// refresh); States for removed worktrees are dropped.
+// refresh); States for removed worktrees are dropped, and any per-
+// worktree watchers registered via WatcherHook are closed.
+//
+// Refresh returns an error when two discovered worktrees share the
+// same basename (e.g. /a/proj and /b/proj). The operator is expected
+// to rename or relocate one of them; silent last-write-wins would
+// hide one worktree from all transports.
 func (m *MultiState) Refresh() error {
 	entries, err := worktree.Discover(m.root)
 	if err != nil {
 		return fmt.Errorf("serve: discover worktrees: %w", err)
 	}
 	m.mu.Lock()
-	defer m.mu.Unlock()
 
 	next := make(map[string]worktree.Entry, len(entries))
 	order := make([]string, 0, len(entries))
@@ -91,11 +124,12 @@ func (m *MultiState) Refresh() error {
 		if e.Name == "" {
 			continue
 		}
-		if _, dup := next[e.Name]; dup {
-			// Disambiguate duplicate leaf names by suffixing the branch
-			// (rare — two worktrees at paths sharing basename).
-			alt := e.Name + "@" + e.Branch
-			e.Name = alt
+		if prev, dup := next[e.Name]; dup {
+			m.mu.Unlock()
+			return fmt.Errorf(
+				"serve: duplicate worktree name %q (paths %q and %q) — rename one worktree directory to disambiguate",
+				e.Name, prev.Path, e.Path,
+			)
 		}
 		next[e.Name] = e
 		order = append(order, e.Name)
@@ -104,13 +138,48 @@ func (m *MultiState) Refresh() error {
 	m.entries = next
 	m.order = order
 
-	// Drop cached states whose worktrees have disappeared.
+	// Drop cached states whose worktrees have disappeared, and close
+	// any watchers they held. We collect closers under the lock and
+	// close them after releasing it so a slow Close cannot deadlock
+	// callers of MultiState.
+	var toClose []io.Closer
 	for name := range m.states {
 		if _, ok := next[name]; !ok {
 			delete(m.states, name)
+			if c, ok := m.watchers[name]; ok && c != nil {
+				toClose = append(toClose, c)
+			}
+			delete(m.watchers, name)
 		}
 	}
+	m.mu.Unlock()
+
+	for _, c := range toClose {
+		_ = c.Close()
+	}
 	return nil
+}
+
+// Close releases every per-worktree watcher tracked by the MultiState.
+// Safe to call multiple times; states themselves are not mutated.
+func (m *MultiState) Close() error {
+	m.mu.Lock()
+	closers := make([]io.Closer, 0, len(m.watchers))
+	for _, c := range m.watchers {
+		if c != nil {
+			closers = append(closers, c)
+		}
+	}
+	m.watchers = make(map[string]io.Closer)
+	m.mu.Unlock()
+
+	var firstErr error
+	for _, c := range closers {
+		if err := c.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
 }
 
 // Worktrees returns the discovered entries in lexical order.
@@ -177,11 +246,37 @@ func (m *MultiState) Get(ctx context.Context, name string) (*State, error) {
 	}
 
 	m.mu.Lock()
-	defer m.mu.Unlock()
 	if existing, ok := m.states[name]; ok {
+		m.mu.Unlock()
 		return existing, nil
 	}
 	m.states[name] = loaded
+	hook := m.watcherHook
+	m.mu.Unlock()
+
+	// Spin up the per-worktree watcher outside the lock so a slow
+	// fsnotify setup cannot block other Get calls. If the hook fails
+	// we keep the loaded state (the transport is still usable — just
+	// without auto-reload) and surface the error to the caller; the
+	// daemon logs it and carries on.
+	if hook != nil {
+		closer, err := hook(ctx, name, loaded)
+		if err != nil {
+			return loaded, fmt.Errorf("serve: watcher hook for %q: %w", name, err)
+		}
+		if closer != nil {
+			m.mu.Lock()
+			// Replacing an existing closer is unusual but possible if
+			// two concurrent Gets race; close the loser.
+			if prev, ok := m.watchers[name]; ok && prev != nil {
+				m.mu.Unlock()
+				_ = closer.Close()
+				return loaded, nil
+			}
+			m.watchers[name] = closer
+			m.mu.Unlock()
+		}
+	}
 	return loaded, nil
 }
 

--- a/internal/serve/multistate_test.go
+++ b/internal/serve/multistate_test.go
@@ -1,0 +1,124 @@
+package serve
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/kgatilin/archai/internal/worktree"
+)
+
+// newGitRepo creates a minimal git repo with a go.mod and one commit,
+// so `git worktree list` has a primary worktree to report.
+func newGitRepo(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "go.mod"),
+		[]byte("module example.com/multi\n\ngo 1.21\n"), 0o644); err != nil {
+		t.Fatalf("go.mod: %v", err)
+	}
+	run := func(args ...string) {
+		cmd := exec.Command("git", append([]string{"-C", root}, args...)...)
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=t@e",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=t@e",
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	run("init", "-q", "-b", "main")
+	run("add", ".")
+	run("commit", "-qm", "init")
+	return root
+}
+
+// stubLoader returns a StateLoader that increments *count each call
+// and yields a bare State rooted at path (no Go extraction). Used to
+// assert lazy-load cache behaviour without the reader's overhead.
+func stubLoader(count *int64) StateLoader {
+	return func(_ context.Context, _, path string) (*State, error) {
+		atomic.AddInt64(count, 1)
+		return NewState(path), nil
+	}
+}
+
+func TestMultiState_RefreshAndGet(t *testing.T) {
+	root := newGitRepo(t)
+	var loadCount int64
+	m := NewMultiState(root, stubLoader(&loadCount))
+
+	if err := m.Refresh(); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+
+	names := m.Names()
+	if len(names) != 1 {
+		t.Fatalf("want 1 worktree, got %d: %v", len(names), names)
+	}
+
+	// First Get triggers load.
+	if _, err := m.Get(context.Background(), names[0]); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got := atomic.LoadInt64(&loadCount); got != 1 {
+		t.Errorf("load count after first Get = %d, want 1", got)
+	}
+
+	// Second Get hits cache — loader must not re-run.
+	if _, err := m.Get(context.Background(), names[0]); err != nil {
+		t.Fatalf("Get (second): %v", err)
+	}
+	if got := atomic.LoadInt64(&loadCount); got != 1 {
+		t.Errorf("load count after second Get = %d, want 1 (cache miss)", got)
+	}
+
+	// Unknown worktree returns an error.
+	if _, err := m.Get(context.Background(), "nope"); err == nil {
+		t.Errorf("Get(nope) expected error")
+	}
+}
+
+func TestMultiState_RefreshDropsRemoved(t *testing.T) {
+	var loadCount int64
+	m := NewMultiState(t.TempDir(), stubLoader(&loadCount))
+
+	// Seed state manually for a worktree that "exists".
+	m.entries["alpha"] = worktree.Entry{Name: "alpha", Path: "/tmp/alpha"}
+	m.order = []string{"alpha"}
+	if _, err := m.Get(context.Background(), "alpha"); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if atomic.LoadInt64(&loadCount) != 1 {
+		t.Fatalf("load count after first Get = %d, want 1", loadCount)
+	}
+
+	// Simulate a Refresh that yields no worktrees. Drop entries to empty
+	// and invoke the drop loop directly — the git fallback would reuse
+	// the CWD name, which would keep alpha alive.
+	m.mu.Lock()
+	m.entries = map[string]worktree.Entry{}
+	m.order = nil
+	for name := range m.states {
+		if _, ok := m.entries[name]; !ok {
+			delete(m.states, name)
+		}
+	}
+	m.mu.Unlock()
+
+	// Re-seeding and Get should trigger a fresh load (proving the cache
+	// was dropped when the worktree disappeared).
+	m.mu.Lock()
+	m.entries["alpha"] = worktree.Entry{Name: "alpha", Path: "/tmp/alpha"}
+	m.order = []string{"alpha"}
+	m.mu.Unlock()
+	if _, err := m.Get(context.Background(), "alpha"); err != nil {
+		t.Fatalf("Get after drop: %v", err)
+	}
+	if atomic.LoadInt64(&loadCount) != 2 {
+		t.Errorf("load count after re-Get = %d, want 2 (cache should have been dropped)", loadCount)
+	}
+}

--- a/internal/serve/multistate_test.go
+++ b/internal/serve/multistate_test.go
@@ -2,13 +2,14 @@ package serve
 
 import (
 	"context"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
-
-	"github.com/kgatilin/archai/internal/worktree"
 )
 
 // newGitRepo creates a minimal git repo with a go.mod and one commit,
@@ -82,43 +83,242 @@ func TestMultiState_RefreshAndGet(t *testing.T) {
 	}
 }
 
+// runGit runs a git subcommand against repo and fails the test on error.
+func runGit(t *testing.T, repo string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", repo}, args...)...)
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=t@e",
+		"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=t@e",
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}
+
+// TestMultiState_RefreshDropsRemoved exercises the full Refresh → Get
+// → Refresh-drop → Get cycle against a real git repo with an added and
+// then removed worktree. It goes through the exported MultiState API
+// only; no private fields are touched.
 func TestMultiState_RefreshDropsRemoved(t *testing.T) {
+	root := newGitRepo(t)
+
+	// Create a sibling worktree 'extra' on a new branch; after Refresh
+	// MultiState should see two entries.
+	parent := filepath.Dir(root)
+	extraPath := filepath.Join(parent, "extra-"+filepath.Base(root))
+	runGit(t, root, "worktree", "add", "-b", "extra-branch", extraPath)
+	t.Cleanup(func() {
+		// Best-effort: extra may already be removed by the test itself.
+		_ = exec.Command("git", "-C", root, "worktree", "remove", "--force", extraPath).Run()
+	})
+
 	var loadCount int64
-	m := NewMultiState(t.TempDir(), stubLoader(&loadCount))
-
-	// Seed state manually for a worktree that "exists".
-	m.entries["alpha"] = worktree.Entry{Name: "alpha", Path: "/tmp/alpha"}
-	m.order = []string{"alpha"}
-	if _, err := m.Get(context.Background(), "alpha"); err != nil {
-		t.Fatalf("Get: %v", err)
-	}
-	if atomic.LoadInt64(&loadCount) != 1 {
-		t.Fatalf("load count after first Get = %d, want 1", loadCount)
+	m := NewMultiState(root, stubLoader(&loadCount))
+	if err := m.Refresh(); err != nil {
+		t.Fatalf("Refresh: %v", err)
 	}
 
-	// Simulate a Refresh that yields no worktrees. Drop entries to empty
-	// and invoke the drop loop directly — the git fallback would reuse
-	// the CWD name, which would keep alpha alive.
-	m.mu.Lock()
-	m.entries = map[string]worktree.Entry{}
-	m.order = nil
-	for name := range m.states {
-		if _, ok := m.entries[name]; !ok {
-			delete(m.states, name)
+	names := m.Names()
+	if len(names) != 2 {
+		t.Fatalf("want 2 worktrees after Refresh, got %d: %v", len(names), names)
+	}
+
+	// Locate the extra entry by path so we can reference it across the
+	// refresh drop. Its Name is set by worktree.Discover to basename.
+	var extraName string
+	for _, n := range names {
+		e, _ := m.Entry(n)
+		if e.Path == extraPath {
+			extraName = n
+			break
 		}
 	}
-	m.mu.Unlock()
-
-	// Re-seeding and Get should trigger a fresh load (proving the cache
-	// was dropped when the worktree disappeared).
-	m.mu.Lock()
-	m.entries["alpha"] = worktree.Entry{Name: "alpha", Path: "/tmp/alpha"}
-	m.order = []string{"alpha"}
-	m.mu.Unlock()
-	if _, err := m.Get(context.Background(), "alpha"); err != nil {
-		t.Fatalf("Get after drop: %v", err)
+	if extraName == "" {
+		t.Fatalf("could not find extra worktree in Names %v", names)
 	}
-	if atomic.LoadInt64(&loadCount) != 2 {
-		t.Errorf("load count after re-Get = %d, want 2 (cache should have been dropped)", loadCount)
+
+	// First Get triggers load for the extra worktree.
+	if _, err := m.Get(context.Background(), extraName); err != nil {
+		t.Fatalf("Get(%q): %v", extraName, err)
+	}
+	if got := atomic.LoadInt64(&loadCount); got != 1 {
+		t.Fatalf("load count after first Get = %d, want 1", got)
+	}
+
+	// Second Get hits cache.
+	if _, err := m.Get(context.Background(), extraName); err != nil {
+		t.Fatalf("Get(%q) second: %v", extraName, err)
+	}
+	if got := atomic.LoadInt64(&loadCount); got != 1 {
+		t.Fatalf("load count after cached Get = %d, want 1", got)
+	}
+
+	// Remove the worktree via git, then Refresh. The cached state must
+	// be dropped so a subsequent Get (once re-added) triggers a fresh
+	// load.
+	runGit(t, root, "worktree", "remove", "--force", extraPath)
+	if err := m.Refresh(); err != nil {
+		t.Fatalf("Refresh after remove: %v", err)
+	}
+	if m.Has(extraName) {
+		t.Fatalf("extra worktree %q still present after removal", extraName)
+	}
+
+	// Querying the removed worktree returns an unknown-worktree error.
+	if _, err := m.Get(context.Background(), extraName); err == nil {
+		t.Fatalf("Get(%q) on removed worktree expected error", extraName)
+	}
+
+	// Re-add the same worktree path + branch, Refresh, Get again —
+	// load count should advance to 2, proving the prior cache was
+	// dropped and not silently re-used.
+	runGit(t, root, "worktree", "add", extraPath, "extra-branch")
+	if err := m.Refresh(); err != nil {
+		t.Fatalf("Refresh after re-add: %v", err)
+	}
+	if !m.Has(extraName) {
+		t.Fatalf("extra worktree %q missing after re-add", extraName)
+	}
+	if _, err := m.Get(context.Background(), extraName); err != nil {
+		t.Fatalf("Get(%q) after re-add: %v", extraName, err)
+	}
+	if got := atomic.LoadInt64(&loadCount); got != 2 {
+		t.Errorf("load count after re-add Get = %d, want 2 (cache should have been dropped)", got)
+	}
+}
+
+// fakeCloser records a single Close call.
+type fakeCloser struct {
+	closed int64
+}
+
+func (f *fakeCloser) Close() error {
+	atomic.AddInt64(&f.closed, 1)
+	return nil
+}
+
+// TestMultiState_WatcherHookLifecycle verifies that a WatcherHook is
+// invoked exactly once per loaded worktree (even across concurrent
+// Gets), that its closer is released when the worktree is dropped by
+// a Refresh, and that MultiState.Close releases any remaining closers.
+func TestMultiState_WatcherHookLifecycle(t *testing.T) {
+	root := newGitRepo(t)
+
+	// Add a second worktree so we can test per-worktree isolation.
+	parent := filepath.Dir(root)
+	extraPath := filepath.Join(parent, "hook-"+filepath.Base(root))
+	runGit(t, root, "worktree", "add", "-b", "hook-branch", extraPath)
+	t.Cleanup(func() {
+		_ = exec.Command("git", "-C", root, "worktree", "remove", "--force", extraPath).Run()
+	})
+
+	m := NewMultiState(root, stubLoader(new(int64)))
+
+	var (
+		hookMu    sync.Mutex
+		byName    = map[string]*fakeCloser{}
+		hookCalls int
+	)
+	m.SetWatcherHook(func(_ context.Context, name string, _ *State) (io.Closer, error) {
+		hookMu.Lock()
+		defer hookMu.Unlock()
+		hookCalls++
+		c := &fakeCloser{}
+		byName[name] = c
+		return c, nil
+	})
+
+	if err := m.Refresh(); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+
+	names := m.Names()
+	if len(names) != 2 {
+		t.Fatalf("want 2 worktrees, got %d: %v", len(names), names)
+	}
+
+	// Load both states; each should trigger exactly one hook call.
+	for _, n := range names {
+		if _, err := m.Get(context.Background(), n); err != nil {
+			t.Fatalf("Get(%q): %v", n, err)
+		}
+	}
+	// A second Get hits the cache and must not re-run the hook.
+	for _, n := range names {
+		if _, err := m.Get(context.Background(), n); err != nil {
+			t.Fatalf("Get(%q) cached: %v", n, err)
+		}
+	}
+	hookMu.Lock()
+	if hookCalls != 2 {
+		t.Errorf("hook calls = %d, want 2", hookCalls)
+	}
+	hookMu.Unlock()
+
+	// Remove the extra worktree; Refresh must close its hook.
+	runGit(t, root, "worktree", "remove", "--force", extraPath)
+	if err := m.Refresh(); err != nil {
+		t.Fatalf("Refresh after remove: %v", err)
+	}
+
+	// Find the extra hook's closer — by process of elimination, it's
+	// the one whose name is not the primary.
+	primary := filepath.Base(root)
+	hookMu.Lock()
+	var extraCloser *fakeCloser
+	for n, c := range byName {
+		if n != primary {
+			extraCloser = c
+		}
+	}
+	hookMu.Unlock()
+	if extraCloser == nil {
+		t.Fatalf("could not locate extra worktree closer")
+	}
+	if got := atomic.LoadInt64(&extraCloser.closed); got != 1 {
+		t.Errorf("extra closer Close count = %d, want 1", got)
+	}
+
+	// Close the MultiState — remaining closer(s) must be released.
+	if err := m.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	hookMu.Lock()
+	primaryCloser := byName[primary]
+	hookMu.Unlock()
+	if primaryCloser == nil {
+		t.Fatalf("primary closer missing")
+	}
+	if got := atomic.LoadInt64(&primaryCloser.closed); got != 1 {
+		t.Errorf("primary closer Close count after MultiState.Close = %d, want 1", got)
+	}
+}
+
+// TestMultiState_RefreshRejectsDuplicateNames creates two worktrees
+// whose basenames collide and verifies Refresh reports an explicit
+// error rather than silently dropping one of them.
+func TestMultiState_RefreshRejectsDuplicateNames(t *testing.T) {
+	root := newGitRepo(t)
+
+	// Build a nested directory whose basename matches root's basename.
+	// e.g. if root is /tmp/X/foo, extra sits at /tmp/X/foo/sub/foo.
+	parent := filepath.Join(root, "sub")
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		t.Fatalf("mkdir sub: %v", err)
+	}
+	dup := filepath.Join(parent, filepath.Base(root))
+	runGit(t, root, "worktree", "add", "-b", "dup-branch", dup)
+	t.Cleanup(func() {
+		_ = exec.Command("git", "-C", root, "worktree", "remove", "--force", dup).Run()
+	})
+
+	m := NewMultiState(root, stubLoader(new(int64)))
+	err := m.Refresh()
+	if err == nil {
+		t.Fatalf("Refresh with duplicate basenames: expected error, got nil (names=%v)", m.Names())
+	}
+	if !strings.Contains(err.Error(), "duplicate worktree name") {
+		t.Errorf("error = %q, want contains %q", err.Error(), "duplicate worktree name")
 	}
 }

--- a/internal/worktree/discover.go
+++ b/internal/worktree/discover.go
@@ -1,0 +1,112 @@
+package worktree
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// Entry describes a single git worktree as discovered by
+// `git worktree list --porcelain`. Path is the absolute filesystem
+// path to the worktree root; Name is filepath.Base(Path). Branch is
+// the current branch (may be empty for detached HEAD). Bare is true
+// for bare repositories (these are skipped by Discover since they
+// have no working tree).
+type Entry struct {
+	Path   string
+	Name   string
+	Branch string
+	Head   string
+	Bare   bool
+}
+
+// Discover runs `git worktree list --porcelain` from projectRoot and
+// returns the parsed entries, excluding bare repos. On success the
+// result is sorted by Name. When git is unavailable or projectRoot is
+// not inside a git repo, Discover returns a single synthetic entry
+// matching projectRoot so callers can still serve the current
+// directory without a git repo.
+func Discover(projectRoot string) ([]Entry, error) {
+	cmd := exec.Command("git", "-C", projectRoot, "worktree", "list", "--porcelain")
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	var errBuf bytes.Buffer
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		// Fallback: treat projectRoot as a single standalone worktree.
+		abs, aerr := filepath.Abs(projectRoot)
+		if aerr != nil {
+			abs = projectRoot
+		}
+		return []Entry{{Path: abs, Name: filepath.Base(abs)}}, nil
+	}
+	entries, err := ParseWorktreeList(buf.String())
+	if err != nil {
+		return nil, fmt.Errorf("worktree: parse list: %w", err)
+	}
+	var out []Entry
+	for _, e := range entries {
+		if e.Bare {
+			continue
+		}
+		if e.Name == "" {
+			e.Name = filepath.Base(e.Path)
+		}
+		out = append(out, e)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out, nil
+}
+
+// ParseWorktreeList parses the porcelain output of
+// `git worktree list --porcelain`. Each record is terminated by a
+// blank line; fields are whitespace-separated "key value" pairs with
+// a leading line of "worktree <path>". The "bare" and "detached"
+// lines have no value. Unknown keys are ignored.
+func ParseWorktreeList(output string) ([]Entry, error) {
+	var out []Entry
+	var cur *Entry
+	flush := func() {
+		if cur == nil {
+			return
+		}
+		if cur.Path != "" && cur.Name == "" {
+			cur.Name = filepath.Base(cur.Path)
+		}
+		out = append(out, *cur)
+		cur = nil
+	}
+	for _, raw := range strings.Split(output, "\n") {
+		line := strings.TrimRight(raw, "\r")
+		if line == "" {
+			flush()
+			continue
+		}
+		// "worktree <path>" starts a new record.
+		if strings.HasPrefix(line, "worktree ") {
+			flush()
+			cur = &Entry{Path: strings.TrimPrefix(line, "worktree ")}
+			continue
+		}
+		if cur == nil {
+			continue
+		}
+		switch {
+		case line == "bare":
+			cur.Bare = true
+		case strings.HasPrefix(line, "HEAD "):
+			cur.Head = strings.TrimPrefix(line, "HEAD ")
+		case strings.HasPrefix(line, "branch "):
+			// Value is a ref like refs/heads/main.
+			ref := strings.TrimPrefix(line, "branch ")
+			cur.Branch = strings.TrimPrefix(ref, "refs/heads/")
+		case line == "detached":
+			// No branch value. Branch stays empty.
+		}
+	}
+	flush()
+	return out, nil
+}

--- a/internal/worktree/discover_test.go
+++ b/internal/worktree/discover_test.go
@@ -1,0 +1,62 @@
+package worktree
+
+import "testing"
+
+func TestParseWorktreeList_Porcelain(t *testing.T) {
+	input := "worktree /home/u/proj\nHEAD abcdef1\nbranch refs/heads/main\n\n" +
+		"worktree /home/u/proj-feat\nHEAD 123456a\nbranch refs/heads/feat/x\n\n" +
+		"worktree /home/u/proj-detached\nHEAD deadbee\ndetached\n\n"
+
+	got, err := ParseWorktreeList(input)
+	if err != nil {
+		t.Fatalf("ParseWorktreeList: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("want 3 entries, got %d: %+v", len(got), got)
+	}
+	if got[0].Path != "/home/u/proj" || got[0].Branch != "main" || got[0].Name != "proj" {
+		t.Errorf("entry[0] = %+v", got[0])
+	}
+	if got[1].Branch != "feat/x" || got[1].Name != "proj-feat" {
+		t.Errorf("entry[1] = %+v", got[1])
+	}
+	if got[2].Branch != "" || got[2].Head != "deadbee" {
+		t.Errorf("entry[2] = %+v", got[2])
+	}
+}
+
+func TestParseWorktreeList_Bare(t *testing.T) {
+	input := "worktree /srv/repo.git\nbare\n\n" +
+		"worktree /srv/repo-work\nHEAD aaa111\nbranch refs/heads/main\n\n"
+
+	got, err := ParseWorktreeList(input)
+	if err != nil {
+		t.Fatalf("ParseWorktreeList: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("want 2, got %d", len(got))
+	}
+	if !got[0].Bare {
+		t.Errorf("entry[0] should be bare: %+v", got[0])
+	}
+	if got[1].Bare {
+		t.Errorf("entry[1] should not be bare: %+v", got[1])
+	}
+}
+
+func TestParseWorktreeList_TrailingNoBlank(t *testing.T) {
+	// Some git versions may omit the trailing blank line; the parser
+	// should still emit the final record.
+	input := "worktree /home/u/proj\nHEAD abc\nbranch refs/heads/main"
+
+	got, err := ParseWorktreeList(input)
+	if err != nil {
+		t.Fatalf("ParseWorktreeList: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("want 1, got %d", len(got))
+	}
+	if got[0].Branch != "main" {
+		t.Errorf("branch = %q", got[0].Branch)
+	}
+}


### PR DESCRIPTION
Implements #50.

## Summary
- `archai serve --multi` exposes every git worktree under `/w/{name}/*` on one HTTP port.
- Single-worktree mode (default) is unchanged.
- Lazy per-worktree `State` cache keyed by worktree name, dropped when a worktree disappears.

## What changed
- **`internal/worktree/discover.go`** — `Discover()` parses `git worktree list --porcelain`. Falls back to a single synthetic CWD entry when git is unavailable.
- **`internal/serve/multistate.go`** — `MultiState` holds one `*State` per worktree, lazy-loaded via an injected `StateLoader` (constructor DI; `DefaultStateLoader` for production). `Refresh()` re-runs discovery and drops caches for vanished worktrees.
- **`internal/adapter/http`**
  - New `NewMultiServer(*MultiState)` constructor.
  - `dispatchWorktree` strips `/w/{name}`, resolves the `State`, and stashes both on the request context.
  - Legacy roots (`/`, `/layers`, `/packages`, `/configs`, `/diff`, `/targets`, `/search`, `/types/`, …) redirect to `/w/{selected}/...` via cookie `archai_worktree` (falls back to first-alphabetical).
  - `POST /worktree/select` sets the cookie; returns `303 See Other` for plain POSTs and `HX-Redirect` for HTMX clients.
  - Top-nav switcher dropdown in `base.html` (auto-submits on change).
  - All page handlers resolve state via `stateFor(r)` and prefix their nav links via `navPrefix(r)`.
- **`cmd/archai/main.go`** — `serve --multi` flag; wires `MultiState` + `NewMultiServer`. Incompatible with `--mcp-stdio`.
- **`internal/serve/daemon.go`** — multi mode skips the fsnotify watcher (per-worktree watchers are future work) and blocks on `ctx` so the HTTP transport stays alive.

## Tests
- `internal/worktree`: porcelain parser (branch / detached / bare / trailing-newline variants).
- `internal/serve`: `Refresh` + lazy `Get` cache semantics, cache-drop on removed worktrees (via stub loader + load counter).
- `internal/adapter/http`: `stripWorktreePrefix` + `rewriteForWorktree` unit tests; full HTTP round-trips against a real two-worktree git repo — legacy redirect (with/without cookie), `/w/{name}/` dispatch + nav-prefix rendering, unknown worktree 404, switcher cookie (regular + HTMX), lazy load cache reuse, single-mode regression guard that `/layers` still returns 200 without any `/w/*` routes installed.

## Notes
- No test-only production code: `MultiState` takes its `StateLoader` at construction, and http multi-mode tests use a real git worktree set (`git worktree add`) rather than any exported seeding helper.
- Cross-worktree aggregated dashboards / merged diffs are deliberately out of scope per #50.

Closes #50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)