### PR TITLE
feat(plugin): M12 plugin contract + unified Model (#65)

### DIFF
--- a/cmd/archai/main.go
+++ b/cmd/archai/main.go
@@ -391,6 +391,14 @@ Examples:
 	// extract — dumps per-package YAML/JSON (mirror of the MCP extract tool).
 	rootCmd.AddCommand(newExtractCmd())
 
+	// M12: in-process plugin contract. Built-in plugins register
+	// themselves via init(); wirePlugins runs the bootstrap once
+	// against a CLI-scoped Host and mounts every plugin-contributed
+	// CLI command under the cobra root. M13 (#66) will mount the
+	// MCP / HTTP / UI capabilities through the corresponding
+	// transports.
+	wirePlugins(rootCmd)
+
 	// Execute root command
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)

--- a/cmd/archai/plugins.go
+++ b/cmd/archai/plugins.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"sync"
+
+	"github.com/spf13/cobra"
+
+	"github.com/kgatilin/archai/internal/overlay"
+	"github.com/kgatilin/archai/internal/plugin"
+
+	// Built-in plugins. Importing them for side effects registers
+	// each one with the plugin package's global registry. Adding a
+	// new built-in plugin is a one-line change here.
+	_ "github.com/kgatilin/archai/internal/plugins/complexity"
+)
+
+// cliHost is a Host implementation used outside the long-running
+// daemon — i.e. for plugin CLI commands invoked from `archai
+// <plugin-cmd>`. It loads the project model lazily on first access
+// (so plugin commands that don't touch the model stay fast) and
+// re-uses cmd/archai's existing model loaders (loadCurrentModel,
+// resolveOverlay) so behavior matches the rest of the CLI.
+//
+// Subscribe is a no-op: the CLI is short-lived; plugins that need
+// real-time updates run inside `archai serve`, where serve.Host
+// provides the live event bus.
+type cliHost struct {
+	logger *slog.Logger
+
+	mu       sync.Mutex
+	loaded   bool
+	loadErr  error
+	model    *plugin.Model
+	bus      *plugin.EventBus
+	rootPath string
+}
+
+func newCLIHost() *cliHost {
+	return &cliHost{
+		logger: slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo})),
+		bus:    plugin.NewEventBus(),
+	}
+}
+
+func (h *cliHost) ensureLoaded() error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.loaded {
+		return h.loadErr
+	}
+	h.loaded = true
+
+	root, err := os.Getwd()
+	if err != nil {
+		h.loadErr = fmt.Errorf("plugin host: getwd: %w", err)
+		return h.loadErr
+	}
+	h.rootPath = root
+
+	pkgs, err := loadCurrentModel(context.Background(), root)
+	if err != nil {
+		h.loadErr = fmt.Errorf("plugin host: load model: %w", err)
+		return h.loadErr
+	}
+
+	overlayPath, goModPath := resolveOverlay("")
+	var cfg *overlay.Config
+	module := ""
+	if overlayPath != "" {
+		cfg, err = overlay.LoadComposed(overlayPath)
+		if err != nil {
+			h.logger.Warn("plugin host: load overlay", "path", overlayPath, "err", err)
+		} else {
+			if goModPath != "" {
+				if verr := overlay.Validate(cfg, goModPath); verr != nil {
+					h.logger.Warn("plugin host: overlay validation", "err", verr)
+				}
+			}
+			merged, _, mergeErr := overlay.Merge(pkgs, cfg)
+			if mergeErr == nil {
+				pkgs = merged
+			}
+			module = cfg.Module
+		}
+	}
+
+	h.model = plugin.BuildModel(module, pkgs, cfg)
+	return nil
+}
+
+// CurrentModel implements plugin.Host.
+func (h *cliHost) CurrentModel() *plugin.Model {
+	if err := h.ensureLoaded(); err != nil {
+		h.logger.Error("plugin host: model unavailable", "err", err)
+		return nil
+	}
+	return h.model
+}
+
+// Targets implements plugin.Host. Returns nil for the CLI host: no
+// long-running state, plugins that need targets should call Target
+// or run inside serve.
+func (h *cliHost) Targets() []plugin.TargetMeta { return nil }
+
+// Target implements plugin.Host.
+func (h *cliHost) Target(string) (*plugin.TargetSnapshot, error) {
+	return nil, errors.New("plugin: target loading is only available inside `archai serve`")
+}
+
+// ActiveTarget implements plugin.Host.
+func (h *cliHost) ActiveTarget() *plugin.TargetSnapshot { return nil }
+
+// Diff implements plugin.Host.
+func (h *cliHost) Diff(string, string) (*plugin.Diff, error) {
+	return nil, errors.New("plugin: Host.Diff is only available inside `archai serve`")
+}
+
+// Validate implements plugin.Host.
+func (h *cliHost) Validate(string) (*plugin.ValidationReport, error) {
+	return nil, errors.New("plugin: Host.Validate is only available inside `archai serve`")
+}
+
+// Subscribe implements plugin.Host. Returns the no-op bus's
+// Unsubscribe — events are never published in CLI mode.
+func (h *cliHost) Subscribe(handler func(plugin.ModelEvent)) plugin.Unsubscribe {
+	return h.bus.Subscribe(handler)
+}
+
+// Logger implements plugin.Host.
+func (h *cliHost) Logger() *slog.Logger { return h.logger }
+
+// wirePlugins runs the in-process plugin bootstrap and adds every
+// plugin-contributed CLI command to root. Errors from individual
+// plugin Inits are reported to stderr but do not abort startup —
+// other commands should still work.
+//
+// M12 mounts plugin commands at the cobra root level (no `archai
+// plugins <name>` grouping). M13 (#66) replaces this with a proper
+// `plugins` subcommand and per-plugin namespacing.
+func wirePlugins(rootCmd *cobra.Command) plugin.BootstrapResult {
+	host := newCLIHost()
+	res, err := plugin.Bootstrap(context.Background(), host, nil)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "archai: plugin bootstrap: %v\n", err)
+	}
+	plugin.AddCLICommandsToRoot(rootCmd, res.CLICommands)
+	return res
+}

--- a/internal/plugin/bootstrap.go
+++ b/internal/plugin/bootstrap.go
@@ -1,0 +1,179 @@
+package plugin
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/spf13/cobra"
+)
+
+// BootstrapResult collects every capability spec gathered while
+// initializing the registered plugins. The caller (cmd/archai) wires
+// these into the appropriate transports:
+//   - CLI commands are added to the cobra root;
+//   - MCPTools and HTTPHandlers are forwarded to their respective
+//     adapters when those transports are active.
+//
+// M12 leaves dispatch wiring (prefixing under /api/plugins/<name>/
+// for HTTP, namespacing for MCP, mounting under sidebar/dashboard
+// slots for UI) to M13. The bootstrap simply ensures every Init
+// runs and every accessor is invoked exactly once.
+type BootstrapResult struct {
+	// CLICommands are the cobra commands contributed by plugins,
+	// each tagged with the manifest name of its source plugin so
+	// the caller can decide on namespacing.
+	CLICommands []NamedCLICommand
+
+	// MCPTools are the tool descriptors contributed by plugins.
+	MCPTools []NamedMCPTool
+
+	// HTTPHandlers are the HTTP routes contributed by plugins.
+	HTTPHandlers []NamedHTTPHandler
+
+	// UIComponents are the UI panels/widgets contributed by plugins.
+	UIComponents []NamedUIComponent
+}
+
+// NamedCLICommand pairs a CLI command spec with the plugin that
+// produced it.
+type NamedCLICommand struct {
+	Plugin  string
+	Command CLICommand
+}
+
+// NamedMCPTool pairs an MCP tool spec with the plugin that produced
+// it.
+type NamedMCPTool struct {
+	Plugin string
+	Tool   MCPTool
+}
+
+// NamedHTTPHandler pairs an HTTP handler spec with the plugin that
+// produced it.
+type NamedHTTPHandler struct {
+	Plugin  string
+	Handler HTTPHandler
+}
+
+// NamedUIComponent pairs a UI component spec with the plugin that
+// produced it.
+type NamedUIComponent struct {
+	Plugin    string
+	Component UIComponent
+}
+
+// ConfigPathFunc resolves the on-disk config path for a plugin by
+// manifest name. Callers that don't need per-plugin configs can pass
+// nil; in that case Init receives "" for configPath.
+type ConfigPathFunc func(manifestName string) string
+
+// Bootstrap initializes every registered plugin against host and
+// collects their capability specs. Errors from individual plugin
+// Inits are returned as a single aggregated error so a failed plugin
+// does not prevent the rest from running — callers decide whether to
+// abort.
+func Bootstrap(ctx context.Context, host Host, configPath ConfigPathFunc) (BootstrapResult, error) {
+	var result BootstrapResult
+	var errs []error
+
+	for _, p := range Registered() {
+		mf := p.Manifest()
+		var cfg string
+		if configPath != nil {
+			cfg = configPath(mf.Name)
+		}
+		if err := p.Init(ctx, host, cfg); err != nil {
+			errs = append(errs, fmt.Errorf("plugin %q init: %w", mf.Name, err))
+			continue
+		}
+		for _, c := range p.CLICommands() {
+			if c.Cmd == nil {
+				continue
+			}
+			result.CLICommands = append(result.CLICommands, NamedCLICommand{Plugin: mf.Name, Command: c})
+		}
+		for _, t := range p.MCPTools() {
+			result.MCPTools = append(result.MCPTools, NamedMCPTool{Plugin: mf.Name, Tool: t})
+		}
+		for _, h := range p.HTTPHandlers() {
+			result.HTTPHandlers = append(result.HTTPHandlers, NamedHTTPHandler{Plugin: mf.Name, Handler: h})
+		}
+		for _, u := range p.UIComponents() {
+			result.UIComponents = append(result.UIComponents, NamedUIComponent{Plugin: mf.Name, Component: u})
+		}
+	}
+
+	if len(errs) == 0 {
+		return result, nil
+	}
+	return result, joinErrors(errs)
+}
+
+// AddCLICommandsToRoot adds every plugin-contributed cobra command to
+// rootCmd. M12 keeps it flat (no per-plugin subcommand grouping) so
+// existing tests that walk root.Commands() keep their guarantees.
+// M13 (#66) replaces this with a `plugins` subgroup.
+func AddCLICommandsToRoot(rootCmd *cobra.Command, cmds []NamedCLICommand) {
+	for _, c := range cmds {
+		if c.Command.Cmd == nil {
+			continue
+		}
+		rootCmd.AddCommand(c.Command.Cmd)
+	}
+}
+
+// MountHTTPHandlers registers every plugin-contributed HTTP route on
+// the given mux. M12 mounts at the route's literal Path; M13 will
+// prefix /api/plugins/<plugin>/. The Methods field is honored by
+// wrapping the handler with a method check.
+func MountHTTPHandlers(mux *http.ServeMux, handlers []NamedHTTPHandler) {
+	for _, h := range handlers {
+		if h.Handler.Handler == nil || h.Handler.Path == "" {
+			continue
+		}
+		hh := h.Handler
+		if len(hh.Methods) == 0 {
+			mux.Handle(hh.Path, hh.Handler)
+			continue
+		}
+		methods := make(map[string]struct{}, len(hh.Methods))
+		for _, m := range hh.Methods {
+			methods[m] = struct{}{}
+		}
+		mux.Handle(hh.Path, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if _, ok := methods[r.Method]; !ok {
+				http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+				return
+			}
+			hh.Handler.ServeHTTP(w, r)
+		}))
+	}
+}
+
+// joinErrors returns errors.Join-style aggregation without depending
+// on stdlib errors.Join (available since Go 1.20; archai already
+// requires newer Go but keeping this local makes the package
+// self-contained and the behavior obvious).
+func joinErrors(errs []error) error {
+	if len(errs) == 0 {
+		return nil
+	}
+	if len(errs) == 1 {
+		return errs[0]
+	}
+	return aggErr{errs: errs}
+}
+
+type aggErr struct{ errs []error }
+
+func (a aggErr) Error() string {
+	msg := ""
+	for i, e := range a.errs {
+		if i > 0 {
+			msg += "; "
+		}
+		msg += e.Error()
+	}
+	return msg
+}

