### PR TITLE
fix(plugin): make ModelURL configurable; fix complexity widget 404 (#74)

### DIFF
--- a/internal/adapter/http/plugin_routes_test.go
+++ b/internal/adapter/http/plugin_routes_test.go
@@ -123,10 +123,11 @@ func TestServer_PackageDetailRendersPluginTab(t *testing.T) {
 		UIComponents: []plugin.NamedUIComponent{{
 			Plugin: "complexity",
 			Component: plugin.UIComponent{
-				Element: "plugin-complexity-heatmap",
-				Assets:  fstest.MapFS{"heatmap.js": &fstest.MapFile{Data: []byte("// stub")}},
-				Entry:   "heatmap.js",
-				EmbedAt: []plugin.EmbedSlot{{View: plugin.ViewPackageDetail, Slot: plugin.SlotExtraTab, Label: "Complexity"}},
+				Element:  "plugin-complexity-heatmap",
+				Assets:   fstest.MapFS{"heatmap.js": &fstest.MapFile{Data: []byte("// stub")}},
+				Entry:    "heatmap.js",
+				EmbedAt:  []plugin.EmbedSlot{{View: plugin.ViewPackageDetail, Slot: plugin.SlotExtraTab, Label: "Complexity"}},
+				ModelURL: "/api/plugins/complexity/scores",
 			},
 		}},
 	})
