### PR TITLE
feat(ux): mobile-responsive dashboard, package detail, layer map (#73)

### DIFF
--- a/internal/adapter/http/assets/graph.js
+++ b/internal/adapter/http/assets/graph.js
@@ -353,6 +353,42 @@
         if (!el.style.height) { el.style.height = '300px'; }
     }
 
+    // ensureZoomOverlay (#73): inject a small +/- stack into the
+    // bottom-right corner of every cytoscape container so touch users
+    // can zoom even when the toolbar above the graph is scrolled out
+    // of view. Skipped when interactive=false or already added.
+    function ensureZoomOverlay(el, cy) {
+        if (el.dataset.cyZoomOverlay === 'on') { return; }
+        el.dataset.cyZoomOverlay = 'on';
+        var parent = el.parentElement;
+        if (!parent) { return; }
+        if (!parent.classList.contains('cy-graph-wrap')) {
+            parent.classList.add('cy-graph-wrap');
+        }
+        var overlay = document.createElement('div');
+        overlay.className = 'cy-zoom-controls';
+        var mkBtn = function (label, ariaLabel, fn) {
+            var b = document.createElement('button');
+            b.type = 'button';
+            b.className = 'cy-btn';
+            b.textContent = label;
+            b.setAttribute('aria-label', ariaLabel);
+            b.addEventListener('click', function (ev) {
+                ev.preventDefault();
+                fn();
+            });
+            return b;
+        };
+        overlay.appendChild(mkBtn('+', 'Zoom in', function () {
+            cy.zoom({ level: cy.zoom() * 1.25, renderedPosition: { x: el.clientWidth / 2, y: el.clientHeight / 2 } });
+        }));
+        overlay.appendChild(mkBtn('\u2212', 'Zoom out', function () {
+            cy.zoom({ level: cy.zoom() / 1.25, renderedPosition: { x: el.clientWidth / 2, y: el.clientHeight / 2 } });
+        }));
+        overlay.appendChild(mkBtn('\u25A1', 'Fit', function () { cy.fit(null, 20); }));
+        parent.appendChild(overlay);
+    }
+
     function renderGraph(el) {
         applyHeight(el);
         var view = el.getAttribute('data-view') || 'type-detail';
@@ -365,10 +401,16 @@
                 return;
             }
             var elements = hydrateElements(payload);
+            // #73: tune touch interactions. wheelSensitivity reduces
+            // jitter on trackpads + phones; touchTapThreshold avoids
+            // accidental taps mid-pan. Pinch-to-zoom is enabled by
+            // default in cytoscape.
             var cy = window.cytoscape({
                 container: el,
                 elements: elements,
                 layout: preset.layout,
+                wheelSensitivity: 0.2,
+                touchTapThreshold: 8,
                 style: preset.style.concat([
                     { selector: '.cy-faded', style: { 'opacity': 0.2 } },
                     { selector: '.cy-hi', style: { 'opacity': 1 } }
@@ -376,6 +418,9 @@
             });
             attachInteractions(cy, el, interactive);
             attachToolbar(el, cy);
+            if (interactive) {
+                ensureZoomOverlay(el, cy);
+            }
         };
 
         // Source 1: inline payload (M7d path).

--- a/internal/adapter/http/assets/styles.css
+++ b/internal/adapter/http/assets/styles.css
@@ -1045,3 +1045,205 @@ table.config-fields th { color: var(--muted); font-weight: 600; }
     background: #fed7aa;
     color: #7c2d12;
 }
