### PR TITLE
feat(overview): default to public API diagram with full-mode toggle (#61)

### DIFF
--- a/cmd/archai/main.go
+++ b/cmd/archai/main.go
@@ -88,6 +88,7 @@ Examples:
 	generateCmd.Flags().StringP("format", "f", "d2", "Output format: d2 or yaml")
 	generateCmd.Flags().Bool("debug", false, "Print debug information about packages and dependencies")
 	generateCmd.Flags().String("overlay", "", "Path to archai.yaml overlay (default: auto-detect in current directory)")
+	generateCmd.Flags().String("mode", "public", "Combined-mode overview detail: 'public' (default) or 'full'")
 
 	diagramCmd.AddCommand(generateCmd)
 
@@ -730,6 +731,7 @@ func runGenerate(cmd *cobra.Command, args []string) error {
 	format, _ := cmd.Flags().GetString("format")
 	debug, _ := cmd.Flags().GetBool("debug")
 	overlayFlag, _ := cmd.Flags().GetString("overlay")
+	modeFlag, _ := cmd.Flags().GetString("mode")
 
 	// Resolve overlay path: explicit flag wins; otherwise auto-detect
 	// archai.yaml in the current working directory.
@@ -769,9 +771,52 @@ func runGenerate(cmd *cobra.Command, args []string) error {
 
 	// Combined mode: --output flag present
 	if output != "" {
-		// --pub and --internal don't apply to combined mode
+		// --pub and --internal don't apply to combined mode (the mode
+		// selector for combined output is --mode, not these flags).
 		if pubOnly || internalOnly {
-			fmt.Fprintln(os.Stderr, "Note: --pub and --internal flags are ignored in combined mode (always public)")
+			fmt.Fprintln(os.Stderr, "Note: --pub and --internal flags are ignored in combined mode (use --mode=full to include internal detail)")
+		}
+
+		// #61: combined output supports a Public (default) and Full
+		// overview mode. For Full we bypass the service writer and
+		// call the D2 adapter's WriteCombinedWithMode directly so we
+		// don't have to widen the service.ModelWriter interface for
+		// a single optional capability.
+		overviewMode := d2.ParseOverviewMode(modeFlag)
+		if overviewMode == d2.OverviewModeFull && format == "d2" {
+			// Use the WriteCombinedWithMode capability on the D2
+			// writer via interface assertion (the concrete type is
+			// unexported).
+			type combinedWithMode interface {
+				WriteCombinedWithMode(ctx context.Context, models []domain.PackageModel, outputPath string, mode d2.OverviewMode) error
+			}
+			cwm, ok := writer.(combinedWithMode)
+			if !ok {
+				return fmt.Errorf("writer does not support full-mode combined output (use --format=d2)")
+			}
+			packages, err := goReader.Read(ctx, args)
+			if err != nil {
+				return fmt.Errorf("generation failed: reading packages: %w", err)
+			}
+			// Full mode includes internal symbols too, so don't filter
+			// on HasExportedSymbols; include any package that has at
+			// least one symbol of any kind.
+			var filtered []domain.PackageModel
+			for _, pkg := range packages {
+				if len(pkg.Interfaces)+len(pkg.Structs)+len(pkg.Functions)+len(pkg.TypeDefs) > 0 {
+					filtered = append(filtered, pkg)
+				}
+			}
+			if len(filtered) == 0 {
+				fmt.Println("No packages with symbols found")
+				return nil
+			}
+			if err := cwm.WriteCombinedWithMode(ctx, filtered, output, d2.OverviewModeFull); err != nil {
+				return fmt.Errorf("generation failed: %w", err)
+			}
+			fmt.Printf("Combined diagram generated: %s (mode: full)\n", output)
+			fmt.Printf("Packages included: %d\n", len(filtered))
+			return nil
 		}
 
 		opts := service.GenerateCombinedOptions{
@@ -790,7 +835,7 @@ func runGenerate(cmd *cobra.Command, args []string) error {
 			return nil
 		}
 
-		fmt.Printf("Combined diagram generated: %s\n", result.OutputPath)
+		fmt.Printf("Combined diagram generated: %s (mode: public)\n", result.OutputPath)
 		fmt.Printf("Packages included: %d\n", result.PackageCount)
 		return nil
 	}

--- a/internal/adapter/d2/combined_builder.go
+++ b/internal/adapter/d2/combined_builder.go
@@ -8,28 +8,82 @@ import (
 	"github.com/kgatilin/archai/internal/domain"
 )
 
+// OverviewMode controls how much detail an overview diagram includes.
+//
+//   - OverviewModePublic: only exported types, functions and methods are
+//     rendered. This is the default and produces the "public API surface"
+//     view of the codebase.
+//   - OverviewModeFull: every symbol (including unexported) is rendered.
+//     Useful for debugging the model or auditing internal coupling.
+//
+// New consumers should always default to OverviewModePublic; OverviewModeFull
+// is only exposed behind explicit user toggles (CLI flag, ?mode=full query).
+type OverviewMode string
+
+const (
+	OverviewModePublic OverviewMode = "public"
+	OverviewModeFull   OverviewMode = "full"
+)
+
+// Normalize coerces an unknown / empty mode value to OverviewModePublic.
+func (m OverviewMode) Normalize() OverviewMode {
+	switch m {
+	case OverviewModeFull:
+		return OverviewModeFull
+	default:
+		return OverviewModePublic
+	}
+}
+
+// includesUnexported reports whether the mode wants unexported symbols
+// rendered in the diagram.
+func (m OverviewMode) includesUnexported() bool {
+	return m.Normalize() == OverviewModeFull
+}
+
+// ParseOverviewMode parses an HTTP / CLI mode value. Empty or unknown
+// inputs return OverviewModePublic so callers always default to the
+// public surface.
+func ParseOverviewMode(s string) OverviewMode {
+	return OverviewMode(strings.ToLower(strings.TrimSpace(s))).Normalize()
+}
+
+// EntryPointStereotype is the stereotype label assigned to exported
+// constructor-style functions (`New<Type>` factories) when an overview
+// is being rendered. It is *visual* metadata — the underlying domain
+// stereotype is not mutated.
+const EntryPointStereotype = "<<entry-point>>"
+
 // combinedBuilder builds D2 diagram content from multiple packages.
 // Unlike d2TextBuilder (which groups by file within a single package),
 // combinedBuilder creates package-level containers and shows cross-package dependencies.
 type combinedBuilder struct {
 	buf    strings.Builder
 	indent int
+	mode   OverviewMode
 }
 
-// newCombinedBuilder creates a new combined builder.
+// newCombinedBuilder creates a new combined builder defaulted to public-only mode.
 func newCombinedBuilder() *combinedBuilder {
-	return &combinedBuilder{}
+	return &combinedBuilder{mode: OverviewModePublic}
 }
 
-// Build generates D2 diagram content from multiple packages.
-// It creates package-level containers with exported symbols only,
-// and renders both intra-package and cross-package dependencies.
+// newCombinedBuilderWithMode returns a builder configured for the given
+// mode. Empty/unknown modes fall back to OverviewModePublic.
+func newCombinedBuilderWithMode(mode OverviewMode) *combinedBuilder {
+	return &combinedBuilder{mode: mode.Normalize()}
+}
+
+// Build generates D2 diagram content from multiple packages using the
+// builder's configured mode (defaults to public-only).
 func (b *combinedBuilder) Build(packages []domain.PackageModel) string {
 	b.buf.Reset()
 	b.indent = 0
 
-	// 1. Write header comment
+	// 1. Write header comment. The mode marker keeps two diagrams from
+	// the same model trivially distinguishable in diffs and golden tests.
 	b.writeComment("Combined Architecture Diagram")
+	b.writeComment(fmt.Sprintf("mode: %s", b.mode.Normalize()))
 	b.writeLine("")
 
 	// 2. Write reusable style classes
@@ -72,7 +126,8 @@ func (b *combinedBuilder) Build(packages []domain.PackageModel) string {
 	return b.buf.String()
 }
 
-// writePackageContainer writes a D2 container for a package with all its exported symbols.
+// writePackageContainer writes a D2 container for a package using the builder's mode.
+// Public mode includes only exported symbols; full mode includes everything.
 func (b *combinedBuilder) writePackageContainer(pkg domain.PackageModel, symbolIndex map[string]map[string]bool) {
 	pkgID := sanitizePackageID(pkg.Path)
 
@@ -92,41 +147,34 @@ func (b *combinedBuilder) writePackageContainer(pkg domain.PackageModel, symbolI
 	b.writeLine(fmt.Sprintf(`class: %s`, class))
 	b.writeLine("")
 
-	// Write exported interfaces
-	for _, iface := range pkg.ExportedInterfaces() {
+	// Pick visible symbols based on mode.
+	for _, iface := range b.visibleInterfaces(pkg) {
 		b.writeInterface(iface)
 		b.writeLine("")
 	}
-
-	// Write exported structs
-	for _, s := range pkg.ExportedStructs() {
+	for _, s := range b.visibleStructs(pkg) {
 		b.writeStruct(s)
 		b.writeLine("")
 	}
-
-	// Write exported functions
-	for _, fn := range pkg.ExportedFunctions() {
+	for _, fn := range b.visibleFunctions(pkg) {
 		b.writeFunction(fn)
 		b.writeLine("")
 	}
-
-	// Write exported type definitions
-	for _, td := range pkg.ExportedTypeDefs() {
+	for _, td := range b.visibleTypeDefs(pkg) {
 		b.writeTypeDef(td)
 		b.writeLine("")
 	}
 
-	// Write exported constants, variables, and errors blocks
-	if exportedConsts := pkg.ExportedConstants(); len(exportedConsts) > 0 {
-		b.writeConstantsBlock(exportedConsts)
+	if consts := b.visibleConstants(pkg); len(consts) > 0 {
+		b.writeConstantsBlock(consts)
 		b.writeLine("")
 	}
-	if exportedVars := pkg.ExportedVariables(); len(exportedVars) > 0 {
-		b.writeVariablesBlock(exportedVars)
+	if vars := b.visibleVariables(pkg); len(vars) > 0 {
+		b.writeVariablesBlock(vars)
 		b.writeLine("")
 	}
-	if exportedErrs := pkg.ExportedErrors(); len(exportedErrs) > 0 {
-		b.writeErrorsBlock(exportedErrs)
+	if errs := b.visibleErrors(pkg); len(errs) > 0 {
+		b.writeErrorsBlock(errs)
 		b.writeLine("")
 	}
 
@@ -144,27 +192,130 @@ func (b *combinedBuilder) writePackageContainer(pkg domain.PackageModel, symbolI
 	b.writeLine("}")
 }
 
-// collectSymbolInfo collects stereotype information from all exported symbols in a package.
+// collectSymbolInfo collects stereotype information from visible symbols
+// in a package. Visibility is mode-aware (public vs full).
 func (b *combinedBuilder) collectSymbolInfo(pkg domain.PackageModel) []symbolInfo {
 	var symbols []symbolInfo
 
-	for _, iface := range pkg.ExportedInterfaces() {
+	for _, iface := range b.visibleInterfaces(pkg) {
 		symbols = append(symbols, symbolInfo{stereotype: iface.Stereotype})
 	}
-	for _, s := range pkg.ExportedStructs() {
+	for _, s := range b.visibleStructs(pkg) {
 		symbols = append(symbols, symbolInfo{stereotype: s.Stereotype})
 	}
-	for _, fn := range pkg.ExportedFunctions() {
+	for _, fn := range b.visibleFunctions(pkg) {
 		symbols = append(symbols, symbolInfo{stereotype: fn.Stereotype})
 	}
-	for _, td := range pkg.ExportedTypeDefs() {
+	for _, td := range b.visibleTypeDefs(pkg) {
 		symbols = append(symbols, symbolInfo{stereotype: td.Stereotype})
 	}
 
 	return symbols
 }
 
-// writeInterface writes a D2 class shape for an exported interface.
+// --- visibility-aware selectors -------------------------------------
+
+// visibleInterfaces returns interfaces matching the configured mode.
+// Public mode: only exported. Full mode: every interface.
+func (b *combinedBuilder) visibleInterfaces(pkg domain.PackageModel) []domain.InterfaceDef {
+	if b.mode.includesUnexported() {
+		out := make([]domain.InterfaceDef, len(pkg.Interfaces))
+		copy(out, pkg.Interfaces)
+		return out
+	}
+	return pkg.ExportedInterfaces()
+}
+
+func (b *combinedBuilder) visibleStructs(pkg domain.PackageModel) []domain.StructDef {
+	if b.mode.includesUnexported() {
+		out := make([]domain.StructDef, len(pkg.Structs))
+		copy(out, pkg.Structs)
+		return out
+	}
+	return pkg.ExportedStructs()
+}
+
+func (b *combinedBuilder) visibleFunctions(pkg domain.PackageModel) []domain.FunctionDef {
+	if b.mode.includesUnexported() {
+		out := make([]domain.FunctionDef, len(pkg.Functions))
+		copy(out, pkg.Functions)
+		return out
+	}
+	return pkg.ExportedFunctions()
+}
+
+func (b *combinedBuilder) visibleTypeDefs(pkg domain.PackageModel) []domain.TypeDef {
+	if b.mode.includesUnexported() {
+		out := make([]domain.TypeDef, len(pkg.TypeDefs))
+		copy(out, pkg.TypeDefs)
+		return out
+	}
+	return pkg.ExportedTypeDefs()
+}
+
+func (b *combinedBuilder) visibleConstants(pkg domain.PackageModel) []domain.ConstDef {
+	if b.mode.includesUnexported() {
+		out := make([]domain.ConstDef, len(pkg.Constants))
+		copy(out, pkg.Constants)
+		return out
+	}
+	return pkg.ExportedConstants()
+}
+
+func (b *combinedBuilder) visibleVariables(pkg domain.PackageModel) []domain.VarDef {
+	if b.mode.includesUnexported() {
+		out := make([]domain.VarDef, len(pkg.Variables))
+		copy(out, pkg.Variables)
+		return out
+	}
+	return pkg.ExportedVariables()
+}
+
+func (b *combinedBuilder) visibleErrors(pkg domain.PackageModel) []domain.ErrorDef {
+	if b.mode.includesUnexported() {
+		out := make([]domain.ErrorDef, len(pkg.Errors))
+		copy(out, pkg.Errors)
+		return out
+	}
+	return pkg.ExportedErrors()
+}
+
+// IsConstructor returns true for exported `New<Type>` factory functions.
+// Used to render entry-point markers / styles in overview diagrams.
+func IsConstructor(fn domain.FunctionDef) bool {
+	if !fn.IsExported {
+		return false
+	}
+	if !strings.HasPrefix(fn.Name, "New") {
+		return false
+	}
+	// "New" alone is allowed (e.g. NewService where the type is implicit
+	// but Stereotype already marked it as factory). Otherwise the next
+	// rune must be uppercase to count as `New<Type>`.
+	if len(fn.Name) == 3 {
+		return true
+	}
+	r := fn.Name[3]
+	return r >= 'A' && r <= 'Z'
+}
+
+// IsEntryPoint reports whether fn should be rendered as a domain-facing
+// entry point in an overview. Currently this is the union of:
+//
+//   - exported factory-stereotyped functions, and
+//   - exported `New<Type>` constructors (regardless of stereotype).
+func IsEntryPoint(fn domain.FunctionDef) bool {
+	if !fn.IsExported {
+		return false
+	}
+	if fn.Stereotype == domain.StereotypeFactory {
+		return true
+	}
+	return IsConstructor(fn)
+}
+
+// writeInterface writes a D2 class shape for an interface, including
+// methods filtered by the current mode.
 func (b *combinedBuilder) writeInterface(iface domain.InterfaceDef) {
 	b.writeLine(fmt.Sprintf("%s: {", iface.Name))
 	b.indent++
@@ -172,11 +323,10 @@ func (b *combinedBuilder) writeInterface(iface domain.InterfaceDef) {
 	b.writeLine("shape: class")
 	b.writeLine(`stereotype: "<<interface>>"`)
 
-	// Write exported methods only
-	exportedMethods := b.filterExportedMethods(iface.Methods)
-	if len(exportedMethods) > 0 {
+	methods := b.visibleMethods(iface.Methods)
+	if len(methods) > 0 {
 		b.writeLine("")
-		for _, m := range exportedMethods {
+		for _, m := range methods {
 			b.writeMethod(m)
 		}
 	}
@@ -185,7 +335,8 @@ func (b *combinedBuilder) writeInterface(iface domain.InterfaceDef) {
 	b.writeLine("}")
 }
 
-// writeStruct writes a D2 class shape for an exported struct.
+// writeStruct writes a D2 class shape for a struct. Field & method
+// visibility honours the builder mode (public-only vs full).
 func (b *combinedBuilder) writeStruct(s domain.StructDef) {
 	b.writeLine(fmt.Sprintf("%s: {", s.Name))
 	b.indent++
@@ -193,20 +344,18 @@ func (b *combinedBuilder) writeStruct(s domain.StructDef) {
 	b.writeLine("shape: class")
 	b.writeLine(`stereotype: "<<struct>>"`)
 
-	// Write exported fields
-	exportedFields := b.filterExportedFields(s.Fields)
-	if len(exportedFields) > 0 {
+	fields := b.visibleFields(s.Fields)
+	if len(fields) > 0 {
 		b.writeLine("")
-		for _, f := range exportedFields {
+		for _, f := range fields {
 			b.writeField(f)
 		}
 	}
 
-	// Write exported methods
-	exportedMethods := b.filterExportedMethods(s.Methods)
-	if len(exportedMethods) > 0 {
+	methods := b.visibleMethods(s.Methods)
+	if len(methods) > 0 {
 		b.writeLine("")
-		for _, m := range exportedMethods {
+		for _, m := range methods {
 			b.writeMethod(m)
 		}
 	}
@@ -215,18 +364,32 @@ func (b *combinedBuilder) writeStruct(s domain.StructDef) {
 	b.writeLine("}")
 }
 
-// writeFunction writes a D2 class shape for an exported function.
+// writeFunction writes a D2 class shape for a function. Exported
+// factories / constructors get the dedicated factory style + an
+// "<<entry-point>>" marker line so they stand out in the overview.
 func (b *combinedBuilder) writeFunction(fn domain.FunctionDef) {
 	b.writeLine(fmt.Sprintf("%s: {", fn.Name))
 	b.indent++
 
 	b.writeLine("shape: class")
 
+	entry := IsEntryPoint(fn)
+
 	// Write stereotype
-	if fn.Stereotype == domain.StereotypeFactory {
+	if fn.Stereotype == domain.StereotypeFactory || IsConstructor(fn) {
 		b.writeLine(`stereotype: "<<factory>>"`)
 	} else {
 		b.writeLine(`stereotype: "<<function>>"`)
+	}
+
+	// Distinct styling for entry points: explicit class assignment plus
+	// a visual marker. The class name resolves to the existing
+	// "factory" colour palette already declared at the top of the file.
+	if entry {
+		b.writeLine(fmt.Sprintf(`class: %s`, ClassFactory))
+		b.writeLine(`style.bold: true`)
+		b.writeLine(`style.stroke-width: 2`)
+		b.writeLine(fmt.Sprintf(`"%s": ""`, EntryPointStereotype))
 	}
 
 	// Write parameters as fields
@@ -384,8 +547,14 @@ func (b *combinedBuilder) formatReturns(returns []domain.TypeRef) string {
 	return "(" + strings.Join(parts, ", ") + ")"
 }
 
-// filterExportedMethods returns only exported methods.
-func (b *combinedBuilder) filterExportedMethods(methods []domain.MethodDef) []domain.MethodDef {
+// visibleMethods returns methods filtered by the current mode (public
+// returns only exported; full returns all).
+func (b *combinedBuilder) visibleMethods(methods []domain.MethodDef) []domain.MethodDef {
+	if b.mode.includesUnexported() {
+		out := make([]domain.MethodDef, len(methods))
+		copy(out, methods)
+		return out
+	}
 	var result []domain.MethodDef
 	for _, m := range methods {
 		if m.IsExported {
@@ -395,8 +564,13 @@ func (b *combinedBuilder) filterExportedMethods(methods []domain.MethodDef) []do
 	return result
 }
 
-// filterExportedFields returns only exported fields.
-func (b *combinedBuilder) filterExportedFields(fields []domain.FieldDef) []domain.FieldDef {
+// visibleFields returns fields filtered by the current mode.
+func (b *combinedBuilder) visibleFields(fields []domain.FieldDef) []domain.FieldDef {
+	if b.mode.includesUnexported() {
+		out := make([]domain.FieldDef, len(fields))
+		copy(out, fields)
+		return out
+	}
 	var result []domain.FieldDef
 	for _, f := range fields {
 		if f.IsExported {
@@ -415,21 +589,23 @@ type depInfo struct {
 	kind       domain.DependencyKind
 }
 
-// buildSymbolIndex builds an index of visible (exported) symbols per package.
+// buildSymbolIndex builds an index of visible symbols per package. The
+// definition of "visible" follows the builder's mode: public renders
+// only exported symbols, full renders every symbol.
 func (b *combinedBuilder) buildSymbolIndex(packages []domain.PackageModel) map[string]map[string]bool {
 	symbolIndex := make(map[string]map[string]bool)
 	for _, pkg := range packages {
 		symbols := make(map[string]bool)
-		for _, iface := range pkg.ExportedInterfaces() {
+		for _, iface := range b.visibleInterfaces(pkg) {
 			symbols[iface.Name] = true
 		}
-		for _, s := range pkg.ExportedStructs() {
+		for _, s := range b.visibleStructs(pkg) {
 			symbols[s.Name] = true
 		}
-		for _, fn := range pkg.ExportedFunctions() {
+		for _, fn := range b.visibleFunctions(pkg) {
 			symbols[fn.Name] = true
 		}
-		for _, td := range pkg.ExportedTypeDefs() {
+		for _, td := range b.visibleTypeDefs(pkg) {
 			symbols[td.Name] = true
 		}
 		symbolIndex[pkg.Path] = symbols
@@ -438,7 +614,9 @@ func (b *combinedBuilder) buildSymbolIndex(packages []domain.PackageModel) map[s
 }
 
 // collectIntraPackageDeps collects dependencies within a single package.
-// Combined mode is always public-only, so only dependencies through exported methods/fields are included.
+// In public mode only "ThroughExported" deps are kept (the public surface
+// is the only thing readers care about); in full mode every dep that
+// connects two visible symbols is included.
 func (b *combinedBuilder) collectIntraPackageDeps(pkg domain.PackageModel, symbolIndex map[string]map[string]bool) []depInfo {
 	var deps []depInfo
 	seen := make(map[string]bool)
@@ -454,8 +632,9 @@ func (b *combinedBuilder) collectIntraPackageDeps(pkg domain.PackageModel, symbo
 			continue
 		}
 
-		// Combined mode: only show dependencies through exported methods/fields
-		if !dep.ThroughExported {
+		// Public mode: only show dependencies through exported methods/fields.
+		// Full mode: keep them all (caller wants the gory detail).
+		if !b.mode.includesUnexported() && !dep.ThroughExported {
 			continue
 		}
 
@@ -501,8 +680,9 @@ func (b *combinedBuilder) collectIntraPackageDeps(pkg domain.PackageModel, symbo
 	return deps
 }
 
-// collectCrossPackageDeps collects dependencies between packages.
-// Combined mode is always public-only, so only dependencies through exported methods/fields are included.
+// collectCrossPackageDeps collects dependencies between packages. The
+// "ThroughExported" gate is only enforced in public mode; full mode
+// includes private wiring too.
 func (b *combinedBuilder) collectCrossPackageDeps(packages []domain.PackageModel, symbolIndex map[string]map[string]bool) []depInfo {
 	var deps []depInfo
 	seen := make(map[string]bool)
@@ -514,8 +694,7 @@ func (b *combinedBuilder) collectCrossPackageDeps(packages []domain.PackageModel
 				continue
 			}
 
-			// Combined mode: only show dependencies through exported methods/fields
-			if !dep.ThroughExported {
+			if !b.mode.includesUnexported() && !dep.ThroughExported {
 				continue
 			}
 

--- a/internal/adapter/d2/combined_builder_test.go
+++ b/internal/adapter/d2/combined_builder_test.go
@@ -499,3 +499,143 @@ func TestCombinedBuilder_DeterministicOutput(t *testing.T) {
 		t.Logf("Output2:\n%s", output2)
 	}
 }
+
+// --- M9 / #61: overview-mode (Public vs Full) tests --------------------
+
+// fixtureMixedPackage returns a single package containing both
+// exported and unexported symbols, plus an exported factory and a
+// regular function. Used by mode/entry-point tests below.
+func fixtureMixedPackage() domain.PackageModel {
+	return domain.PackageModel{
+		Name: "svc",
+		Path: "internal/svc",
+		Interfaces: []domain.InterfaceDef{
+			{Name: "PublicAPI", IsExported: true, SourceFile: "api.go"},
+			{Name: "internalHelper", IsExported: false, SourceFile: "helper.go"},
+		},
+		Structs: []domain.StructDef{
+			{Name: "Service", IsExported: true, SourceFile: "service.go"},
+			{Name: "cache", IsExported: false, SourceFile: "cache.go"},
+		},
+		Functions: []domain.FunctionDef{
+			{Name: "NewService", IsExported: true, SourceFile: "service.go", Stereotype: domain.StereotypeFactory},
+			{Name: "Run", IsExported: true, SourceFile: "service.go"},
+			{Name: "internalCalc", IsExported: false, SourceFile: "service.go"},
+		},
+	}
+}
+
+func TestCombinedBuilder_PublicMode_OmitsUnexported(t *testing.T) {
+	pkg := fixtureMixedPackage()
+	builder := newCombinedBuilderWithMode(OverviewModePublic)
+	out := builder.Build([]domain.PackageModel{pkg})
+
+	mustContain := []string{
+		"# mode: public",
+		"PublicAPI",
+		"Service",
+		"NewService",
+	}
+	for _, want := range mustContain {
+		if !strings.Contains(out, want) {
+			t.Errorf("public mode output missing %q\noutput:\n%s", want, out)
+		}
+	}
+	mustOmit := []string{
+		"internalHelper",
+		"cache",
+		"internalCalc",
+	}
+	for _, banned := range mustOmit {
+		if strings.Contains(out, banned) {
+			t.Errorf("public mode output unexpectedly contains %q\noutput:\n%s", banned, out)
+		}
+	}
+}
+
+func TestCombinedBuilder_FullMode_IncludesUnexported(t *testing.T) {
+	pkg := fixtureMixedPackage()
+	builder := newCombinedBuilderWithMode(OverviewModeFull)
+	out := builder.Build([]domain.PackageModel{pkg})
+
+	mustContain := []string{
+		"# mode: full",
+		"PublicAPI",
+		"internalHelper",
+		"Service",
+		"cache",
+		"NewService",
+		"internalCalc",
+	}
+	for _, want := range mustContain {
+		if !strings.Contains(out, want) {
+			t.Errorf("full mode output missing %q\noutput:\n%s", want, out)
+		}
+	}
+}
+
+func TestCombinedBuilder_EntryPointStyling(t *testing.T) {
+	pkg := fixtureMixedPackage()
+	builder := newCombinedBuilderWithMode(OverviewModePublic)
+	out := builder.Build([]domain.PackageModel{pkg})
+
+	// The factory should be flagged as an entry point.
+	if !strings.Contains(out, EntryPointStereotype) {
+		t.Errorf("expected %q stereotype on factory in public mode\noutput:\n%s",
+			EntryPointStereotype, out)
+	}
+	// And styling: bold border (style.bold true / stroke-width 2).
+	if !strings.Contains(out, "style.bold: true") {
+		t.Errorf("expected bold styling on entry point\noutput:\n%s", out)
+	}
+}
+
+func TestCombinedBuilder_ModeNormalization(t *testing.T) {
+	pkg := fixtureMixedPackage()
+
+	// Empty / unknown / case-variant inputs should all collapse to public.
+	for _, raw := range []string{"", "PUBLIC", "garbage", "  public  "} {
+		builder := newCombinedBuilderWithMode(ParseOverviewMode(raw))
+		out := builder.Build([]domain.PackageModel{pkg})
+		if !strings.Contains(out, "# mode: public") {
+			t.Errorf("ParseOverviewMode(%q) did not normalize to public\noutput:\n%s", raw, out)
+		}
+		if strings.Contains(out, "internalCalc") {
+			t.Errorf("ParseOverviewMode(%q) leaked unexported symbols", raw)
+		}
+	}
+}
+
+func TestCombinedBuilder_DeterministicAcrossModes(t *testing.T) {
+	pkg := fixtureMixedPackage()
+
+	// Both modes must produce byte-identical output across builds.
+	for _, mode := range []OverviewMode{OverviewModePublic, OverviewModeFull} {
+		out1 := newCombinedBuilderWithMode(mode).Build([]domain.PackageModel{pkg})
+		out2 := newCombinedBuilderWithMode(mode).Build([]domain.PackageModel{pkg})
+		if out1 != out2 {
+			t.Errorf("mode %q output is not deterministic", mode)
+		}
+	}
+}
+
+func TestParseOverviewMode(t *testing.T) {
+	tests := []struct {
+		input string
+		want  OverviewMode
+	}{
+		{"", OverviewModePublic},
+		{"public", OverviewModePublic},
+		{"PUBLIC", OverviewModePublic},
+		{" public ", OverviewModePublic},
+		{"full", OverviewModeFull},
+		{"FULL", OverviewModeFull},
+		{"unknown", OverviewModePublic},
+	}
+	for _, tt := range tests {
+		got := ParseOverviewMode(tt.input)
+		if got != tt.want {
+			t.Errorf("ParseOverviewMode(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}

--- a/internal/adapter/d2/writer.go
+++ b/internal/adapter/d2/writer.go
@@ -58,8 +58,15 @@ func (w *writer) Write(ctx context.Context, model domain.PackageModel, opts doma
 }
 
 // WriteCombined generates a single D2 diagram from multiple packages.
-// Combined mode always renders public API only with package-level containers.
+// The default render is the public API surface (OverviewModePublic).
+// Callers that need internal detail should use WriteCombinedWithMode.
 func (w *writer) WriteCombined(ctx context.Context, models []domain.PackageModel, outputPath string) error {
+	return w.WriteCombinedWithMode(ctx, models, outputPath, OverviewModePublic)
+}
+
+// WriteCombinedWithMode is the mode-aware variant of WriteCombined.
+// Empty / unknown modes fall back to OverviewModePublic.
+func (w *writer) WriteCombinedWithMode(ctx context.Context, models []domain.PackageModel, outputPath string, mode OverviewMode) error {
 	// Check context cancellation before starting
 	select {
 	case <-ctx.Done():
@@ -67,8 +74,8 @@ func (w *writer) WriteCombined(ctx context.Context, models []domain.PackageModel
 	default:
 	}
 
-	// Build combined D2 content
-	builder := newCombinedBuilder()
+	// Build combined D2 content using the requested mode.
+	builder := newCombinedBuilderWithMode(mode)
 	content := builder.Build(models)
 
 	// Ensure parent directory exists
@@ -83,4 +90,13 @@ func (w *writer) WriteCombined(ctx context.Context, models []domain.PackageModel
 	}
 
 	return nil
+}
+
+// BuildOverviewSource is the in-memory entry point used by HTTP/CLI
+// callers when they need the D2 source string (rather than a file). It
+// intentionally lives next to the writer so callers don't have to depend
+// on the unexported builder.
+func BuildOverviewSource(models []domain.PackageModel, mode OverviewMode) string {
+	builder := newCombinedBuilderWithMode(mode)
+	return builder.Build(models)
 }

--- a/internal/adapter/http/assets/graph.js
+++ b/internal/adapter/http/assets/graph.js
@@ -179,6 +179,17 @@
                 { selector: 'node[kind = "interface"]', style: { 'background-color': '#0ea5e9' } },
                 { selector: 'node[kind = "struct"]', style: { 'background-color': '#7c3aed' } },
                 { selector: 'node[kind = "function"]', style: { 'background-color': '#0d9488' } },
+                // M9 (#61): exported factories / constructors are the
+                // "entry points" of a package's public surface; render
+                // them with a distinct green fill and a bold dark border
+                // so they stand out from regular functions.
+                { selector: 'node[kind = "entry-point"]', style: {
+                    'background-color': '#16a34a',
+                    'border-color': '#064e3b',
+                    'border-width': 3,
+                    'shape': 'round-rectangle',
+                    'font-weight': 'bold'
+                } },
                 { selector: 'node[kind = "package"]', style: { 'background-color': '#1e293b', 'shape': 'round-rectangle', 'padding': 12, 'background-opacity': 0.4 } },
                 { selector: 'node[kind = "package-in"]', style: { 'background-color': '#475569' } },
                 { selector: 'node[kind = "package-out"]', style: { 'background-color': '#334155' } },
@@ -310,6 +321,24 @@
                                 document.body.appendChild(a);
                                 a.click();
                                 document.body.removeChild(a);
+                            } catch (_err) { /* silent */ }
+                            break;
+                        case 'set-mode':
+                            // M9 (#61): switch overview detail mode
+                            // (public ↔ full). The server renders the
+                            // page differently per ?mode= query, so the
+                            // simplest deterministic path is to update
+                            // the URL and reload. Public is the default
+                            // so dropping the param is fine.
+                            try {
+                                var mode = btn.getAttribute('data-mode') || 'public';
+                                var url = new URL(window.location.href);
+                                if (mode === 'full') {
+                                    url.searchParams.set('mode', 'full');
+                                } else {
+                                    url.searchParams.delete('mode');
+                                }
+                                window.location.assign(url.toString());
                             } catch (_err) { /* silent */ }
                             break;
                     }

--- a/internal/adapter/http/assets/styles.css
+++ b/internal/adapter/http/assets/styles.css
@@ -1006,6 +1006,30 @@ table.config-fields th { color: var(--muted); font-weight: 600; }
     background: var(--border, #334155);
 }
 
+/* M9 (#61): toggle group for Public / Full overview detail. */
+.cy-mode-toggle {
+    display: inline-flex;
+    border-radius: 0.3rem;
+    overflow: hidden;
+    margin-right: 0.4rem;
+}
+
+.cy-mode-toggle .cy-btn-mode {
+    border-radius: 0;
+    border-right-width: 0;
+}
+
+.cy-mode-toggle .cy-btn-mode:last-child {
+    border-right-width: 1px;
+}
+
+.cy-btn-mode.is-active {
+    background: var(--accent, #16a34a);
+    color: #ffffff;
+    border-color: var(--accent, #16a34a);
+    font-weight: 600;
+}
+
 .cy-graph.layer-map,
 .cy-graph.layer-map-mini,
 .cy-graph.package-overview,

--- a/internal/adapter/http/graphs.go
+++ b/internal/adapter/http/graphs.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 
+	d2adapter "github.com/kgatilin/archai/internal/adapter/d2"
 	"github.com/kgatilin/archai/internal/diff"
 	"github.com/kgatilin/archai/internal/domain"
 	"github.com/kgatilin/archai/internal/overlay"
@@ -31,6 +32,9 @@ type graphMeta struct {
 	View   string `json:"view"`
 	Layout string `json:"layout"`
 	Title  string `json:"title,omitempty"`
+	// Mode is set on overview-style payloads ("public" / "full") so the
+	// browser can render the correct toggle state without a round-trip.
+	Mode string `json:"mode,omitempty"`
 }
 
 // graphEndpointDoc describes where graph.js should refresh the data
@@ -147,15 +151,23 @@ func sortedLayerNames(cfg *overlay.Config) []string {
 // --- Package overview -----------------------------------------------
 
 // buildPackageOverviewGraph builds the client-side graph for the
-// Package Overview tab. The subject package sits at the centre with
-// exported types as children; immediate internal dependency targets
+// Package Overview tab. The subject package sits at the centre with its
+// types/functions as children; immediate internal dependency targets
 // (inbound + outbound packages) appear around it.
-func buildPackageOverviewGraph(pkg domain.PackageModel, allPkgs []domain.PackageModel) graphPayload {
+//
+// In OverviewModePublic (the default) only exported symbols are
+// rendered, and entry-point functions (factories / `New<Type>`
+// constructors) are tagged with kind="entry-point" so the browser can
+// style them distinctly. OverviewModeFull additionally renders
+// unexported symbols.
+func buildPackageOverviewGraph(pkg domain.PackageModel, allPkgs []domain.PackageModel, mode d2adapter.OverviewMode) graphPayload {
+	mode = mode.Normalize()
 	out := graphPayload{
 		Meta: graphMeta{
 			View:   "package-overview",
 			Layout: "dagre",
 			Title:  pkg.Path,
+			Mode:   string(mode),
 		},
 	}
 
@@ -167,8 +179,20 @@ func buildPackageOverviewGraph(pkg domain.PackageModel, allPkgs []domain.Package
 		Root:  true,
 	})
 
-	// Exported types as children of the package compound.
-	ifaces := append([]domain.InterfaceDef(nil), pkg.ExportedInterfaces()...)
+	// Decide which symbols to render based on mode.
+	var ifaces []domain.InterfaceDef
+	var structs []domain.StructDef
+	var fns []domain.FunctionDef
+	if mode == d2adapter.OverviewModeFull {
+		ifaces = append([]domain.InterfaceDef(nil), pkg.Interfaces...)
+		structs = append([]domain.StructDef(nil), pkg.Structs...)
+		fns = append([]domain.FunctionDef(nil), pkg.Functions...)
+	} else {
+		ifaces = append([]domain.InterfaceDef(nil), pkg.ExportedInterfaces()...)
+		structs = append([]domain.StructDef(nil), pkg.ExportedStructs()...)
+		fns = append([]domain.FunctionDef(nil), pkg.ExportedFunctions()...)
+	}
+
 	sort.Slice(ifaces, func(i, j int) bool { return ifaces[i].Name < ifaces[j].Name })
 	for _, i := range ifaces {
 		out.Nodes = append(out.Nodes, graphNode{
@@ -178,7 +202,6 @@ func buildPackageOverviewGraph(pkg domain.PackageModel, allPkgs []domain.Package
 			Parent: rootID,
 		})
 	}
-	structs := append([]domain.StructDef(nil), pkg.ExportedStructs()...)
 	sort.Slice(structs, func(i, j int) bool { return structs[i].Name < structs[j].Name })
 	for _, s := range structs {
 		out.Nodes = append(out.Nodes, graphNode{
@@ -188,13 +211,19 @@ func buildPackageOverviewGraph(pkg domain.PackageModel, allPkgs []domain.Package
 			Parent: rootID,
 		})
 	}
-	fns := append([]domain.FunctionDef(nil), pkg.ExportedFunctions()...)
 	sort.Slice(fns, func(i, j int) bool { return fns[i].Name < fns[j].Name })
 	for _, f := range fns {
+		kind := "function"
+		// Entry-point detection: factories + `New<Type>` constructors.
+		// We only mark exported entry points; unexported helpers stay
+		// as plain "function" nodes even in full mode.
+		if d2adapter.IsEntryPoint(f) {
+			kind = "entry-point"
+		}
 		out.Nodes = append(out.Nodes, graphNode{
 			ID:     "fn:" + pkg.Path + "." + f.Name,
 			Label:  f.Name,
-			Kind:   "function",
+			Kind:   kind,
 			Parent: rootID,
 		})
 	}
@@ -417,7 +446,8 @@ func (s *Server) handlePackageGraphJSON(w nethttp.ResponseWriter, r *nethttp.Req
 		nethttp.NotFound(w, r)
 		return
 	}
-	writeJSON(w, buildPackageOverviewGraph(pkg, pkgs))
+	mode := d2adapter.ParseOverviewMode(r.URL.Query().Get("mode"))
+	writeJSON(w, buildPackageOverviewGraph(pkg, pkgs, mode))
 }
 
 // handleDiffGraphJSON serves /api/diff?against=<targetID>&kind=<kind>.
@@ -497,7 +527,8 @@ func (s *Server) handlePackageExport(w nethttp.ResponseWriter, r *nethttp.Reques
 		nethttp.NotFound(w, r)
 		return
 	}
-	src := d2SourceForPackage(pkg)
+	mode := d2adapter.ParseOverviewMode(r.URL.Query().Get("mode"))
+	src := d2SourceForPackage(pkg, mode)
 	name := safeFilename(pkg.Path)
 	if fmtSuffix == "d2" {
 		writeText(w, name+".d2", src)

--- a/internal/adapter/http/graphs_test.go
+++ b/internal/adapter/http/graphs_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	d2adapter "github.com/kgatilin/archai/internal/adapter/d2"
 	"github.com/kgatilin/archai/internal/diff"
 	"github.com/kgatilin/archai/internal/domain"
 	"github.com/kgatilin/archai/internal/target"
@@ -128,7 +129,7 @@ func TestBuildPackageOverviewGraph_IncludesTypesAndInternalDeps(t *testing.T) {
 			{To: domain.SymbolRef{Package: "internal/foo", Symbol: "Hello"}},
 		},
 	}
-	g := buildPackageOverviewGraph(foo, []domain.PackageModel{foo, bar})
+	g := buildPackageOverviewGraph(foo, []domain.PackageModel{foo, bar}, d2adapter.OverviewModePublic)
 	if g.Meta.View != "package-overview" {
 		t.Errorf("view = %q", g.Meta.View)
 	}
@@ -160,6 +161,85 @@ func TestBuildPackageOverviewGraph_IncludesTypesAndInternalDeps(t *testing.T) {
 	if in == 0 {
 		t.Error("missing inbound edge bar -> foo")
 	}
+}
+
+// M9 (#61): Public mode hides unexported symbols, Full mode includes
+// them. Factories tagged with the factory stereotype render as
+// kind=entry-point so the front-end can highlight them.
+func TestBuildPackageOverviewGraph_ModeFiltering(t *testing.T) {
+	foo := domain.PackageModel{
+		Path: "internal/foo",
+		Name: "foo",
+		Interfaces: []domain.InterfaceDef{
+			{Name: "PublicAPI", IsExported: true},
+			{Name: "internalIface", IsExported: false},
+		},
+		Structs: []domain.StructDef{
+			{Name: "Public", IsExported: true},
+			{Name: "private", IsExported: false},
+		},
+		Functions: []domain.FunctionDef{
+			{Name: "NewService", IsExported: true, Stereotype: domain.StereotypeFactory},
+			{Name: "internalFn", IsExported: false},
+		},
+	}
+
+	t.Run("public mode omits unexported", func(t *testing.T) {
+		g := buildPackageOverviewGraph(foo, []domain.PackageModel{foo}, d2adapter.OverviewModePublic)
+		ids := nodeIDs(g)
+		for _, want := range []string{
+			"type:internal/foo.PublicAPI",
+			"type:internal/foo.Public",
+			"fn:internal/foo.NewService",
+		} {
+			if !ids[want] {
+				t.Errorf("missing exported node %q", want)
+			}
+		}
+		for _, banned := range []string{
+			"type:internal/foo.internalIface",
+			"type:internal/foo.private",
+			"fn:internal/foo.internalFn",
+		} {
+			if ids[banned] {
+				t.Errorf("public mode unexpectedly includes %q", banned)
+			}
+		}
+		// Mode must be reflected in meta for client-side reasoning.
+		if g.Meta.Mode != string(d2adapter.OverviewModePublic) {
+			t.Errorf("meta.mode = %q, want %q", g.Meta.Mode, d2adapter.OverviewModePublic)
+		}
+		// Factory function is tagged as an entry point.
+		var found bool
+		for _, n := range g.Nodes {
+			if n.ID == "fn:internal/foo.NewService" && n.Kind == "entry-point" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected NewService to render as kind=entry-point")
+		}
+	})
+
+	t.Run("full mode includes unexported", func(t *testing.T) {
+		g := buildPackageOverviewGraph(foo, []domain.PackageModel{foo}, d2adapter.OverviewModeFull)
+		ids := nodeIDs(g)
+		for _, want := range []string{
+			"type:internal/foo.PublicAPI",
+			"type:internal/foo.internalIface",
+			"type:internal/foo.private",
+			"fn:internal/foo.NewService",
+			"fn:internal/foo.internalFn",
+		} {
+			if !ids[want] {
+				t.Errorf("full mode missing node %q", want)
+			}
+		}
+		if g.Meta.Mode != string(d2adapter.OverviewModeFull) {
+			t.Errorf("meta.mode = %q, want %q", g.Meta.Mode, d2adapter.OverviewModeFull)
+		}
+	})
 }
 
 func TestBuildDiffGraph_ColoursByOp(t *testing.T) {
@@ -551,4 +631,61 @@ func nodeIDs(g graphPayload) map[string]bool {
 		out[n.ID] = true
 	}
 	return out
+}
+
+// M9 (#61): per-package D2 source must respect mode and stay deterministic.
+func TestD2SourceForPackage_ModeAndDeterminism(t *testing.T) {
+	pkg := domain.PackageModel{
+		Path: "internal/svc",
+		Name: "svc",
+		Interfaces: []domain.InterfaceDef{
+			{Name: "Greeter", IsExported: true},
+			{Name: "internalIface", IsExported: false},
+		},
+		Structs: []domain.StructDef{
+			{Name: "Service", IsExported: true},
+			{Name: "cache", IsExported: false},
+		},
+		Functions: []domain.FunctionDef{
+			{Name: "NewService", IsExported: true, Stereotype: domain.StereotypeFactory},
+			{Name: "Run", IsExported: true},
+			{Name: "internalCalc", IsExported: false},
+		},
+	}
+
+	pub := d2SourceForPackage(pkg, d2adapter.OverviewModePublic)
+	full := d2SourceForPackage(pkg, d2adapter.OverviewModeFull)
+
+	// Header reflects mode.
+	if !strings.Contains(pub, "# mode: public") {
+		t.Errorf("public output missing mode header: %s", pub)
+	}
+	if !strings.Contains(full, "# mode: full") {
+		t.Errorf("full output missing mode header: %s", full)
+	}
+
+	// Public hides unexported, full shows them.
+	for _, banned := range []string{"internalIface", "cache", "internalCalc"} {
+		if strings.Contains(pub, banned) {
+			t.Errorf("public mode includes unexported symbol %q", banned)
+		}
+		if !strings.Contains(full, banned) {
+			t.Errorf("full mode missing unexported symbol %q", banned)
+		}
+	}
+
+	// Entry-point stereotype on the factory in public mode.
+	if !strings.Contains(pub, "<<entry-point>>") {
+		t.Errorf("public mode missing entry-point stereotype: %s", pub)
+	}
+
+	// Determinism: identical inputs produce identical output across runs.
+	pub2 := d2SourceForPackage(pkg, d2adapter.OverviewModePublic)
+	if pub != pub2 {
+		t.Error("public-mode d2 output is non-deterministic across calls")
+	}
+	full2 := d2SourceForPackage(pkg, d2adapter.OverviewModeFull)
+	if full != full2 {
+		t.Error("full-mode d2 output is non-deterministic across calls")
+	}
 }

--- a/internal/adapter/http/package_detail_data.go
+++ b/internal/adapter/http/package_detail_data.go
@@ -135,6 +135,11 @@ type packageDetailData struct {
 	SVGError    string
 	Stereotypes []string
 	LayerBadge  string
+	// Mode is the overview-render mode ("public" by default, "full" when
+	// the user toggles internal detail). Used by the Overview tab to
+	// control which graph payload is fetched and which export links are
+	// shown.
+	Mode string
 
 	// Public API / Internal
 	Interfaces []domain.InterfaceDef

--- a/internal/adapter/http/packages_handler.go
+++ b/internal/adapter/http/packages_handler.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 
+	d2adapter "github.com/kgatilin/archai/internal/adapter/d2"
 	"github.com/kgatilin/archai/internal/domain"
 	"github.com/kgatilin/archai/internal/overlay"
 )
@@ -95,6 +96,8 @@ func (s *Server) handlePackageDetail(w nethttp.ResponseWriter, r *nethttp.Reques
 	data := buildPackageDetail(active, pkg, pkgs, snap.Overlay, modulePath)
 	data.pageData = s.basePageData(r, "Package "+pkg.Path, "/packages")
 	data.Partial = isHTMX(r)
+	// Overview render mode (#61): default Public, opt-in Full via ?mode=full.
+	data.Mode = string(d2adapter.ParseOverviewMode(r.URL.Query().Get("mode")).Normalize())
 
 	// M8 (#46): Overview no longer emits server-rendered D2→SVG.
 	// The tab-overview template includes a .cy-graph div that fetches
@@ -184,10 +187,11 @@ func (s *Server) renderPartial(w nethttp.ResponseWriter, tmpl, defineName string
 }
 
 // renderPackageD2 produces the D2 SVG for the package's Overview tab.
-// Public-only content keeps the Overview diagram readable; Internal
-// details live in their own tab.
-func renderPackageD2(ctx context.Context, pkg domain.PackageModel) ([]byte, error) {
-	source := d2SourceForPackage(pkg)
+// Public-only mode keeps the Overview diagram readable; full-mode
+// callers can pass d2adapter.OverviewModeFull to include internal
+// detail.
+func renderPackageD2(ctx context.Context, pkg domain.PackageModel, mode d2adapter.OverviewMode) ([]byte, error) {
+	source := d2SourceForPackage(pkg, mode)
 	if strings.TrimSpace(source) == "" {
 		return nil, fmt.Errorf("render: empty package")
 	}
@@ -195,21 +199,51 @@ func renderPackageD2(ctx context.Context, pkg domain.PackageModel) ([]byte, erro
 }
 
 // d2SourceForPackage renders a minimal, self-contained D2 source for a
-// single package. We use the existing d2 adapter's combined builder
-// with just this package — the existing per-package Build() writes
-// file-grouped containers which are noisy for the Overview tab.
-// Instead we emit a flat list of public symbols with directed edges
-// for inter-package dependencies visible from this package.
-func d2SourceForPackage(pkg domain.PackageModel) string {
-	// Sort symbols deterministically.
-	ifaces := append([]domain.InterfaceDef(nil), pkg.ExportedInterfaces()...)
+// single package overview. The default (OverviewModePublic) emits only
+// exported symbols and tags exported `New<Type>` constructors / factory
+// functions with the "<<entry-point>>" stereotype so they are visually
+// distinct in the rendered SVG. OverviewModeFull additionally renders
+// unexported symbols (constructors / functions / types) for debugging.
+//
+// Output is deterministic — callers can rely on byte-identical results
+// for identical inputs (golden tests, caching, drift detection).
+func d2SourceForPackage(pkg domain.PackageModel, mode d2adapter.OverviewMode) string {
+	mode = mode.Normalize()
+
+	// Decide which symbol slices to render based on mode.
+	var ifaces []domain.InterfaceDef
+	var structs []domain.StructDef
+	var fns []domain.FunctionDef
+	if mode == d2adapter.OverviewModeFull {
+		ifaces = append([]domain.InterfaceDef(nil), pkg.Interfaces...)
+		structs = append([]domain.StructDef(nil), pkg.Structs...)
+		fns = append([]domain.FunctionDef(nil), pkg.Functions...)
+	} else {
+		ifaces = append([]domain.InterfaceDef(nil), pkg.ExportedInterfaces()...)
+		structs = append([]domain.StructDef(nil), pkg.ExportedStructs()...)
+		fns = append([]domain.FunctionDef(nil), pkg.ExportedFunctions()...)
+	}
 	sort.Slice(ifaces, func(i, j int) bool { return ifaces[i].Name < ifaces[j].Name })
-	structs := append([]domain.StructDef(nil), pkg.ExportedStructs()...)
 	sort.Slice(structs, func(i, j int) bool { return structs[i].Name < structs[j].Name })
-	fns := append([]domain.FunctionDef(nil), pkg.ExportedFunctions()...)
 	sort.Slice(fns, func(i, j int) bool { return fns[i].Name < fns[j].Name })
 
+	// Track which symbol IDs we've actually rendered so dependency
+	// edges don't dangle when their endpoints aren't visible in this
+	// mode.
+	visible := make(map[string]struct{}, len(ifaces)+len(structs)+len(fns))
+	for _, iface := range ifaces {
+		visible[iface.Name] = struct{}{}
+	}
+	for _, st := range structs {
+		visible[st.Name] = struct{}{}
+	}
+	for _, fn := range fns {
+		visible[fn.Name] = struct{}{}
+	}
+
 	var sb strings.Builder
+	// Header comments tag the active mode for trivial diffability.
+	fmt.Fprintf(&sb, "# mode: %s\n", mode)
 	// Title as a node header so the diagram is never empty even when
 	// the package has no exported symbols.
 	fmt.Fprintf(&sb, "title: {\n  label: %s\n  near: top-center\n  shape: text\n}\n", quoteD2(pkg.Path))
@@ -222,8 +256,18 @@ func d2SourceForPackage(pkg domain.PackageModel) string {
 			quoteD2(st.Name), st.Name)
 	}
 	for _, fn := range fns {
-		fmt.Fprintf(&sb, "%s: {\n  shape: class\n  label: \"%s\\n<<function>>\"\n}\n",
-			quoteD2(fn.Name), fn.Name)
+		stereo := "<<function>>"
+		if d2adapter.IsEntryPoint(fn) {
+			// Entry-point styling: bold stroke + dedicated stereotype
+			// label. The label itself doubles as the visual marker so
+			// renderers without CSS hooks still differentiate them.
+			stereo = "<<entry-point>>"
+			fmt.Fprintf(&sb, "%s: {\n  shape: class\n  label: \"%s\\n%s\"\n  style.bold: true\n  style.stroke-width: 2\n}\n",
+				quoteD2(fn.Name), fn.Name, stereo)
+			continue
+		}
+		fmt.Fprintf(&sb, "%s: {\n  shape: class\n  label: \"%s\\n%s\"\n}\n",
+			quoteD2(fn.Name), fn.Name, stereo)
 	}
 	// Edges for same-package dependencies to give the diagram some
 	// structure. We don't draw cross-package edges here — they live in
@@ -231,6 +275,14 @@ func d2SourceForPackage(pkg domain.PackageModel) string {
 	seenEdge := make(map[string]struct{})
 	for _, d := range pkg.Dependencies {
 		if d.To.Package != pkg.Path {
+			continue
+		}
+		// Skip edges that point at symbols that aren't rendered in
+		// this mode (avoids D2 referring to undeclared identifiers).
+		if _, ok := visible[d.From.Symbol]; !ok {
+			continue
+		}
+		if _, ok := visible[d.To.Symbol]; !ok {
 			continue
 		}
 		key := d.From.Symbol + "->" + d.To.Symbol

--- a/internal/adapter/http/templates/package_detail.html
+++ b/internal/adapter/http/templates/package_detail.html
@@ -48,18 +48,31 @@
 {{define "tab-overview"}}
 <div class="tab-overview">
     <div class="cy-toolbar" role="toolbar" aria-label="Diagram controls">
+        <div class="cy-mode-toggle" role="group" aria-label="Diagram detail mode">
+            <button type="button" class="cy-btn cy-btn-mode{{if ne .Mode "full"}} is-active{{end}}"
+                    data-cy-action="set-mode" data-mode="public"
+                    aria-pressed="{{if ne .Mode "full"}}true{{else}}false{{end}}">Public API</button>
+            <button type="button" class="cy-btn cy-btn-mode{{if eq .Mode "full"}} is-active{{end}}"
+                    data-cy-action="set-mode" data-mode="full"
+                    aria-pressed="{{if eq .Mode "full"}}true{{else}}false{{end}}">Full detail</button>
+        </div>
+        <span class="cy-toolbar-spacer"></span>
         <button type="button" class="cy-btn" data-cy-action="fit">Fit</button>
         <button type="button" class="cy-btn" data-cy-action="zoom-in" aria-label="Zoom in">+</button>
         <button type="button" class="cy-btn" data-cy-action="zoom-out" aria-label="Zoom out">-</button>
         <span class="cy-toolbar-spacer"></span>
-        <a class="cy-btn" href="/view/packages/{{.Pkg.Path}}/d2" download>Export D2</a>
-        <a class="cy-btn" href="/view/packages/{{.Pkg.Path}}/svg" download>Export SVG</a>
+        <a class="cy-btn cy-export-d2" href="/view/packages/{{.Pkg.Path}}/d2{{if eq .Mode "full"}}?mode=full{{end}}" download>Export D2</a>
+        <a class="cy-btn cy-export-svg" href="/view/packages/{{.Pkg.Path}}/svg{{if eq .Mode "full"}}?mode=full{{end}}" download>Export SVG</a>
         <button type="button" class="cy-btn" data-cy-action="export-png">Export PNG</button>
     </div>
     <div class="cy-graph package-overview"
-         data-api="/api/packages/{{.Pkg.Path}}/graph"
+         data-api="/api/packages/{{.Pkg.Path}}/graph{{if eq .Mode "full"}}?mode=full{{end}}"
+         data-api-base="/api/packages/{{.Pkg.Path}}/graph"
+         data-export-d2-base="/view/packages/{{.Pkg.Path}}/d2"
+         data-export-svg-base="/view/packages/{{.Pkg.Path}}/svg"
          data-view="package-overview"
          data-layout="dagre"
+         data-mode="{{.Mode}}"
          data-height="420"></div>
     <dl class="pkg-meta-list">
         <dt>Path</dt><dd><code>{{.Pkg.Path}}</code></dd>


### PR DESCRIPTION
Closes #61.

## Summary
- Public API is now the default render for both the system overview and per-package overview; full/internal detail is an explicit opt-in via `?mode=full` (HTTP) or `--mode=full` (CLI combined output).
- Exported factories and `New<Type>` constructors render with a distinct `<<entry-point>>` stereotype, bold border, and green fill so domain-facing entry points are immediately visible.
- Output is deterministic — every code path threads through `OverviewMode.Normalize()` and writes a `# mode: <mode>` header so diffs/cache-keys stay stable.

## Decisions

**Entry-point detection.** A function is an entry point if it carries `domain.StereotypeFactory` or is exported and its name matches `New<Type>` / `New`. The same predicate (`d2.IsEntryPoint`) is used by the combined D2 builder, the per-package D2 source builder, and the cytoscape JSON builder — so styling is consistent across surfaces.

**Toggle exposure.**
- Browser: a Public API / Full detail button group in the overview toolbar; clicking either button re-navigates with `?mode=full` or drops the param. The active mode is reflected in `meta.mode` of the graph payload and on the toggle's `aria-pressed`.
- HTTP API: `/api/packages/<path>/graph?mode=full`, `/view/packages/<path>/d2?mode=full`, `/view/packages/<path>/svg?mode=full`. Empty / unknown values normalize to `public`.
- CLI: `archai diagram generate ./internal/... -o arch.d2 --mode=full`. Default remains `public`. The flag is ignored for non-combined / yaml output.
- MCP: served transparently — MCP is a thin client over HTTP since #51, so the existing `?mode=` query param flows through.

**Service interface stability.** `service.ModelWriter` keeps its current `WriteCombined(ctx, models, outputPath)` signature — `WriteCombinedWithMode` is a separate method on the concrete D2 writer. The CLI uses an interface assertion when `--mode=full` is set so the cross-adapter contract isn't widened for one optional capability.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] New unit tests:
  - Combined builder: Public mode omits unexported, Full mode includes them, entry-point stereotype + bold styling, mode normalization, deterministic output across modes, `ParseOverviewMode` table.
  - Package overview graph (HTTP): mode filtering (subtests for public/full), `meta.mode` plumbed, factory tagged as `kind=entry-point`.
  - Per-package D2 source (HTTP): mode header, public/full filtering, `<<entry-point>>` stereotype, byte-identical determinism across calls.

## Visuals
A before/after side-by-side wasn't captured here — Kira can't render the browser overview from the worktree. The toggle UI lives at `/packages/<path>` (overview tab); the graph adapter emits `kind=entry-point` for factories, which graph.js styles with a green fill (`#16a34a`) and 3px dark green border, distinct from the teal regular-function fill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)