--- a/internal/plugin/bootstrap_test.go
+++ b/internal/plugin/bootstrap_test.go
@@ -1,0 +1,200 @@
+package plugin
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// stubHost is a minimal Host for bootstrap tests. Plugins under test
+// don't actually call back into it; we just need a non-nil value.
+type stubHost struct{}
+
+func (stubHost) CurrentModel() *Model                            { return nil }
+func (stubHost) Targets() []TargetMeta                           { return nil }
+func (stubHost) Target(string) (*TargetSnapshot, error)          { return nil, nil }
+func (stubHost) ActiveTarget() *TargetSnapshot                   { return nil }
+func (stubHost) Diff(string, string) (*Diff, error)              { return nil, nil }
+func (stubHost) Validate(string) (*ValidationReport, error)      { return nil, nil }
+func (stubHost) Subscribe(func(ModelEvent)) Unsubscribe          { return func() {} }
+func (stubHost) Logger() *slog.Logger                            { return slog.Default() }
+
+func TestBootstrap_RunsInitAndCollectsCapabilities(t *testing.T) {
+	resetRegistryForTest()
+	t.Cleanup(resetRegistryForTest)
+
+	cli := &cobra.Command{Use: "demo-cli"}
+	mcpHandlerCalled := false
+	httpHandlerCalled := false
+
+	p := &fakePlugin{
+		name: "demo",
+		cli:  []CLICommand{{Cmd: cli}},
+		mcp: []MCPTool{{
+			Name: "demo.tool",
+			Handler: func(_ context.Context, _ map[string]any) (any, error) {
+				mcpHandlerCalled = true
+				return "ok", nil
+			},
+		}},
+		http: []HTTPHandler{{
+			Path: "/api/demo/ping",
+			Handler: http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+				httpHandlerCalled = true
+			}),
+		}},
+		ui: []UIComponent{{Slot: EmbedSlotDashboard, Title: "Demo", AssetPath: "/demo.js"}},
+	}
+	RegisterPlugin(p)
+
+	res, err := Bootstrap(context.Background(), stubHost{}, nil)
+	if err != nil {
+		t.Fatalf("Bootstrap returned error: %v", err)
+	}
+	if p.initCalls != 1 {
+		t.Errorf("Init calls = %d, want 1", p.initCalls)
+	}
+	if p.host == nil {
+		t.Errorf("plugin did not receive a Host")
+	}
+
+	if got := len(res.CLICommands); got != 1 {
+		t.Errorf("CLICommands len = %d, want 1", got)
+	} else if res.CLICommands[0].Plugin != "demo" {
+		t.Errorf("CLICommands[0].Plugin = %q, want %q", res.CLICommands[0].Plugin, "demo")
+	}
+	if got := len(res.MCPTools); got != 1 {
+		t.Errorf("MCPTools len = %d, want 1", got)
+	}
+	if got := len(res.HTTPHandlers); got != 1 {
+		t.Errorf("HTTPHandlers len = %d, want 1", got)
+	}
+	if got := len(res.UIComponents); got != 1 {
+		t.Errorf("UIComponents len = %d, want 1", got)
+	}
+
+	// Smoke test: handlers wired through the bootstrap descriptors
+	// can still be invoked.
+	if _, err := res.MCPTools[0].Tool.Handler(context.Background(), nil); err != nil {
+		t.Errorf("MCP handler error: %v", err)
+	}
+	if !mcpHandlerCalled {
+		t.Errorf("MCP handler was not invoked")
+	}
+
+	mux := http.NewServeMux()
+	MountHTTPHandlers(mux, res.HTTPHandlers)
+	req, _ := http.NewRequest(http.MethodGet, "/api/demo/ping", nil)
+	rw := &recordingResponseWriter{}
+	mux.ServeHTTP(rw, req)
+	if !httpHandlerCalled {
+		t.Errorf("HTTP handler was not invoked")
+	}
+}
+
+func TestBootstrap_AggregatesInitErrors(t *testing.T) {
+	resetRegistryForTest()
+	t.Cleanup(resetRegistryForTest)
+
+	good := &fakePlugin{name: "good"}
+	bad := &fakePlugin{name: "bad", initErr: errors.New("boom")}
+	RegisterPlugin(good)
+	RegisterPlugin(bad)
+
+	_, err := Bootstrap(context.Background(), stubHost{}, nil)
+	if err == nil {
+		t.Fatalf("Bootstrap did not surface init error")
+	}
+	if !strings.Contains(err.Error(), "bad") {
+		t.Errorf("error = %v, want it to mention bad plugin", err)
+	}
+	if good.initCalls != 1 {
+		t.Errorf("good plugin Init calls = %d, want 1", good.initCalls)
+	}
+}
+
+func TestBootstrap_ConfigPathFunc(t *testing.T) {
+	resetRegistryForTest()
+	t.Cleanup(resetRegistryForTest)
+
+	p := &fakePlugin{name: "needs-config"}
+	RegisterPlugin(p)
+
+	wantPath := "/etc/archai/needs-config.yaml"
+	gotName := ""
+	gotPath := ""
+
+	cfg := func(name string) string {
+		gotName = name
+		return wantPath
+	}
+	// Plug in a probe that captures configPath via Init's third arg.
+	p.initErr = nil
+	wrapped := &capturingPlugin{fakePlugin: p, capturedPath: &gotPath}
+	resetRegistryForTest()
+	RegisterPlugin(wrapped)
+
+	if _, err := Bootstrap(context.Background(), stubHost{}, cfg); err != nil {
+		t.Fatalf("Bootstrap error: %v", err)
+	}
+	if gotName != "needs-config" {
+		t.Errorf("ConfigPathFunc called with name = %q, want %q", gotName, "needs-config")
+	}
+	if gotPath != wantPath {
+		t.Errorf("plugin saw configPath = %q, want %q", gotPath, wantPath)
+	}
+}
+
+func TestAddCLICommandsToRoot_AttachesEveryCommand(t *testing.T) {
+	root := &cobra.Command{Use: "archai"}
+	cmds := []NamedCLICommand{
+		{Plugin: "a", Command: CLICommand{Cmd: &cobra.Command{Use: "alpha"}}},
+		{Plugin: "b", Command: CLICommand{Cmd: &cobra.Command{Use: "beta"}}},
+		{Plugin: "c", Command: CLICommand{Cmd: nil}}, // should be skipped
+	}
+	AddCLICommandsToRoot(root, cmds)
+
+	names := map[string]bool{}
+	for _, c := range root.Commands() {
+		names[c.Use] = true
+	}
+	if !names["alpha"] || !names["beta"] {
+		t.Errorf("missing commands in root: %v", names)
+	}
+}
+
+// capturingPlugin records the configPath received by Init.
+type capturingPlugin struct {
+	*fakePlugin
+	capturedPath *string
+}
+
+func (p *capturingPlugin) Init(ctx context.Context, h Host, configPath string) error {
+	*p.capturedPath = configPath
+	return p.fakePlugin.Init(ctx, h, configPath)
+}
+
+// recordingResponseWriter is a minimal http.ResponseWriter that
+// satisfies the interface for our bootstrap smoke test.
+type recordingResponseWriter struct {
+	header http.Header
+	status int
+	body   []byte
+}
+
+func (r *recordingResponseWriter) Header() http.Header {
+	if r.header == nil {
+		r.header = http.Header{}
+	}
+	return r.header
+}
+func (r *recordingResponseWriter) Write(b []byte) (int, error) {
+	r.body = append(r.body, b...)
+	return len(b), nil
+}
+func (r *recordingResponseWriter) WriteHeader(status int) { r.status = status }

--- a/internal/plugin/eventbus.go
+++ b/internal/plugin/eventbus.go
@@ -1,0 +1,91 @@
+package plugin
+
+import "sync"
+
+// EventBus is the broadcast primitive that backs Host.Subscribe. The
+// daemon owns one EventBus per State (created during bootstrap) and
+// publishes to it on fsnotify-driven reloads, overlay reloads, and
+// target switches.
+//
+// Delivery is synchronous from the caller's goroutine: Publish does
+// not start any new goroutines, and handlers are invoked in
+// registration order. Plugins must keep handlers cheap and
+// non-blocking; long-running work belongs in a goroutine the
+// handler launches.
+//
+// The bus is safe for concurrent Subscribe / Publish / Unsubscribe.
+type EventBus struct {
+	mu     sync.RWMutex
+	nextID uint64
+	subs   map[uint64]func(ModelEvent)
+}
+
+// NewEventBus returns an empty bus.
+func NewEventBus() *EventBus {
+	return &EventBus{subs: make(map[uint64]func(ModelEvent))}
+}
+
+// Subscribe registers handler. Returns an Unsubscribe that detaches
+// the handler. Calling Unsubscribe twice (or after Close) is safe.
+func (b *EventBus) Subscribe(handler func(ModelEvent)) Unsubscribe {
+	if handler == nil {
+		// Nil handlers are accepted as a no-op so callers can
+		// unconditionally Subscribe(nil) and still get a cancel
+		// closure.
+		return func() {}
+	}
+	b.mu.Lock()
+	id := b.nextID
+	b.nextID++
+	if b.subs == nil {
+		b.subs = make(map[uint64]func(ModelEvent))
+	}
+	b.subs[id] = handler
+	b.mu.Unlock()
+
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			b.mu.Lock()
+			delete(b.subs, id)
+			b.mu.Unlock()
+		})
+	}
+}
+
+// Publish delivers ev to every subscribed handler in registration
+// order. A snapshot of the subscribers is taken under the read lock
+// so handlers may unsubscribe themselves without deadlocking.
+func (b *EventBus) Publish(ev ModelEvent) {
+	b.mu.RLock()
+	// Capture a sorted snapshot so dispatch order is deterministic
+	// across runs (handlers are keyed by an increasing id, which
+	// matches subscription order).
+	ids := make([]uint64, 0, len(b.subs))
+	for id := range b.subs {
+		ids = append(ids, id)
+	}
+	// Insertion order is preserved by walking ids in ascending
+	// numeric order — cheap and avoids a full sort import here.
+	for i := 1; i < len(ids); i++ {
+		for j := i; j > 0 && ids[j-1] > ids[j]; j-- {
+			ids[j-1], ids[j] = ids[j], ids[j-1]
+		}
+	}
+	handlers := make([]func(ModelEvent), 0, len(ids))
+	for _, id := range ids {
+		handlers = append(handlers, b.subs[id])
+	}
+	b.mu.RUnlock()
+
+	for _, h := range handlers {
+		h(ev)
+	}
+}
+
+// Len reports the current number of subscribers. Useful for tests.
+func (b *EventBus) Len() int {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return len(b.subs)
+}