@@ -163,7 +164,7 @@ func TestServer_PackageDetailRendersPluginTab(t *testing.T) {
 	html2 := string(body2)
 	for _, want := range []string{
 		"<plugin-complexity-heatmap",
-		`data-model-url="/api/plugins/complexity"`,
+		`data-model-url="/api/plugins/complexity/scores"`,
 		`data-package="internal/foo"`,
 	} {
 		if !strings.Contains(html2, want) {
@@ -189,10 +190,11 @@ func TestServer_DashboardRendersPluginPanel(t *testing.T) {
 		UIComponents: []plugin.NamedUIComponent{{
 			Plugin: "complexity",
 			Component: plugin.UIComponent{
-				Element: "plugin-complexity-heatmap",
-				Assets:  fstest.MapFS{"heatmap.js": &fstest.MapFile{Data: []byte("// stub")}},
-				Entry:   "heatmap.js",
-				EmbedAt: []plugin.EmbedSlot{{View: plugin.ViewDashboard, Slot: plugin.SlotMain, Label: "Complexity"}},
+				Element:  "plugin-complexity-heatmap",
+				Assets:   fstest.MapFS{"heatmap.js": &fstest.MapFile{Data: []byte("// stub")}},
+				Entry:    "heatmap.js",
+				EmbedAt:  []plugin.EmbedSlot{{View: plugin.ViewDashboard, Slot: plugin.SlotMain, Label: "Complexity"}},
+				ModelURL: "/api/plugins/complexity/scores",
 			},
 		}},
 	}
@@ -209,12 +211,82 @@ func TestServer_DashboardRendersPluginPanel(t *testing.T) {
 
 	wants := []string{
 		"<plugin-complexity-heatmap",
-		`data-model-url="/api/plugins/complexity"`,
+		`data-model-url="/api/plugins/complexity/scores"`,
 		`/plugins/complexity/assets/heatmap.js`,
 	}
 	for _, want := range wants {
 		if !strings.Contains(html, want) {
 			t.Errorf("dashboard missing %q\n--- body ---\n%s", want, html)
 		}
+	}
+}
+
+// TestServer_DashboardWidgetModelURLIsRoutable is the regression test for
+// issue #74: when the dashboard widget renders a plugin's custom element,
+// its data-model-url attribute must point at a route that actually
+// returns 200, not 404. The previous default produced /api/plugins/<name>
+// which didn't match a handler mounted at /<sub-path>.
+func TestServer_DashboardWidgetModelURLIsRoutable(t *testing.T) {
+	res := plugin.BootstrapResult{
+		HTTPHandlers: []plugin.NamedHTTPHandler{{
+			Plugin: "complexity",
+			Handler: plugin.HTTPHandler{
+				Path:    "/scores",
+				Methods: []string{nethttp.MethodGet},
+				Handler: nethttp.HandlerFunc(func(w nethttp.ResponseWriter, _ *nethttp.Request) {
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = w.Write([]byte(`{"ok":true}`))
+				}),
+			},
+		}},
+		UIComponents: []plugin.NamedUIComponent{{
+			Plugin: "complexity",
+			Component: plugin.UIComponent{
+				Element:  "plugin-complexity-heatmap",
+				Assets:   fstest.MapFS{"heatmap.js": &fstest.MapFile{Data: []byte("// stub")}},
+				Entry:    "heatmap.js",
+				EmbedAt:  []plugin.EmbedSlot{{View: plugin.ViewDashboard, Slot: plugin.SlotMain, Label: "Complexity"}},
+				ModelURL: "/api/plugins/complexity/scores",
+			},
+		}},
+	}
+	ts := newTestServerWithPlugins(t, res)
+	defer ts.Close()
+
+	resp, err := ts.Client().Get(ts.URL + "/")
+	if err != nil {
+		t.Fatalf("GET /: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	html := string(body)
+
+	// Pull the data-model-url value the browser would use.
+	idx := strings.Index(html, `data-model-url="`)
+	if idx < 0 {
+		t.Fatalf("dashboard missing data-model-url attribute\n%s", html)
+	}
+	rest := html[idx+len(`data-model-url="`):]
+	end := strings.Index(rest, `"`)
+	if end < 0 {
+		t.Fatalf("malformed data-model-url attribute")
+	}
+	modelURL := rest[:end]
+	if modelURL == "" {
+		t.Fatalf("data-model-url is empty")
+	}
+
+	// Hit it. Pre-fix this returned 404.
+	resp2, err := ts.Client().Get(ts.URL + modelURL)
+	if err != nil {
+		t.Fatalf("GET %s: %v", modelURL, err)
+	}
+	defer resp2.Body.Close()
+	if resp2.StatusCode != nethttp.StatusOK {
+		t.Fatalf("GET %s status = %d, want 200 (issue #74 regression)", modelURL, resp2.StatusCode)
+	}
+	got, _ := io.ReadAll(resp2.Body)
+	if len(got) == 0 {
+		t.Errorf("GET %s body is empty", modelURL)
 	}
 }

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -202,6 +202,17 @@ type UIComponent struct {
 	// should be rendered. A single component can appear in multiple
 	// views (e.g. dashboard card + package_detail tab).
 	EmbedAt []EmbedSlot
+
+	// ModelURL is the absolute URL the host page emits as the
+	// data-model-url attribute on this custom element. Set it
+	// explicitly when the plugin's HTTP handler is mounted at a
+	// non-root path (e.g. HTTPHandler.Path = "/scores", so
+	// ModelURL = "/api/plugins/<plugin-name>/scores"), or when the
+	// plugin contributes multiple HTTPHandlers and the component
+	// should target a specific one. Empty falls back to
+	// PluginAPIPrefix + plugin name, which only matches a handler
+	// mounted at Path = "" or "/".
+	ModelURL string
 }
 
 // EmbedSlot identifies one mount point on a host page. View picks the

--- a/internal/plugin/uiregistry.go
+++ b/internal/plugin/uiregistry.go
@@ -38,9 +38,12 @@ type UIRegistryScript struct {
 // BuildUIRegistry builds the registry from the BootstrapResult's
 // UIComponents. EmbedSlot entries with an unknown View or Slot are
 // dropped; the caller can detect this by inspecting Lookup before
-// rendering. ModelURL defaults to /api/plugins/<plugin-name> when the
-// plugin contributes any HTTP handler — host pages may override per
-// component.
+// rendering. ModelURL is taken verbatim from UIComponent.ModelURL when
+// the plugin author set it; otherwise it falls back to
+// /api/plugins/<plugin-name> when the plugin contributes any HTTP
+// handler. The fallback only matches a handler mounted at Path = ""
+// or "/" — plugins whose handler lives at a non-root path (e.g.
+// "/scores") must set UIComponent.ModelURL explicitly.
 func BuildUIRegistry(res BootstrapResult) *UIRegistry {
 	reg := &UIRegistry{
 		entries: make(map[string]map[string][]UIRegistryEntry),
@@ -59,9 +62,11 @@ func BuildUIRegistry(res BootstrapResult) *UIRegistry {
 		if comp.Element == "" {
 			continue
 		}
-		modelURL := ""
-		if _, ok := httpPlugins[c.Plugin]; ok {
-			modelURL = PluginAPIPrefix + c.Plugin
+		modelURL := comp.ModelURL
+		if modelURL == "" {
+			if _, ok := httpPlugins[c.Plugin]; ok {
+				modelURL = PluginAPIPrefix + c.Plugin
+			}
 		}
 		for _, slot := range comp.EmbedAt {
 			if !validView(slot.View) || !validSlot(slot.Slot) {

--- a/internal/plugin/uiregistry_test.go
+++ b/internal/plugin/uiregistry_test.go
@@ -143,6 +143,91 @@ func TestPrefixedMCPName(t *testing.T) {
 	}
 }
 
+// TestBuildUIRegistry_ExplicitModelURLRespected verifies that when a
+// UIComponent sets ModelURL the registry passes it through verbatim
+// rather than falling back to the per-plugin default. This is the
+// hook plugin authors use when their HTTP handler lives at a non-root
+// Path (issue #74).
+func TestBuildUIRegistry_ExplicitModelURLRespected(t *testing.T) {
+	res := BootstrapResult{
+		HTTPHandlers: []NamedHTTPHandler{{
+			Plugin: "complexity",
+			Handler: HTTPHandler{
+				Path:    "/scores",
+				Handler: http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}),
+			},
+		}},
+		UIComponents: []NamedUIComponent{{
+			Plugin: "complexity",
+			Component: UIComponent{
+				Element:  "plugin-complexity-heatmap",
+				Assets:   fstest.MapFS{"heatmap.js": &fstest.MapFile{Data: []byte("// stub")}},
+				Entry:    "heatmap.js",
+				EmbedAt:  []EmbedSlot{{View: ViewDashboard, Slot: SlotMain}},
+				ModelURL: "/api/plugins/complexity/scores",
+			},
+		}},
+	}
+	reg := BuildUIRegistry(res)
+	dash := reg.Lookup(ViewDashboard, SlotMain)
+	if len(dash) != 1 {
+		t.Fatalf("entries = %d, want 1", len(dash))
+	}
+	if got, want := dash[0].ModelURL, "/api/plugins/complexity/scores"; got != want {
+		t.Errorf("ModelURL = %q, want %q (explicit value should be respected)", got, want)
+	}
+}
+
+// TestBuildUIRegistry_EmptyModelURLFallsBack verifies that an empty
+// UIComponent.ModelURL falls back to PluginAPIPrefix + plugin name
+// when the plugin contributes any HTTP handler. Preserves backward
+// compatibility for plugins that don't set the new field.
+func TestBuildUIRegistry_EmptyModelURLFallsBack(t *testing.T) {
+	res := BootstrapResult{
+		HTTPHandlers: []NamedHTTPHandler{{
+			Plugin: "p",
+			Handler: HTTPHandler{
+				Path:    "",
+				Handler: http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}),
+			},
+		}},
+		UIComponents: []NamedUIComponent{{
+			Plugin: "p",
+			Component: fakeUIComponent("plugin-p", "p.js",
+				EmbedSlot{View: ViewDashboard, Slot: SlotMain}),
+		}},
+	}
+	reg := BuildUIRegistry(res)
+	dash := reg.Lookup(ViewDashboard, SlotMain)
+	if len(dash) != 1 {
+		t.Fatalf("entries = %d, want 1", len(dash))
+	}
+	if got, want := dash[0].ModelURL, PluginAPIPrefix+"p"; got != want {
+		t.Errorf("ModelURL = %q, want %q (default fallback)", got, want)
+	}
+}
+
+// TestBuildUIRegistry_NoHTTPHandlerAndEmptyModelURL verifies that a
+// plugin without any HTTP handler and without an explicit ModelURL
+// produces an empty ModelURL — there's nothing sensible to default to.
+func TestBuildUIRegistry_NoHTTPHandlerAndEmptyModelURL(t *testing.T) {
+	res := BootstrapResult{
+		UIComponents: []NamedUIComponent{{
+			Plugin: "p",
+			Component: fakeUIComponent("plugin-p", "p.js",
+				EmbedSlot{View: ViewDashboard, Slot: SlotMain}),
+		}},
+	}
+	reg := BuildUIRegistry(res)
+	dash := reg.Lookup(ViewDashboard, SlotMain)
+	if len(dash) != 1 {
+		t.Fatalf("entries = %d, want 1", len(dash))
+	}
+	if dash[0].ModelURL != "" {
+		t.Errorf("ModelURL = %q, want empty", dash[0].ModelURL)
+	}
+}
+
 func TestUIRegistry_Views(t *testing.T) {
 	res := BootstrapResult{
 		UIComponents: []NamedUIComponent{

--- a/internal/plugins/complexity/complexity.go
+++ b/internal/plugins/complexity/complexity.go
@@ -142,6 +142,13 @@ func (p *Plugin) UIComponents() []plugin.UIComponent {
 			{View: plugin.ViewDashboard, Slot: plugin.SlotMain, Label: "Complexity"},
 			{View: plugin.ViewPackageDetail, Slot: plugin.SlotExtraTab, Label: "Complexity"},
 		},
+		// HTTPHandlers above mounts /scores; the host's per-plugin
+		// prefix /api/plugins/complexity makes the full URL
+		// /api/plugins/complexity/scores. Set explicitly so the
+		// dashboard widget's data-model-url matches the registered
+		// route (the default fallback would be /api/plugins/complexity
+		// → 404). See issue #74.
+		ModelURL: plugin.PluginAPIPrefix + "complexity/scores",
 	}}
 }
 


### PR DESCRIPTION
## Summary

The dashboard plugin widget for `complexity` fetched `/api/plugins/complexity` and got 404, because the plugin's HTTP handler is mounted at `Path=\"/scores\"` (full route `/api/plugins/complexity/scores`).

Add `UIComponent.ModelURL` so plugins whose handler lives at a non-root path can declare the URL explicitly. Default fallback (`PluginAPIPrefix+plugin-name`) is preserved for the simple case (handler at `Path=\"\"` or `\"/\"`).

Wire complexity plugin's `UIComponent.ModelURL` to the actual route. Adds regression tests:

- `BuildUIRegistry` honors `UIComponent.ModelURL` when set
- `BuildUIRegistry` falls back when `ModelURL` empty + handler at root  
- `/api/plugins/complexity/scores` returns 200

Closes #74.

## Test plan
- [x] All tests pass: \`go test ./...\`
- [x] Manual: visit dashboard, complexity widget no longer 404s

🤖 Generated with [Claude Code](https://claude.com/claude-code)