+
+/* ---- Mobile responsive (#73) -----------------------------------------
+   Layout, typography and graph rules so the browser is usable on a
+   phone. All rules below are additive: they only override existing
+   declarations inside the listed media queries / for the listed
+   widgets, the desktop look is otherwise unchanged. */
+
+/* Long Go FQNs and import paths must wrap rather than push the layout. */
+.mono,
+code,
+.pkg-link,
+.dep-pkg,
+.search-pkg,
+.search-file,
+.search-name,
+nav.crumbs,
+.pkg-path-muted,
+.diff-table .col-path,
+dl.pkg-meta-list dd {
+    overflow-wrap: anywhere;
+    word-break: break-word;
+}
+
+/* Prevent any descendant from triggering a horizontal scroll of the
+   whole document. <pre> already has overflow-x: auto. */
+html, body {
+    overflow-x: hidden;
+}
+
+/* Card grids use auto-fit, minmax(280px, 1fr) so they cleanly drop
+   from 3 to 2 to 1 column as viewport narrows. */
+.dash-grid,
+.layer-grid {
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+/* Tables that can be wide: scroll inside the table container, not the
+   page. */
+.diff-table,
+.targets-table,
+table.config-fields {
+    display: block;
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+}
+
+.diff-table thead,
+.diff-table tbody,
+.targets-table thead,
+.targets-table tbody,
+table.config-fields thead,
+table.config-fields tbody {
+    display: table;
+    width: 100%;
+    table-layout: fixed;
+}
+
+/* Cytoscape containers: width 100%, disable browser pinch / double-tap
+   zoom on the canvas so cytoscape owns the gesture. */
+.cy-graph {
+    width: 100%;
+    touch-action: none;
+}
+
+.cy-toolbar {
+    flex-wrap: wrap;
+    row-gap: 0.4rem;
+}
+
+.cy-btn {
+    min-height: 32px;
+    min-width: 32px;
+}
+
+/* Hamburger toggle is hidden on desktop, surfaced under 720px via the
+   media query below. The nav uses a CSS-only checkbox hack (see
+   base.html) so no JS is required for the menu. */
+.nav-toggle-input,
+.nav-toggle-label {
+    display: none;
+}
+
+@media (max-width: 720px) {
+    header.site-nav {
+        flex-wrap: wrap;
+        gap: 0.5rem;
+        padding: 0.5rem 0.75rem;
+        align-items: center;
+    }
+    header.site-nav .brand {
+        flex: 1;
+    }
+    .nav-toggle-label {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 36px;
+        height: 36px;
+        border: 1px solid var(--border);
+        border-radius: 0.3rem;
+        cursor: pointer;
+        color: var(--fg);
+        background: var(--bg);
+        font-size: 1.25rem;
+        line-height: 1;
+        user-select: none;
+    }
+    header.site-nav nav {
+        display: none;
+        flex-basis: 100%;
+        flex-direction: column;
+        gap: 0.15rem;
+    }
+    .nav-toggle-input:checked ~ nav {
+        display: flex;
+    }
+    header.site-nav .worktree-switcher {
+        flex-basis: 100%;
+    }
+    main.content {
+        padding: 1rem 0.75rem;
+    }
+    nav.pkg-tabs {
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+    /* On mobile, more vertical space for graphs. */
+    .cy-graph,
+    .cy-graph.layer-map,
+    .cy-graph.layer-map-mini,
+    .cy-graph.package-overview,
+    .cy-graph.diff-overlay {
+        height: 320px;
+    }
+    .cy-graph.cy-sequence {
+        height: 280px;
+    }
+    .diff-body {
+        grid-template-columns: 1fr;
+    }
+    .diff-filter {
+        position: static;
+    }
+}
+
+@media (max-width: 480px) {
+    html, body {
+        font-size: 14px;
+    }
+    main.content {
+        padding: 0.75rem 0.5rem;
+    }
+    .card {
+        padding: 0.75rem;
+    }
+    .dash-grid,
+    .layer-grid {
+        grid-template-columns: 1fr;
+        gap: 0.75rem;
+    }
+    h1 {
+        font-size: 1.25rem;
+    }
+    .pkg-filter-row {
+        flex-direction: column;
+        align-items: stretch;
+    }
+    .pkg-filter label,
+    .pkg-filter label.grow {
+        min-width: 0;
+    }
+    .diff-table th,
+    .diff-table td {
+        padding: 0.3rem 0.4rem;
+        font-size: 0.82rem;
+    }
+}
+
+/* Pan/zoom overlay: a small +/− stack anchored to the bottom-right of
+   any cytoscape container so touch users can reset zoom even when the
+   toolbar above scrolls offscreen. Created by graph.js. */
+.cy-graph-wrap {
+    position: relative;
+}
+.cy-zoom-controls {
+    position: absolute;
+    right: 0.5rem;
+    bottom: 0.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    z-index: 5;
+}
+.cy-zoom-controls .cy-btn {
+    width: 32px;
+    height: 32px;
+    padding: 0;
+    text-align: center;
+    line-height: 30px;
+    background: var(--bg);
+}

--- a/internal/adapter/http/server_test.go
+++ b/internal/adapter/http/server_test.go
@@ -114,6 +114,65 @@ func TestServer_AssetsServed(t *testing.T) {
 	}
 }
 
+// TestServer_StylesheetMobileResponsive (#73) guards the mobile-
+// responsive declarations so a future refactor doesn't silently
+// regress phone usability. Each marker maps to one of the rules from
+// the ticket: card grid auto-fit, mobile breakpoint, hamburger nav,
+// cytoscape touch-action, FQN wrap.
+func TestServer_StylesheetMobileResponsive(t *testing.T) {
+	ts := newTestServer(t)
+	defer ts.Close()
+
+	resp, err := ts.Client().Get(ts.URL + "/assets/styles.css")
+	if err != nil {
+		t.Fatalf("GET /assets/styles.css: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != nethttp.StatusOK {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+	css := string(body)
+	wantMarkers := []string{
+		"minmax(280px, 1fr)",
+		"@media (max-width: 480px)",
+		"@media (max-width: 720px)",
+		"touch-action: none",
+		"overflow-wrap: anywhere",
+		".nav-toggle-input",
+		".cy-zoom-controls",
+	}
+	for _, m := range wantMarkers {
+		if !strings.Contains(css, m) {
+			t.Errorf("styles.css missing responsive marker %q", m)
+		}
+	}
+}
+
+// TestServer_BaseTemplate_HamburgerToggle (#73) asserts that pages
+// served from the base layout include the CSS-only nav toggle. We
+// hit the dashboard and look for the input + label markers.
+func TestServer_BaseTemplate_HamburgerToggle(t *testing.T) {
+	ts := newTestServer(t)
+	defer ts.Close()
+
+	resp, err := ts.Client().Get(ts.URL + "/")
+	if err != nil {
+		t.Fatalf("GET /: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != nethttp.StatusOK {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+	html := string(body)
+	for _, m := range []string{`class="nav-toggle-input"`, `class="nav-toggle-label"`} {
+		if !strings.Contains(html, m) {
+			t.Errorf("rendered page missing %q", m)
+		}
+	}
+}
+
 func TestServer_RenderEndpoint_POSTForm(t *testing.T) {
 	ts := newTestServer(t)
 	defer ts.Close()

--- a/internal/adapter/http/templates/base.html
+++ b/internal/adapter/http/templates/base.html
@@ -10,6 +10,8 @@
 <body>
 <header class="site-nav">
     <a href="{{if .NavPrefix}}{{.NavPrefix}}/{{else}}/{{end}}" class="brand">archai</a>
+    <input type="checkbox" id="nav-toggle" class="nav-toggle-input" aria-hidden="true">
+    <label for="nav-toggle" class="nav-toggle-label" aria-label="Toggle navigation">&#9776;</label>
     <nav>
         {{range .NavItems}}
             <a href="{{.Href}}"{{if .Active}} class="active"{{end}}>{{.Label}}</a>


### PR DESCRIPTION
Closes #73.

## Summary

Make the archai browser usable on a phone. CSS-only changes plus a small JS overlay for cytoscape touch zoom controls; no new JS frameworks.

## Breakpoints

- **Phone (<480px)** — single-column card grids, base font 14px, card padding 0.75rem, tighter table cells, stacked filter rows.
- **Tablet / narrow (<720px)** — hamburger nav (CSS-only checkbox toggle), graphs grow to 320px tall, package tabs scroll horizontally inside their container, diff body collapses to one column.
- **Desktop (>=720px)** — unchanged from before.

## Changes

- `templates/base.html`: viewport meta already present; add CSS-only `<input type="checkbox">` + `<label>` hamburger toggle in the site header (no JS).
- `assets/styles.css`:
  - `.dash-grid` / `.layer-grid` use `repeat(auto-fit, minmax(280px, 1fr))` so cards reflow 3 to 2 to 1.
  - Long Go FQNs and import paths get `overflow-wrap: anywhere` to wrap instead of pushing layout.
  - `html, body { overflow-x: hidden }` so no descendant can trigger horizontal page scroll.
  - Wide tables (`diff-table`, `targets-table`, `config-fields`) scroll inside the container, not the page.
  - `.cy-graph` gets `width: 100%` and `touch-action: none` so cytoscape owns pinch / double-tap gestures.
  - Two media queries (`max-width: 720px`, `max-width: 480px`) implement the breakpoints above.
- `assets/graph.js`: cytoscape gets `wheelSensitivity: 0.2` and `touchTapThreshold: 8` for smoother phone gestures, and an injected `.cy-zoom-controls` overlay (+/-/fit) anchored bottom-right of every interactive graph so touch users can reset zoom even when the toolbar scrolls offscreen.
- `server_test.go`: two regression tests pin the mobile responsive markers in styles.css and the hamburger toggle in the rendered base layout, so a future refactor can't silently regress phone usability.

## Acceptance criteria

- [x] Dashboard, layers, packages list, package detail, type detail, diff, search readable and interactive at 375px wide without horizontal page scroll.
- [x] Cytoscape graphs pannable / zoomable by touch on mobile (`touch-action: none` on canvas, pinch / drag handled by cytoscape, +/-/fit overlay always visible).
- [x] No layout breakage between 320px and 1920px (auto-fit grids + `overflow-wrap: anywhere` cover both extremes).
- [x] CSS-only changes, isolated to existing stylesheet; no JS framework introduced. The graph.js delta is a small overlay helper (~40 lines), not a new dep.
- [ ] Lighthouse mobile >= 90 — manual run pending; structural rules above (no horizontal scroll, scaled fonts, larger tap targets) should clear it.

## Tested

- `go build ./...` clean.
- `go test ./...` clean (full repo, ~70s).
- DevTools device emulation: iPhone SE (375x812), iPhone 11 (414x896), iPad (768x1024) — portrait and landscape.
- Manual real-device verification recommended before close.

## Coordination

Per task instructions, this PR does NOT add a footer — issue #75 is in flight in parallel and owns the footer addition.