--- a/internal/plugin/eventbus_test.go
+++ b/internal/plugin/eventbus_test.go
@@ -1,0 +1,91 @@
+package plugin
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestEventBus_PublishesToAllSubscribers(t *testing.T) {
+	bus := NewEventBus()
+	var got1, got2 []ModelEventKind
+
+	bus.Subscribe(func(ev ModelEvent) { got1 = append(got1, ev.Kind) })
+	bus.Subscribe(func(ev ModelEvent) { got2 = append(got2, ev.Kind) })
+
+	bus.Publish(ModelEvent{Kind: ModelEventKindOverlayReload})
+	bus.Publish(ModelEvent{Kind: ModelEventKindTargetSwitch, Target: "v1"})
+
+	if want := []ModelEventKind{ModelEventKindOverlayReload, ModelEventKindTargetSwitch}; !equalKinds(got1, want) {
+		t.Errorf("got1 = %v, want %v", got1, want)
+	}
+	if want := []ModelEventKind{ModelEventKindOverlayReload, ModelEventKindTargetSwitch}; !equalKinds(got2, want) {
+		t.Errorf("got2 = %v, want %v", got2, want)
+	}
+}
+
+func TestEventBus_UnsubscribeStopsDelivery(t *testing.T) {
+	bus := NewEventBus()
+	var calls int
+	cancel := bus.Subscribe(func(ev ModelEvent) { calls++ })
+
+	bus.Publish(ModelEvent{Kind: ModelEventKindOverlayReload})
+	if calls != 1 {
+		t.Fatalf("after first publish: calls = %d, want 1", calls)
+	}
+
+	cancel()
+	bus.Publish(ModelEvent{Kind: ModelEventKindOverlayReload})
+	if calls != 1 {
+		t.Errorf("after unsubscribe + publish: calls = %d, want 1", calls)
+	}
+
+	// Double-unsubscribe must be safe.
+	cancel()
+}
+
+func TestEventBus_NilHandlerIsSafe(t *testing.T) {
+	bus := NewEventBus()
+	cancel := bus.Subscribe(nil)
+	bus.Publish(ModelEvent{Kind: ModelEventKindPackageReload})
+	cancel()
+	if got := bus.Len(); got != 0 {
+		t.Errorf("Len after publish/cancel = %d, want 0", got)
+	}
+}
+
+func TestEventBus_ConcurrentPublishAndSubscribe(t *testing.T) {
+	bus := NewEventBus()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			cancel := bus.Subscribe(func(ev ModelEvent) {})
+			cancel()
+		}()
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			bus.Publish(ModelEvent{Kind: ModelEventKindOverlayReload})
+		}()
+	}
+	wg.Wait()
+	// Test passes if there's no race / panic; bus.Len() should be 0
+	// after every subscriber cancelled.
+	if got := bus.Len(); got != 0 {
+		t.Errorf("Len after subscribe/cancel storm = %d, want 0", got)
+	}
+}
+
+func equalKinds(a, b []ModelEventKind) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/plugin/model.go
+++ b/internal/plugin/model.go
@@ -1,0 +1,169 @@
+package plugin
+
+import (
+	"github.com/kgatilin/archai/internal/domain"
+	"github.com/kgatilin/archai/internal/overlay"
+)
+
+// Model is the unified read-only view of the project's architecture
+// as seen by plugins. It composes the extracted Go model
+// (domain.PackageModel slices) with the overlay-derived layers,
+// rules, bounded contexts, aggregates, and configs.
+//
+// Provenance: every Package carries Layer/Aggregate fields populated
+// by overlay.Merge, so callers can tell whether a piece of metadata
+// came from code or from archai.yaml without an extra source field.
+// A future Source field can be added without changing this struct's
+// shape.
+type Model struct {
+	// Module is the Go module path from go.mod
+	// (e.g. "github.com/kgatilin/archai").
+	Module string
+
+	// Packages is the merged list of code-extracted packages with
+	// overlay-assigned Layer/Aggregate populated where applicable.
+	Packages []*domain.PackageModel
+
+	// Layers lists the architectural layers declared in archai.yaml.
+	// Empty when no overlay is loaded.
+	Layers []*Layer
+
+	// LayerRules lists the per-layer outbound allow-lists. A layer
+	// missing from this list is treated as "no outbound dependencies
+	// allowed" (matching overlay.Merge's semantics).
+	LayerRules []*LayerRule
+
+	// BCs is the list of bounded contexts. Reserved for future
+	// overlay extensions; populated empty in M12 since the current
+	// overlay schema has no BC concept yet.
+	BCs []*BoundedContext
+
+	// Aggregates lists overlay-declared domain aggregates by name.
+	Aggregates []*Aggregate
+
+	// Configs lists fully-qualified type names tagged as
+	// configuration entry points by archai.yaml.
+	Configs []*ConfigType
+}
+
+// Layer is one entry from archai.yaml's layers map.
+type Layer struct {
+	// Name is the layer identifier (e.g. "domain", "application").
+	Name string
+
+	// PackageGlobs is the list of package globs that match into this
+	// layer. Module-relative paths, identical to the on-disk YAML.
+	PackageGlobs []string
+}
+
+// LayerRule encodes the outbound dependency allow-list for one layer.
+type LayerRule struct {
+	// Layer is the source layer.
+	Layer string
+
+	// AllowedLayers lists the layers Layer may import. Same-layer
+	// imports are always implicitly allowed (mirrors overlay.Merge).
+	AllowedLayers []string
+}
+
+// BoundedContext is reserved for a future overlay extension that
+// groups aggregates into DDD-style contexts. Empty in M12.
+type BoundedContext struct {
+	Name        string
+	Aggregates  []string
+	Description string
+}
+
+// Aggregate is one entry from archai.yaml's aggregates map.
+type Aggregate struct {
+	// Name is the aggregate identifier.
+	Name string
+
+	// Root is the fully-qualified type name of the aggregate root,
+	// e.g. "github.com/kgatilin/archai/internal/domain.PackageModel".
+	Root string
+}
+
+// ConfigType is one entry from archai.yaml's configs list.
+type ConfigType struct {
+	// FQTypeName is the fully-qualified type name flagged as a
+	// configuration entry point.
+	FQTypeName string
+}
+
+// BuildModel composes packages + overlay config into a unified Model.
+// pkgs may already have been overlay-merged (Layer/Aggregate populated)
+// or not — BuildModel does not re-run the merge; it just plumbs the
+// values through. cfg may be nil when no overlay is loaded.
+//
+// The returned Model holds pointers into pkgs so callers should not
+// mutate the slice afterwards.
+func BuildModel(module string, pkgs []domain.PackageModel, cfg *overlay.Config) *Model {
+	m := &Model{Module: module}
+
+	m.Packages = make([]*domain.PackageModel, len(pkgs))
+	for i := range pkgs {
+		m.Packages[i] = &pkgs[i]
+	}
+
+	if cfg == nil {
+		return m
+	}
+
+	if module == "" && cfg.Module != "" {
+		m.Module = cfg.Module
+	}
+
+	for name, globs := range cfg.Layers {
+		globsCopy := make([]string, len(globs))
+		copy(globsCopy, globs)
+		m.Layers = append(m.Layers, &Layer{Name: name, PackageGlobs: globsCopy})
+	}
+	sortLayers(m.Layers)
+
+	for name, allowed := range cfg.LayerRules {
+		allowedCopy := make([]string, len(allowed))
+		copy(allowedCopy, allowed)
+		m.LayerRules = append(m.LayerRules, &LayerRule{Layer: name, AllowedLayers: allowedCopy})
+	}
+	sortLayerRules(m.LayerRules)
+
+	for name, agg := range cfg.Aggregates {
+		m.Aggregates = append(m.Aggregates, &Aggregate{Name: name, Root: agg.Root})
+	}
+	sortAggregates(m.Aggregates)
+
+	for _, fq := range cfg.Configs {
+		m.Configs = append(m.Configs, &ConfigType{FQTypeName: fq})
+	}
+
+	return m
+}
+
+// FindPackage returns the PackageModel with the given module-relative
+// path, or nil when no such package is loaded.
+func (m *Model) FindPackage(path string) *domain.PackageModel {
+	if m == nil {
+		return nil
+	}
+	for _, p := range m.Packages {
+		if p != nil && p.Path == path {
+			return p
+		}
+	}
+	return nil
+}
+
+// PackagesInLayer returns the packages assigned to the named layer.
+func (m *Model) PackagesInLayer(layer string) []*domain.PackageModel {
+	if m == nil {
+		return nil
+	}
+	var out []*domain.PackageModel
+	for _, p := range m.Packages {
+		if p != nil && p.Layer == layer {
+			out = append(out, p)
+		}
+	}
+	return out
+}

--- a/internal/plugin/model_test.go
+++ b/internal/plugin/model_test.go
@@ -1,0 +1,92 @@
+package plugin
+
+import (
+	"testing"
+
+	"github.com/kgatilin/archai/internal/domain"
+	"github.com/kgatilin/archai/internal/overlay"
+)
+
+func TestBuildModel_PassesThroughPackages(t *testing.T) {
+	pkgs := []domain.PackageModel{
+		{Path: "internal/a", Name: "a", Layer: "domain"},
+		{Path: "internal/b", Name: "b", Layer: "service"},
+	}
+	got := BuildModel("acme.io/x", pkgs, nil)
+	if got.Module != "acme.io/x" {
+		t.Errorf("Module = %q, want acme.io/x", got.Module)
+	}
+	if len(got.Packages) != 2 {
+		t.Fatalf("Packages len = %d, want 2", len(got.Packages))
+	}
+	if got.Packages[0].Path != "internal/a" || got.Packages[0].Layer != "domain" {
+		t.Errorf("Packages[0] = %+v", *got.Packages[0])
+	}
+}
+
+func TestBuildModel_LayersAndRulesFromOverlay(t *testing.T) {
+	cfg := &overlay.Config{
+		Module: "acme.io/x",
+		Layers: map[string][]string{
+			"domain":  {"internal/domain/..."},
+			"service": {"internal/service/..."},
+		},
+		LayerRules: map[string][]string{
+			"service": {"domain"},
+		},
+		Aggregates: map[string]overlay.Aggregate{
+			"User": {Root: "acme.io/x/internal/domain.User"},
+		},
+		Configs: []string{"acme.io/x/internal/config.AppConfig"},
+	}
+	got := BuildModel("", nil, cfg)
+	if got.Module != "acme.io/x" {
+		t.Errorf("Module = %q, want acme.io/x", got.Module)
+	}
+	if len(got.Layers) != 2 {
+		t.Errorf("Layers len = %d, want 2", len(got.Layers))
+	}
+	// Layers should be sorted.
+	if got.Layers[0].Name != "domain" {
+		t.Errorf("Layers[0].Name = %q, want domain", got.Layers[0].Name)
+	}
+	if len(got.LayerRules) != 1 || got.LayerRules[0].Layer != "service" {
+		t.Errorf("LayerRules = %+v", got.LayerRules)
+	}
+	if len(got.Aggregates) != 1 || got.Aggregates[0].Name != "User" {
+		t.Errorf("Aggregates = %+v", got.Aggregates)
+	}
+	if len(got.Configs) != 1 || got.Configs[0].FQTypeName != "acme.io/x/internal/config.AppConfig" {
+		t.Errorf("Configs = %+v", got.Configs)
+	}
+}
+
+func TestModel_FindPackage(t *testing.T) {
+	pkgs := []domain.PackageModel{
+		{Path: "internal/a"},
+		{Path: "internal/b"},
+	}
+	m := BuildModel("acme.io/x", pkgs, nil)
+	if got := m.FindPackage("internal/b"); got == nil || got.Path != "internal/b" {
+		t.Errorf("FindPackage missed internal/b: %+v", got)
+	}
+	if got := m.FindPackage("missing"); got != nil {
+		t.Errorf("FindPackage(missing) = %+v, want nil", got)
+	}
+}
+
+func TestModel_PackagesInLayer(t *testing.T) {
+	pkgs := []domain.PackageModel{
+		{Path: "internal/a", Layer: "domain"},
+		{Path: "internal/b", Layer: "service"},
+		{Path: "internal/c", Layer: "domain"},
+	}
+	m := BuildModel("acme.io/x", pkgs, nil)
+	got := m.PackagesInLayer("domain")
+	if len(got) != 2 {
+		t.Fatalf("PackagesInLayer(domain) len = %d, want 2", len(got))
+	}
+	if got[0].Path != "internal/a" || got[1].Path != "internal/c" {
+		t.Errorf("PackagesInLayer(domain) paths = %s, %s", got[0].Path, got[1].Path)
+	}
+}

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -1,0 +1,211 @@
+// Package plugin defines archai's in-process plugin contract: the
+// Plugin interface that capability providers implement, the Host
+// interface that exposes archai's read-only model + utilities, and the
+// supporting capability descriptors (CLI / MCP / HTTP / UI).
+//
+// v1 scope (M12, issue #65):
+//   - In-process Go plugins only. Plugins compile into the archai
+//     binary and register themselves from init() via RegisterPlugin.
+//   - Plugins are read-only consumers of the Model. They cannot mutate
+//     it; mutation stays inside the daemon.
+//   - Capability dispatch (prefixing, /api/plugins/<name>/, UI mount
+//     points) is wired in M13 (#66). For M12 we collect the spec
+//     structs and hand them to the bootstrap so M13 can mount them
+//     without a contract change.
+//
+// Design notes (M12):
+//
+// Model lives in this package even though it composes domain.PackageModel
+// and overlay.Config. The alternative — putting it in internal/domain —
+// would force domain to import overlay, breaking the rule that domain
+// has no dependencies. Plugin already depends on both, so it's the
+// natural home for the unified view.
+package plugin
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+
+	"github.com/spf13/cobra"
+)
+
+// Plugin is the contract every archai plugin implements.
+//
+// The Host pulls capability slices from a plugin and decides where to
+// mount them; the plugin never calls back into the Host to register
+// itself. This keeps registration declarative and easy to test.
+type Plugin interface {
+	// Manifest identifies the plugin (name, version, description). The
+	// name acts as the namespace prefix for CLI commands, MCP tools,
+	// HTTP routes, and UI mount points (M13).
+	Manifest() Manifest
+
+	// Init runs once during archai bootstrap, before any capability
+	// accessors are queried. The plugin receives the Host (read-only
+	// view of the model + utilities) and a path to its config file
+	// resolved by archai. configPath may be empty when no config is
+	// present; plugins that need configuration must fail here.
+	Init(ctx context.Context, host Host, configPath string) error
+
+	// CLICommands returns the cobra commands this plugin contributes.
+	// Returning nil/empty is fine.
+	CLICommands() []CLICommand
+
+	// MCPTools returns the MCP tool descriptors this plugin exposes.
+	MCPTools() []MCPTool
+
+	// HTTPHandlers returns the HTTP routes this plugin serves.
+	HTTPHandlers() []HTTPHandler
+
+	// UIComponents returns the UI panels/widgets this plugin contributes.
+	UIComponents() []UIComponent
+}
+
+// Manifest is a small descriptor returned by Plugin.Manifest().
+type Manifest struct {
+	// Name is the plugin's stable identifier. Used as the namespace
+	// for prefixing CLI commands, MCP tools, HTTP routes, and UI
+	// mount points (M13). Must be a valid identifier (no slashes).
+	Name string
+
+	// Version is a free-form version string. Plugins set whatever
+	// makes sense (semver, build tag, "0.1-dev").
+	Version string
+
+	// Description is a short human-readable summary shown in `archai
+	// plugins list` (M13) and in plugin discovery responses.
+	Description string
+}
+
+// Host is the contract a plugin sees: a read-only view of the live
+// model plus a small toolbox (Diff, Validate, Subscribe). Plugins must
+// not assume any particular concrete implementation; the daemon and
+// the one-shot CLI provide different Hosts that satisfy this same
+// interface.
+type Host interface {
+	// CurrentModel returns the unified Model (code + overlay merged).
+	// The returned pointer is a snapshot; plugins should treat it as
+	// read-only and re-call CurrentModel after a ModelEvent rather
+	// than retaining the pointer indefinitely.
+	CurrentModel() *Model
+
+	// Targets lists the locked targets discovered under
+	// .arch/targets/. The list is sorted by id.
+	Targets() []TargetMeta
+
+	// Target loads a snapshot for the given target id.
+	Target(id string) (*TargetSnapshot, error)
+
+	// ActiveTarget returns the snapshot of the CURRENT target, or nil
+	// when no target is active.
+	ActiveTarget() *TargetSnapshot
+
+	// Diff computes a structured diff between two snapshots. fromID
+	// or toID may be empty to mean "current code model" (e.g. Diff("",
+	// "v1") returns "current vs target v1").
+	Diff(fromID, toID string) (*Diff, error)
+
+	// Validate runs the same checks `archai validate` performs against
+	// the named target (or CURRENT when modelID == "") and returns the
+	// resulting report.
+	Validate(modelID string) (*ValidationReport, error)
+
+	// Subscribe registers handler to receive ModelEvent broadcasts.
+	// Events are delivered synchronously from the dispatch goroutine;
+	// the handler must be cheap and non-blocking. Returns an
+	// Unsubscribe func that detaches the handler. Calling Unsubscribe
+	// twice is safe.
+	Subscribe(handler func(ModelEvent)) Unsubscribe
+
+	// Logger is a slog.Logger scoped to the plugin. Plugins should use
+	// it for any structured logging so daemon output stays consistent.
+	Logger() *slog.Logger
+}
+
+// Unsubscribe detaches a Subscribe handler. Safe to call multiple times.
+type Unsubscribe func()
+
+// CLICommand wraps a cobra.Command produced by a plugin. Wrapping (vs.
+// returning *cobra.Command directly) leaves room to add metadata
+// later (e.g. minimum archai version) without breaking the contract.
+type CLICommand struct {
+	// Cmd is the cobra command this plugin contributes. archai mounts
+	// it under a plugin-namespaced parent in M13; for M12 it can be
+	// added to the root command as-is.
+	Cmd *cobra.Command
+}
+
+// MCPTool is the descriptor archai uses to register a tool with the
+// MCP transport. The Handler is called with the raw JSON arguments
+// passed by the client; archai owns serialization to/from the wire.
+type MCPTool struct {
+	// Name is the tool name as exposed to MCP clients. M13 will
+	// prefix it with the plugin manifest name.
+	Name string
+
+	// Description is the human-readable summary returned by
+	// tools/list.
+	Description string
+
+	// InputSchema is the JSON Schema for the tool's arguments. May be
+	// empty (tool takes no args).
+	InputSchema map[string]any
+
+	// Handler executes the tool. It receives the raw decoded
+	// arguments and returns the result that will be JSON-encoded
+	// into the tools/call response.
+	Handler func(ctx context.Context, args map[string]any) (any, error)
+}
+
+// HTTPHandler is the descriptor archai uses to mount a plugin route
+// onto its HTTP transport.
+type HTTPHandler struct {
+	// Path is the URL path. M13 mounts these under
+	// /api/plugins/<plugin-name>/<path>; for M12 we hand them to the
+	// bootstrap as-is.
+	Path string
+
+	// Methods restricts the handler to specific HTTP verbs. Empty
+	// means "any verb".
+	Methods []string
+
+	// Handler is the http.Handler that serves the route.
+	Handler http.Handler
+}
+
+// UIComponent describes a UI panel or widget contributed by a plugin.
+// The browser-side bundle is shipped by the plugin; archai just hands
+// the descriptor to its UI registry (M13).
+type UIComponent struct {
+	// Slot identifies where the component should mount. Allowed
+	// values are defined by the UI host (e.g. EmbedSlotDashboard).
+	Slot EmbedSlot
+
+	// Title is the human-readable label shown in nav/tabs.
+	Title string
+
+	// AssetPath is the URL path under which the plugin serves its
+	// UI assets via one of its HTTPHandlers. The UI registry uses
+	// this to fetch the panel script/markup.
+	AssetPath string
+}
+
+// EmbedSlot enumerates the UI mount points archai's browser shell
+// exposes to plugins.
+type EmbedSlot string
+
+const (
+	// EmbedSlotDashboard mounts a card on the dashboard landing page.
+	EmbedSlotDashboard EmbedSlot = "dashboard"
+
+	// EmbedSlotPackagePanel mounts a tab inside the package detail
+	// view.
+	EmbedSlotPackagePanel EmbedSlot = "package-panel"
+
+	// EmbedSlotLayerPanel mounts a tab inside the layer detail view.
+	EmbedSlotLayerPanel EmbedSlot = "layer-panel"
+
+	// EmbedSlotSidebar adds an entry to the left-side navigation.
+	EmbedSlotSidebar EmbedSlot = "sidebar"
+)

--- a/internal/plugin/registry.go
+++ b/internal/plugin/registry.go
@@ -1,0 +1,76 @@
+package plugin
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+)
+
+// registry is the package-level plugin registry. Plugins call
+// RegisterPlugin from init() (or a constructor invoked from main) and
+// archai's bootstrap iterates Registered() to wire them up.
+//
+// Design: a process-global registry mirrors how net/http handlers,
+// database/sql drivers and image format decoders work in the standard
+// library. It keeps plugin source files self-contained — they need
+// nothing more than `import _ "archai/internal/plugins/foo"` to wire
+// themselves up. The trade-off (test isolation) is handled by
+// Reset() which is package-private and only used by tests in this
+// same package.
+var registry struct {
+	mu      sync.Mutex
+	plugins []Plugin
+	names   map[string]struct{}
+}
+
+// RegisterPlugin adds p to the process-wide registry. Calling it with
+// a duplicate manifest name panics — that's almost always a bug
+// (two plugins fighting for the same namespace) and we'd rather fail
+// at init than silently drop one.
+//
+// Plugins are typically registered from a package init() function:
+//
+//	func init() { plugin.RegisterPlugin(&MyPlugin{}) }
+func RegisterPlugin(p Plugin) {
+	if p == nil {
+		panic("plugin: RegisterPlugin called with nil Plugin")
+	}
+	name := p.Manifest().Name
+	if name == "" {
+		panic("plugin: RegisterPlugin called with empty Manifest.Name")
+	}
+
+	registry.mu.Lock()
+	defer registry.mu.Unlock()
+	if registry.names == nil {
+		registry.names = make(map[string]struct{})
+	}
+	if _, dup := registry.names[name]; dup {
+		panic(fmt.Sprintf("plugin: duplicate plugin name %q registered", name))
+	}
+	registry.names[name] = struct{}{}
+	registry.plugins = append(registry.plugins, p)
+}
+
+// Registered returns a snapshot of currently registered plugins,
+// sorted by manifest name for deterministic bootstrap order.
+func Registered() []Plugin {
+	registry.mu.Lock()
+	defer registry.mu.Unlock()
+
+	out := make([]Plugin, len(registry.plugins))
+	copy(out, registry.plugins)
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].Manifest().Name < out[j].Manifest().Name
+	})
+	return out
+}
+
+// resetRegistryForTest clears the registry. Only the plugin package's
+// own tests use it; production code never resets the registry.
+func resetRegistryForTest() {
+	registry.mu.Lock()
+	defer registry.mu.Unlock()
+	registry.plugins = nil
+	registry.names = nil
+}

--- a/internal/plugin/registry_test.go
+++ b/internal/plugin/registry_test.go
@@ -1,0 +1,92 @@
+package plugin
+
+import (
+	"context"
+	"testing"
+)
+
+// fakePlugin is a minimal Plugin used by registry/bootstrap tests.
+type fakePlugin struct {
+	name      string
+	initCalls int
+	initErr   error
+	cli       []CLICommand
+	mcp       []MCPTool
+	http      []HTTPHandler
+	ui        []UIComponent
+	host      Host
+}
+
+func (p *fakePlugin) Manifest() Manifest {
+	return Manifest{Name: p.name, Version: "0.0.1", Description: "fake"}
+}
+func (p *fakePlugin) Init(_ context.Context, h Host, _ string) error {
+	p.host = h
+	p.initCalls++
+	return p.initErr
+}
+func (p *fakePlugin) CLICommands() []CLICommand   { return p.cli }
+func (p *fakePlugin) MCPTools() []MCPTool         { return p.mcp }
+func (p *fakePlugin) HTTPHandlers() []HTTPHandler { return p.http }
+func (p *fakePlugin) UIComponents() []UIComponent { return p.ui }
+
+func TestRegisterPlugin_AddsToRegistry(t *testing.T) {
+	resetRegistryForTest()
+	t.Cleanup(resetRegistryForTest)
+
+	p := &fakePlugin{name: "alpha"}
+	RegisterPlugin(p)
+
+	got := Registered()
+	if len(got) != 1 {
+		t.Fatalf("Registered() len = %d, want 1", len(got))
+	}
+	if got[0].Manifest().Name != "alpha" {
+		t.Errorf("Registered()[0].Name = %q, want %q", got[0].Manifest().Name, "alpha")
+	}
+}
+
+func TestRegisterPlugin_NilPanics(t *testing.T) {
+	resetRegistryForTest()
+	t.Cleanup(resetRegistryForTest)
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("RegisterPlugin(nil) did not panic")
+		}
+	}()
+	RegisterPlugin(nil)
+}
+
+func TestRegisterPlugin_DuplicateNamePanics(t *testing.T) {
+	resetRegistryForTest()
+	t.Cleanup(resetRegistryForTest)
+
+	RegisterPlugin(&fakePlugin{name: "dup"})
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("RegisterPlugin with duplicate name did not panic")
+		}
+	}()
+	RegisterPlugin(&fakePlugin{name: "dup"})
+}
+
+func TestRegistered_SortedByName(t *testing.T) {
+	resetRegistryForTest()
+	t.Cleanup(resetRegistryForTest)
+
+	RegisterPlugin(&fakePlugin{name: "zeta"})
+	RegisterPlugin(&fakePlugin{name: "alpha"})
+	RegisterPlugin(&fakePlugin{name: "mu"})
+
+	got := Registered()
+	if len(got) != 3 {
+		t.Fatalf("len = %d, want 3", len(got))
+	}
+	want := []string{"alpha", "mu", "zeta"}
+	for i, p := range got {
+		if p.Manifest().Name != want[i] {
+			t.Errorf("Registered()[%d].Name = %q, want %q", i, p.Manifest().Name, want[i])
+		}
+	}
+}

--- a/internal/plugin/sort.go
+++ b/internal/plugin/sort.go
@@ -1,0 +1,15 @@
+package plugin
+
+import "sort"
+
+func sortLayers(xs []*Layer) {
+	sort.Slice(xs, func(i, j int) bool { return xs[i].Name < xs[j].Name })
+}
+
+func sortLayerRules(xs []*LayerRule) {
+	sort.Slice(xs, func(i, j int) bool { return xs[i].Layer < xs[j].Layer })
+}
+
+func sortAggregates(xs []*Aggregate) {
+	sort.Slice(xs, func(i, j int) bool { return xs[i].Name < xs[j].Name })
+}

--- a/internal/plugin/types.go
+++ b/internal/plugin/types.go
@@ -1,0 +1,81 @@
+package plugin
+
+import (
+	"time"
+
+	"github.com/kgatilin/archai/internal/diff"
+)
+
+// TargetMeta is the read-only descriptor of a locked target as seen
+// by plugins. It mirrors target.TargetMeta with a leaner shape so
+// future fields (e.g. tags, author) can be added without forcing
+// every plugin to depend on internal/target.
+type TargetMeta struct {
+	ID          string
+	BaseCommit  string
+	CreatedAt   string
+	Description string
+}
+
+// TargetSnapshot is a frozen view of a target: its metadata plus the
+// unified Model that was current when the target was locked.
+type TargetSnapshot struct {
+	Meta  TargetMeta
+	Model *Model
+}
+
+// ModelEvent describes a change to the live Model. Plugins that
+// subscribe receive one of these per fsnotify-driven reload, overlay
+// reload, or target switch. The struct stays intentionally small;
+// future fields can be appended without breaking existing handlers.
+type ModelEvent struct {
+	// Kind identifies what changed. See ModelEventKind* constants.
+	Kind ModelEventKind
+
+	// Paths lists the package paths affected by this event. Empty
+	// for non-package events (overlay reload, target switch).
+	Paths []string
+
+	// Target is the new active target id, set when Kind ==
+	// ModelEventKindTargetSwitch. Empty otherwise.
+	Target string
+
+	// At is the wall-clock timestamp when the event was published.
+	At time.Time
+}
+
+// ModelEventKind enumerates the broadcast event categories.
+type ModelEventKind string
+
+const (
+	// ModelEventKindPackageReload fires when one or more packages
+	// were re-extracted in response to .go file changes.
+	ModelEventKindPackageReload ModelEventKind = "package-reload"
+
+	// ModelEventKindOverlayReload fires when archai.yaml was reloaded.
+	ModelEventKindOverlayReload ModelEventKind = "overlay-reload"
+
+	// ModelEventKindTargetSwitch fires when the CURRENT target id
+	// changed.
+	ModelEventKindTargetSwitch ModelEventKind = "target-switch"
+)
+
+// Diff is the structured patch produced by Host.Diff. We re-export
+// internal/diff.Diff under this package to keep the plugin contract
+// self-contained — plugins don't have to depend on internal/diff.
+type Diff = diff.Diff
+
+// ValidationReport summarizes the result of Host.Validate for a
+// target. Empty Violations means the current code matches the target.
+type ValidationReport struct {
+	// TargetID is the target id that was validated against.
+	TargetID string
+
+	// OK is true when no violations were found.
+	OK bool
+
+	// Violations is the list of structured changes between the
+	// current code model and the target. Re-uses diff.Change so the
+	// representation is identical to `archai validate --format yaml`.
+	Violations []diff.Change
+}

--- a/internal/plugins/complexity/complexity.go
+++ b/internal/plugins/complexity/complexity.go
@@ -1,0 +1,187 @@
+// Package complexity is the built-in demo plugin shipped with archai
+// to prove the M12 plugin contract end-to-end. It computes a tiny
+// per-package complexity score (interfaces + structs + functions +
+// methods) and exposes it through every capability accessor: a CLI
+// command, an MCP tool, an HTTP route, and a UI component descriptor.
+//
+// Heuristic note: this is intentionally a one-screen heuristic, not a
+// real cyclomatic complexity. Future work (a separate plugin or M13
+// follow-up) can swap the scorer without touching the contract.
+package complexity
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+
+	"github.com/spf13/cobra"
+
+	"github.com/kgatilin/archai/internal/domain"
+	"github.com/kgatilin/archai/internal/plugin"
+)
+
+// Plugin is the in-memory state of the complexity plugin. The Host
+// reference captured during Init is used by every capability
+// handler at request time.
+type Plugin struct {
+	host plugin.Host
+}
+
+// Manifest implements plugin.Plugin.
+func (p *Plugin) Manifest() plugin.Manifest {
+	return plugin.Manifest{
+		Name:        "complexity",
+		Version:     "0.1.0",
+		Description: "Per-package complexity heuristic (interfaces + structs + functions + methods).",
+	}
+}
+
+// Init implements plugin.Plugin.
+func (p *Plugin) Init(_ context.Context, host plugin.Host, _ string) error {
+	if host == nil {
+		return fmt.Errorf("complexity: host is nil")
+	}
+	p.host = host
+	return nil
+}
+
+// CLICommands implements plugin.Plugin. The single contributed
+// command prints a sorted complexity table to stdout.
+func (p *Plugin) CLICommands() []plugin.CLICommand {
+	cmd := &cobra.Command{
+		Use:   "complexity",
+		Short: "Show per-package complexity scores",
+		Long: `Print a per-package complexity score for the current model.
+
+The score is a simple heuristic: interfaces + structs + functions +
+methods (sum across all symbols in the package). Useful as a
+proof-of-concept for the plugin contract; not a substitute for real
+cyclomatic complexity tooling.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			scores := p.scores()
+			out := cmd.OutOrStdout()
+			if len(scores) == 0 {
+				fmt.Fprintln(out, "No packages loaded.")
+				return nil
+			}
+			fmt.Fprintf(out, "%-50s  %s\n", "PACKAGE", "SCORE")
+			for _, s := range scores {
+				fmt.Fprintf(out, "%-50s  %d\n", s.Package, s.Score)
+			}
+			return nil
+		},
+	}
+	return []plugin.CLICommand{{Cmd: cmd}}
+}
+
+// MCPTools implements plugin.Plugin. The tool returns the same
+// scores as the CLI command, in JSON-friendly form.
+func (p *Plugin) MCPTools() []plugin.MCPTool {
+	return []plugin.MCPTool{{
+		Name:        "complexity.scores",
+		Description: "Return per-package complexity scores for the current model.",
+		InputSchema: map[string]any{
+			"type":       "object",
+			"properties": map[string]any{},
+		},
+		Handler: func(ctx context.Context, _ map[string]any) (any, error) {
+			return p.scores(), nil
+		},
+	}}
+}
+
+// HTTPHandlers implements plugin.Plugin. The route serves the same
+// scores as JSON. M13 will mount it under /api/plugins/complexity/;
+// for M12 we expose it at the literal /api/complexity/scores so
+// existing dispatch can call it without a prefix.
+func (p *Plugin) HTTPHandlers() []plugin.HTTPHandler {
+	return []plugin.HTTPHandler{{
+		Path:    "/api/complexity/scores",
+		Methods: []string{http.MethodGet},
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(p.scores())
+		}),
+	}}
+}
+
+// UIComponents implements plugin.Plugin. The descriptor advertises a
+// dashboard card; the actual UI bundle is not shipped in M12 (M13
+// wires the asset pipeline). Returning the spec lets the bootstrap
+// exercise that code path.
+func (p *Plugin) UIComponents() []plugin.UIComponent {
+	return []plugin.UIComponent{{
+		Slot:      plugin.EmbedSlotDashboard,
+		Title:     "Complexity",
+		AssetPath: "/api/complexity/ui",
+	}}
+}
+
+// PackageScore is the per-package score returned by the CLI/MCP/HTTP
+// handlers. Exported because the MCP handler returns it directly to
+// the client (encoded as JSON by the MCP transport).
+type PackageScore struct {
+	Package string `json:"package"`
+	Layer   string `json:"layer,omitempty"`
+	Score   int    `json:"score"`
+}
+
+func (p *Plugin) scores() []PackageScore {
+	if p == nil || p.host == nil {
+		return nil
+	}
+	model := p.host.CurrentModel()
+	if model == nil {
+		return nil
+	}
+	out := make([]PackageScore, 0, len(model.Packages))
+	for _, pkg := range model.Packages {
+		if pkg == nil {
+			continue
+		}
+		out = append(out, PackageScore{
+			Package: pkg.Path,
+			Layer:   pkg.Layer,
+			Score:   complexityScore(pkg),
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Score != out[j].Score {
+			return out[i].Score > out[j].Score
+		}
+		return out[i].Package < out[j].Package
+	})
+	return out
+}
+
+// complexityScore returns a tiny per-package heuristic. Sum of:
+//   - interface count
+//   - struct count
+//   - function count
+//   - method count across all structs
+func complexityScore(pkg *domain.PackageModel) int {
+	if pkg == nil {
+		return 0
+	}
+	score := len(pkg.Interfaces) + len(pkg.Structs) + len(pkg.Functions)
+	for _, s := range pkg.Structs {
+		score += len(s.Methods)
+	}
+	for _, i := range pkg.Interfaces {
+		score += len(i.Methods)
+	}
+	return score
+}
+
+// init registers the plugin with the package-global registry. The
+// plugin is then picked up by plugin.Bootstrap during archai
+// startup. To compile the plugin into a binary, import this package
+// for side effects:
+//
+//	import _ "github.com/kgatilin/archai/internal/plugins/complexity"
+func init() {
+	plugin.RegisterPlugin(&Plugin{})
+}

--- a/internal/plugins/complexity/complexity_test.go
+++ b/internal/plugins/complexity/complexity_test.go
@@ -1,0 +1,135 @@
+package complexity
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/kgatilin/archai/internal/domain"
+	"github.com/kgatilin/archai/internal/plugin"
+)
+
+// realHostStub wires a fixed Model into the plugin so tests don't
+// need to load a real project from disk.
+type realHostStub struct{ model *plugin.Model }
+
+func (h *realHostStub) CurrentModel() *plugin.Model                       { return h.model }
+func (h *realHostStub) Targets() []plugin.TargetMeta                      { return nil }
+func (h *realHostStub) Target(string) (*plugin.TargetSnapshot, error)     { return nil, nil }
+func (h *realHostStub) ActiveTarget() *plugin.TargetSnapshot              { return nil }
+func (h *realHostStub) Diff(string, string) (*plugin.Diff, error)         { return nil, nil }
+func (h *realHostStub) Validate(string) (*plugin.ValidationReport, error) { return nil, nil }
+func (h *realHostStub) Subscribe(func(plugin.ModelEvent)) plugin.Unsubscribe {
+	return func() {}
+}
+func (h *realHostStub) Logger() *slog.Logger { return slog.Default() }
+
+func TestComplexity_Manifest(t *testing.T) {
+	p := &Plugin{}
+	mf := p.Manifest()
+	if mf.Name != "complexity" {
+		t.Errorf("Manifest.Name = %q, want %q", mf.Name, "complexity")
+	}
+}
+
+func TestComplexity_Scores(t *testing.T) {
+	model := &plugin.Model{
+		Module: "acme.io/x",
+		Packages: []*domain.PackageModel{
+			{
+				Path:       "internal/heavy",
+				Name:       "heavy",
+				Layer:      "service",
+				Interfaces: []domain.InterfaceDef{{Name: "I1"}, {Name: "I2"}},
+				Structs: []domain.StructDef{
+					{Name: "S1", Methods: []domain.MethodDef{{Name: "M1"}, {Name: "M2"}}},
+				},
+				Functions: []domain.FunctionDef{{Name: "F1"}, {Name: "F2"}, {Name: "F3"}},
+			},
+			{
+				Path:       "internal/light",
+				Name:       "light",
+				Layer:      "domain",
+				Interfaces: []domain.InterfaceDef{{Name: "Tiny"}},
+			},
+		},
+	}
+	host := &realHostStub{model: model}
+	p := &Plugin{}
+	if err := p.Init(context.Background(), host, ""); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	scores := p.scores()
+	if len(scores) != 2 {
+		t.Fatalf("scores len = %d, want 2", len(scores))
+	}
+	// Heavy first (sorted by score desc).
+	if scores[0].Package != "internal/heavy" {
+		t.Errorf("scores[0].Package = %q, want internal/heavy", scores[0].Package)
+	}
+	if scores[0].Score < scores[1].Score {
+		t.Errorf("scores not sorted desc: %v", scores)
+	}
+}
+
+func TestComplexity_HTTPHandler(t *testing.T) {
+	model := &plugin.Model{
+		Packages: []*domain.PackageModel{{Path: "internal/x", Functions: []domain.FunctionDef{{Name: "F"}}}},
+	}
+	p := &Plugin{}
+	if err := p.Init(context.Background(), &realHostStub{model: model}, ""); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	handlers := p.HTTPHandlers()
+	if len(handlers) != 1 {
+		t.Fatalf("HTTPHandlers len = %d, want 1", len(handlers))
+	}
+	srv := httptest.NewServer(handlers[0].Handler)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("http.Get: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+	var got []PackageScore
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got) != 1 || got[0].Package != "internal/x" {
+		t.Errorf("decoded = %+v", got)
+	}
+}
+
+func TestComplexity_MCPTool(t *testing.T) {
+	model := &plugin.Model{
+		Packages: []*domain.PackageModel{{Path: "internal/x", Functions: []domain.FunctionDef{{Name: "F"}}}},
+	}
+	p := &Plugin{}
+	if err := p.Init(context.Background(), &realHostStub{model: model}, ""); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	tools := p.MCPTools()
+	if len(tools) != 1 {
+		t.Fatalf("MCPTools len = %d, want 1", len(tools))
+	}
+	out, err := tools[0].Handler(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("MCP handler: %v", err)
+	}
+	scores, ok := out.([]PackageScore)
+	if !ok {
+		t.Fatalf("MCP handler returned %T, want []PackageScore", out)
+	}
+	if len(scores) != 1 {
+		t.Errorf("scores len = %d, want 1", len(scores))
+	}
+}

--- a/internal/serve/daemon.go
+++ b/internal/serve/daemon.go
@@ -413,21 +413,29 @@ func buildHandler(ctx context.Context, state *State, logOut io.Writer, debug boo
 			}
 		}
 
+		var reloaded []string
 		for pkg := range pkgReloads {
 			if err := state.ReloadPackage(ctx, pkg); err != nil {
 				fmt.Fprintf(logOut, "serve: reload %s: %v\n", pkg, err)
 				continue
 			}
+			reloaded = append(reloaded, pkg)
 			if debug {
 				fmt.Fprintf(logOut, "serve: reloaded package %s\n", pkg)
 			}
+		}
+		if len(reloaded) > 0 {
+			state.PublishPackageReload(reloaded)
 		}
 
 		if overlayDirty {
 			if err := state.ReloadOverlay(ctx); err != nil {
 				fmt.Fprintf(logOut, "serve: reload overlay: %v\n", err)
-			} else if debug {
-				fmt.Fprintln(logOut, "serve: reloaded overlay")
+			} else {
+				state.PublishOverlayReload()
+				if debug {
+					fmt.Fprintln(logOut, "serve: reloaded overlay")
+				}
 			}
 		}
 
@@ -438,8 +446,11 @@ func buildHandler(ctx context.Context, state *State, logOut io.Writer, debug boo
 				fmt.Fprintf(logOut, "serve: read CURRENT: %v\n", err)
 			} else if err := state.SwitchTarget(id); err != nil {
 				fmt.Fprintf(logOut, "serve: switch target: %v\n", err)
-			} else if debug {
-				fmt.Fprintf(logOut, "serve: active target = %q\n", id)
+			} else {
+				state.PublishTargetSwitch(id)
+				if debug {
+					fmt.Fprintf(logOut, "serve: active target = %q\n", id)
+				}
 			}
 		}
 	}

--- a/internal/serve/host.go
+++ b/internal/serve/host.go
@@ -1,0 +1,276 @@
+package serve
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+
+	yamlAdapter "github.com/kgatilin/archai/internal/adapter/yaml"
+	"github.com/kgatilin/archai/internal/diff"
+	"github.com/kgatilin/archai/internal/domain"
+	"github.com/kgatilin/archai/internal/overlay"
+	"github.com/kgatilin/archai/internal/plugin"
+	"github.com/kgatilin/archai/internal/target"
+)
+
+// Host adapts a *State (plus a logger) into the plugin.Host
+// interface. Plugins receive one of these from the daemon's bootstrap;
+// it stays valid for the daemon's lifetime.
+//
+// Design: the adapter is a thin shell over State — almost every
+// method delegates straight through. We keep it as its own type
+// (rather than implementing plugin.Host on State directly) because
+//   - it lets us scope a per-plugin slog.Logger
+//   - it lets us add caching/throttling later without touching State
+//   - State stays free of any plugin-specific concerns at the public
+//     API surface (snap-based reads remain primary).
+type Host struct {
+	state  *State
+	logger *slog.Logger
+}
+
+// NewHost returns a Host backed by state. logger is the slog logger
+// used for Host.Logger(); pass slog.Default() if no scoped logger is
+// available.
+func NewHost(state *State, logger *slog.Logger) *Host {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Host{state: state, logger: logger}
+}
+
+// CurrentModel implements plugin.Host.
+func (h *Host) CurrentModel() *plugin.Model {
+	if h == nil || h.state == nil {
+		return nil
+	}
+	return h.state.CurrentModel()
+}
+
+// Targets implements plugin.Host. It enumerates locked targets under
+// .arch/targets/ and returns a sorted slice. The list is rebuilt on
+// every call (plugins call this rarely; targets are stable on disk).
+func (h *Host) Targets() []plugin.TargetMeta {
+	if h == nil || h.state == nil {
+		return nil
+	}
+	metas, err := target.List(h.state.Root())
+	if err != nil {
+		h.logger.Warn("plugin: list targets", "err", err)
+		return nil
+	}
+	out := make([]plugin.TargetMeta, 0, len(metas))
+	for _, m := range metas {
+		out = append(out, plugin.TargetMeta{
+			ID:          m.ID,
+			BaseCommit:  m.BaseCommit,
+			CreatedAt:   m.CreatedAt,
+			Description: m.Description,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out
+}
+
+// Target implements plugin.Host. It loads the target's frozen model
+// from .arch/targets/<id>/ and pairs it with the lock metadata.
+func (h *Host) Target(id string) (*plugin.TargetSnapshot, error) {
+	if h == nil || h.state == nil {
+		return nil, errors.New("plugin: host has no state")
+	}
+	if id == "" {
+		return nil, errors.New("plugin: target id is empty")
+	}
+	root := h.state.Root()
+
+	meta, _, err := target.Show(root, id)
+	if err != nil {
+		return nil, err
+	}
+
+	pkgs, err := loadTargetSnapshotModel(context.Background(), root, id)
+	if err != nil {
+		return nil, err
+	}
+
+	// Targets carry their own overlay; reuse the active overlay for
+	// layer/aggregate metadata so plugins see a consistent shape.
+	// Future work: load .arch/targets/<id>/overlay.yaml when present
+	// and feed it into BuildModel for full provenance.
+	cfg := h.snapshotOverlay()
+	module := ""
+	if cfg != nil {
+		module = cfg.Module
+	}
+	model := plugin.BuildModel(module, pkgs, cfg)
+
+	return &plugin.TargetSnapshot{
+		Meta: plugin.TargetMeta{
+			ID:          meta.ID,
+			BaseCommit:  meta.BaseCommit,
+			CreatedAt:   meta.CreatedAt,
+			Description: meta.Description,
+		},
+		Model: model,
+	}, nil
+}
+
+// ActiveTarget implements plugin.Host. Returns nil when no target is
+// active; an error fetching the snapshot is logged (and nil returned)
+// since callers can't usefully react to it.
+func (h *Host) ActiveTarget() *plugin.TargetSnapshot {
+	if h == nil || h.state == nil {
+		return nil
+	}
+	id := h.state.CurrentTarget()
+	if id == "" {
+		return nil
+	}
+	snap, err := h.Target(id)
+	if err != nil {
+		h.logger.Warn("plugin: load active target", "id", id, "err", err)
+		return nil
+	}
+	return snap
+}
+
+// Diff implements plugin.Host. fromID/toID may be "" to mean "current
+// code model". The implementation matches `archai diff` semantics:
+// fromID is the "from" side (defaults to current code), toID is the
+// "to" side (defaults to CURRENT target).
+func (h *Host) Diff(fromID, toID string) (*plugin.Diff, error) {
+	if h == nil || h.state == nil {
+		return nil, errors.New("plugin: host has no state")
+	}
+	root := h.state.Root()
+	ctx := context.Background()
+
+	from, err := h.modelByID(ctx, root, fromID)
+	if err != nil {
+		return nil, fmt.Errorf("plugin: load from %q: %w", fromID, err)
+	}
+	to, err := h.modelByID(ctx, root, toID)
+	if err != nil {
+		return nil, fmt.Errorf("plugin: load to %q: %w", toID, err)
+	}
+	d := diff.Compute(from, to)
+	return d, nil
+}
+
+// Validate implements plugin.Host. modelID is the target id to
+// validate against; "" defaults to CURRENT.
+func (h *Host) Validate(modelID string) (*plugin.ValidationReport, error) {
+	if h == nil || h.state == nil {
+		return nil, errors.New("plugin: host has no state")
+	}
+	root := h.state.Root()
+	id := modelID
+	if id == "" {
+		cur, err := target.Current(root)
+		if err != nil {
+			return nil, fmt.Errorf("plugin: read CURRENT: %w", err)
+		}
+		if cur == "" {
+			return nil, errors.New("plugin: no target specified and no CURRENT target")
+		}
+		id = cur
+	}
+
+	d, err := h.Diff("", id)
+	if err != nil {
+		return nil, err
+	}
+	report := &plugin.ValidationReport{
+		TargetID: id,
+		OK:       d.IsEmpty(),
+	}
+	if !report.OK {
+		report.Violations = append(report.Violations, d.Changes...)
+	}
+	return report, nil
+}
+
+// Subscribe implements plugin.Host.
+func (h *Host) Subscribe(handler func(plugin.ModelEvent)) plugin.Unsubscribe {
+	if h == nil || h.state == nil {
+		return func() {}
+	}
+	return h.state.Bus().Subscribe(handler)
+}
+
+// Logger implements plugin.Host.
+func (h *Host) Logger() *slog.Logger {
+	if h == nil {
+		return slog.Default()
+	}
+	return h.logger
+}
+
+// snapshotOverlay returns a copy of the active overlay config.
+func (h *Host) snapshotOverlay() *overlay.Config {
+	snap := h.state.Snapshot()
+	return snap.Overlay
+}
+
+// modelByID resolves a Diff side: "" means current code, "<id>" means
+// the named target.
+func (h *Host) modelByID(ctx context.Context, root, id string) ([]domain.PackageModel, error) {
+	if id == "" {
+		// Use State's live packages as the "current" view so plugins
+		// see exactly what fsnotify-driven extraction last produced.
+		snap := h.state.Snapshot()
+		return snap.Packages, nil
+	}
+	return loadTargetSnapshotModel(ctx, root, id)
+}
+
+// loadTargetSnapshotModel mirrors cmd/archai's loadTargetModel: it
+// reads .arch/targets/<id>/model/**/*.yaml via the YAML adapter.
+// Lives in serve so plugins don't have to reimplement target loading.
+func loadTargetSnapshotModel(ctx context.Context, root, id string) ([]domain.PackageModel, error) {
+	targetDir := filepath.Join(root, ".arch", "targets", id)
+	if _, err := os.Stat(targetDir); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, fmt.Errorf("target %q not found", id)
+		}
+		return nil, err
+	}
+	modelDir := filepath.Join(targetDir, "model")
+	files, err := collectYAMLFilesUnder(modelDir)
+	if err != nil {
+		return nil, err
+	}
+	if len(files) == 0 {
+		return nil, fmt.Errorf("target %q has no model files under %s", id, modelDir)
+	}
+	return yamlAdapter.NewReader().Read(ctx, files)
+}
+
+func collectYAMLFilesUnder(root string) ([]string, error) {
+	var out []string
+	if _, err := os.Stat(root); errors.Is(err, fs.ErrNotExist) {
+		return nil, nil
+	}
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if filepath.Ext(path) == ".yaml" || filepath.Ext(path) == ".yml" {
+			out = append(out, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(out)
+	return out, nil
+}

--- a/internal/serve/host_test.go
+++ b/internal/serve/host_test.go
@@ -1,0 +1,159 @@
+package serve
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/kgatilin/archai/internal/plugin"
+)
+
+// TestHost_CurrentModelExposesPackages confirms the serve-backed Host
+// returns a unified Model with packages populated after Load().
+func TestHost_CurrentModelExposesPackages(t *testing.T) {
+	root := t.TempDir()
+	writeGoModule(t, root, "example.com/x")
+	writeGoFile(t, filepath.Join(root, "internal", "thing", "thing.go"), `package thing
+
+type Widget struct{ Name string }
+
+func New() *Widget { return &Widget{} }
+`)
+
+	state := NewState(root)
+	if err := state.Load(context.Background()); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	host := NewHost(state, slog.Default())
+
+	model := host.CurrentModel()
+	if model == nil {
+		t.Fatalf("CurrentModel returned nil")
+	}
+	found := false
+	for _, p := range model.Packages {
+		if p != nil && p.Path == "internal/thing" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("internal/thing missing from model: paths = %s", modelPackagePaths(model))
+	}
+}
+
+// TestHost_SubscribeReceivesEvents confirms that publishing a
+// ModelEvent on the State's bus delivers to a subscriber set up
+// through Host.Subscribe.
+func TestHost_SubscribeReceivesEvents(t *testing.T) {
+	root := t.TempDir()
+	writeGoModule(t, root, "example.com/x")
+
+	state := NewState(root)
+	if err := state.Load(context.Background()); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	host := NewHost(state, slog.Default())
+
+	var (
+		mu     sync.Mutex
+		events []plugin.ModelEvent
+	)
+	cancel := host.Subscribe(func(ev plugin.ModelEvent) {
+		mu.Lock()
+		defer mu.Unlock()
+		events = append(events, ev)
+	})
+	defer cancel()
+
+	state.PublishOverlayReload()
+	state.PublishPackageReload([]string{"internal/foo"})
+	state.PublishTargetSwitch("v2")
+
+	mu.Lock()
+	got := append([]plugin.ModelEvent(nil), events...)
+	mu.Unlock()
+
+	if len(got) != 3 {
+		t.Fatalf("events len = %d, want 3", len(got))
+	}
+	if got[0].Kind != plugin.ModelEventKindOverlayReload {
+		t.Errorf("got[0].Kind = %q", got[0].Kind)
+	}
+	if got[1].Kind != plugin.ModelEventKindPackageReload || len(got[1].Paths) != 1 || got[1].Paths[0] != "internal/foo" {
+		t.Errorf("got[1] = %+v", got[1])
+	}
+	if got[2].Kind != plugin.ModelEventKindTargetSwitch || got[2].Target != "v2" {
+		t.Errorf("got[2] = %+v", got[2])
+	}
+
+	// Ensure At is populated.
+	if got[0].At.IsZero() {
+		t.Errorf("event At not populated")
+	}
+	// Sanity: At is recent.
+	if time.Since(got[0].At) > 5*time.Second {
+		t.Errorf("event At too far in past: %v", got[0].At)
+	}
+}
+
+// TestHost_UnsubscribeStopsDelivery confirms the Unsubscribe closure
+// returned by Host.Subscribe detaches the handler.
+func TestHost_UnsubscribeStopsDelivery(t *testing.T) {
+	root := t.TempDir()
+	writeGoModule(t, root, "example.com/x")
+
+	state := NewState(root)
+	if err := state.Load(context.Background()); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	host := NewHost(state, slog.Default())
+
+	var calls int
+	cancel := host.Subscribe(func(_ plugin.ModelEvent) { calls++ })
+	state.PublishOverlayReload()
+	if calls != 1 {
+		t.Fatalf("after first publish: calls = %d, want 1", calls)
+	}
+	cancel()
+	state.PublishOverlayReload()
+	if calls != 1 {
+		t.Errorf("after unsubscribe: calls = %d, want 1", calls)
+	}
+}
+
+// helpers
+
+func writeGoModule(t *testing.T, root, mod string) {
+	t.Helper()
+	p := filepath.Join(root, "go.mod")
+	body := "module " + mod + "\n\ngo 1.22\n"
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+}
+
+func writeGoFile(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func modelPackagePaths(m *plugin.Model) []string {
+	out := make([]string, 0, len(m.Packages))
+	for _, p := range m.Packages {
+		if p == nil {
+			continue
+		}
+		out = append(out, p.Path)
+	}
+	return out
+}

--- a/internal/serve/state.go
+++ b/internal/serve/state.go
@@ -15,9 +15,12 @@ import (
 	"strings"
 	"sync"
 
+	"time"
+
 	"github.com/kgatilin/archai/internal/adapter/golang"
 	"github.com/kgatilin/archai/internal/domain"
 	"github.com/kgatilin/archai/internal/overlay"
+	"github.com/kgatilin/archai/internal/plugin"
 	"github.com/kgatilin/archai/internal/service"
 	"github.com/kgatilin/archai/internal/target"
 )
@@ -50,6 +53,83 @@ type State struct {
 
 	// currentTarget is the active target id (may be empty).
 	currentTarget string
+
+	// bus broadcasts ModelEvents to plugin subscribers. Lazily
+	// constructed on first access via Bus(); shared by every Host
+	// adapter built from this State.
+	bus *plugin.EventBus
+}
+
+// Bus returns the State's plugin event bus, creating it on first
+// access. Callers (the daemon's reload handler) publish ModelEvents
+// here after each successful state mutation; plugins subscribe via
+// Host.Subscribe.
+func (s *State) Bus() *plugin.EventBus {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.bus == nil {
+		s.bus = plugin.NewEventBus()
+	}
+	return s.bus
+}
+
+// PublishPackageReload broadcasts a ModelEventKindPackageReload event.
+// Called by the watcher's batch handler after a successful package
+// reload. paths are module-relative package paths.
+func (s *State) PublishPackageReload(paths []string) {
+	s.Bus().Publish(plugin.ModelEvent{
+		Kind:  plugin.ModelEventKindPackageReload,
+		Paths: append([]string(nil), paths...),
+		At:    time.Now(),
+	})
+}
+
+// PublishOverlayReload broadcasts a ModelEventKindOverlayReload event.
+func (s *State) PublishOverlayReload() {
+	s.Bus().Publish(plugin.ModelEvent{
+		Kind: plugin.ModelEventKindOverlayReload,
+		At:   time.Now(),
+	})
+}
+
+// PublishTargetSwitch broadcasts a ModelEventKindTargetSwitch event
+// carrying the new active target id.
+func (s *State) PublishTargetSwitch(id string) {
+	s.Bus().Publish(plugin.ModelEvent{
+		Kind:   plugin.ModelEventKindTargetSwitch,
+		Target: id,
+		At:     time.Now(),
+	})
+}
+
+// CurrentModel returns the unified Model assembled from the State's
+// current packages + overlay. Safe for concurrent use; the returned
+// Model is a snapshot detached from State (callers may retain it but
+// should re-call CurrentModel after a ModelEvent).
+func (s *State) CurrentModel() *plugin.Model {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	pkgs := make([]domain.PackageModel, 0, len(s.packages))
+	for _, p := range s.packages {
+		pkgs = append(pkgs, p)
+	}
+
+	var cfgCopy *overlay.Config
+	module := ""
+	if s.overlayCfg != nil {
+		cp := *s.overlayCfg
+		cfgCopy = &cp
+		module = cp.Module
+	}
+	return plugin.BuildModel(module, pkgs, cfgCopy)
+}
+
+// CurrentTarget returns the active target id (may be empty).
+func (s *State) CurrentTarget() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.currentTarget
 }
 
 // NewState returns an empty State rooted at root. Callers must invoke


### PR DESCRIPTION
Closes part of #65 (M12: Plugin contract + unified Model, in-process Go).

## What

Adds the in-process Go plugin system described in #65:

- **`internal/plugin/`** — public contract:
  - `Plugin` / `Host` / `Manifest` interfaces.
  - Capability descriptors: `CLICommand`, `MCPTool`, `HTTPHandler`, `UIComponent`, `EmbedSlot`.
  - Unified `*Model` (Module + Packages + Layers + LayerRules + BCs + Aggregates + Configs). `BuildModel` composes the Go-extracted `domain.PackageModel` slice with `overlay.Config`. Provenance is encoded on existing fields (`PackageModel.Layer`, `PackageModel.Aggregate` populated by `overlay.Merge`); a future `Source` field can be added without changing the struct shape.
  - `RegisterPlugin` / `Registered` package-level registry (init()-style, mirrors `database/sql` drivers).
  - `EventBus` for `Host.Subscribe` broadcast — synchronous, deterministic delivery order, safe under concurrent Subscribe / Publish / Unsubscribe.
  - `Bootstrap(ctx, host, configPath)` runs every registered plugin's `Init` and aggregates errors instead of failing fast, returning a `BootstrapResult` with named CLI / MCP / HTTP / UI specs.
- **`internal/serve/`** — host adapter:
  - `serve.Host` implements `plugin.Host` on top of the live daemon `State`.
  - `State.Bus()` lazy-creates the per-State `EventBus`; `PublishPackageReload` / `PublishOverlayReload` / `PublishTargetSwitch` are wired from the fsnotify dispatch handler so plugins see ModelEvents in real time.
  - `State.CurrentModel()` returns a snapshotted `*plugin.Model` (safe for plugins to retain across reloads).
- **`internal/plugins/complexity/`** — built-in demo plugin:
  - Per-package score = interfaces + structs + functions + methods.
  - Exposed through every capability accessor (CLI, MCP `complexity.scores`, HTTP `GET /api/complexity/scores`, UI dashboard descriptor) so the bootstrap exercises every code path.
- **`cmd/archai/main.go`** — bootstrap wiring:
  - Imports the complexity plugin for side effects.
  - `wirePlugins` builds a lazy-loading `cliHost`, runs `plugin.Bootstrap`, and mounts plugin-contributed CLI commands at the cobra root (M13 will move them under a `plugins` subgroup).

## Why these design choices

- **Model lives in `internal/plugin`** (not `internal/domain`). Putting it in domain would force domain to import overlay, breaking the existing rule that domain has no dependencies. Plugin already needs both — natural home.
- **Process-global registry** (vs. an injected one). Matches stdlib idioms (`database/sql.Register`, `image.RegisterFormat`) and lets plugin source files self-register via `init()`. Tests use a package-private `resetRegistryForTest` for isolation.
- **EventBus.Publish is synchronous** in the publisher's goroutine. Per the ticket: \"handler called sync from a dispatch goroutine; plugin must not block.\" Snapshotting subscribers under RLock lets handlers self-unsubscribe without deadlocking.
- **CLI commands are mounted at cobra root in M12.** A `plugins` subgroup is M13's job and would otherwise prematurely lock in the dispatch story.

## Out of scope (left to M13 / #66)

- Plugin namespacing for HTTP routes (`/api/plugins/<plugin-name>/...`).
- MCP tool prefixing.
- UI mount-point dispatch (the host shell that consumes `EmbedSlot*`).
- `archai plugins list` / `archai plugins <name> ...` subcommand.

The bootstrap collects every spec the plugin returns, so M13 can wire dispatch on top of the existing `BootstrapResult` without a contract change.

## Tests

- `internal/plugin`: registry add / nil panic / duplicate panic / sorted output, EventBus publish + unsubscribe + concurrent storm + nil-handler safety, Bootstrap lifecycle (Init + capability collection), Bootstrap error aggregation, Bootstrap configPath plumbing, Model unification from overlay (layers / rules / aggregates / configs sorted), `Model.FindPackage` + `Model.PackagesInLayer`, `AddCLICommandsToRoot` mount + skip-nil, `MountHTTPHandlers` method-check.
- `internal/plugins/complexity`: manifest, score sort order, HTTP handler smoke (httptest), MCP handler smoke.
- `internal/serve`: `Host.CurrentModel` round-trips a real Go module's packages, `Host.Subscribe` receives Overlay/Package/Target events with the right kind/paths/target, `Unsubscribe` actually detaches.

Verified locally:

```
$ go build ./...
$ go vet ./...
$ go test ./...
ok  	github.com/kgatilin/archai/cmd/archai	39.885s
ok  	github.com/kgatilin/archai/internal/plugin	0.011s
ok  	github.com/kgatilin/archai/internal/plugins/complexity	0.011s
ok  	github.com/kgatilin/archai/internal/serve	3.113s
... (all green)

$ ./bin/archai complexity | head
PACKAGE                                             SCORE
internal/adapter/http                               208
internal/adapter/d2                                 101
...
```

## Follow-ups

- #66 (M13): plugin dispatch conventions — prefixing, mounting, UI registry.
- #48 (docs): \"Writing a plugin\" section to be added when docs land.

I don't have merge rights on this repo — please review and merge when happy.