### PR TITLE
feat(ux): show archai version on dashboard footer + /api/version (#75)

### DIFF
--- a/cmd/archai/main.go
+++ b/cmd/archai/main.go
@@ -21,6 +21,7 @@ import (
 	httpAdapter "github.com/kgatilin/archai/internal/adapter/http"
 	"github.com/kgatilin/archai/internal/adapter/mcp"
 	yamlAdapter "github.com/kgatilin/archai/internal/adapter/yaml"
+	"github.com/kgatilin/archai/internal/buildinfo"
 	"github.com/kgatilin/archai/internal/plugin"
 	"github.com/kgatilin/archai/internal/apply"
 	"github.com/kgatilin/archai/internal/diff"
@@ -491,7 +492,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 			if err != nil {
 				return nil, err
 			}
-			return srv.WithPlugins(plugins), nil
+			return srv.WithVersion(buildinfo.Resolve()).WithPlugins(plugins), nil
 		}
 	} else {
 		opts.PluginBootstrap = bootstrapDaemonPlugins
@@ -500,7 +501,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 			if err != nil {
 				return nil, err
 			}
-			return srv.WithPlugins(plugins), nil
+			return srv.WithVersion(buildinfo.Resolve()).WithPlugins(plugins), nil
 		}
 	}
 

--- a/cmd/archai/version.go
+++ b/cmd/archai/version.go
@@ -2,35 +2,45 @@ package main
 
 import (
 	"fmt"
-	"runtime/debug"
 
+	"github.com/kgatilin/archai/internal/buildinfo"
 	"github.com/spf13/cobra"
 )
 
-// Version is the archai binary version. Defaults to "dev" for
-// unversioned builds and is overridden at build time via ldflags:
+// Version is retained as a CLI-package alias so existing
+// `-ldflags "-X main.Version=..."` invocations keep working. At
+// init time we forward whatever the linker injected into the
+// canonical buildinfo.Version, which is what Resolve() actually
+// reads.
 //
-//	go build -ldflags "-X main.Version=v0.1.0" ./cmd/archai
+// New build scripts should target buildinfo.Version directly:
 //
-// When Version is still "dev" at runtime we fall back to debug.ReadBuildInfo
-// so `go install` / `go run` users get a meaningful version when available.
+//	go build -ldflags "-X github.com/kgatilin/archai/internal/buildinfo.Version=v0.1.0" ./cmd/archai
 var Version = "dev"
 
+func init() {
+	if Version != "" && Version != "dev" {
+		buildinfo.Version = Version
+	}
+}
+
 // resolveVersion returns the effective version string used by
-// `archai version`. It prefers the linker-injected Version; if that
-// hasn't been set it tries debug.ReadBuildInfo so module-managed
-// installs report their module version instead of the literal "dev".
+// `archai version`. It delegates to buildinfo.Resolve() so the CLI
+// and HTTP surfaces never disagree.
+//
+// Forwarding rules:
+//   - When main.Version was overridden (non-"dev"), it wins — mirrors
+//     the legacy `-X main.Version=...` build path.
+//   - When main.Version is "dev" but buildinfo.Version was overridden
+//     directly (`-X internal/buildinfo.Version=...`), we leave it alone
+//     so the new ldflag path takes effect.
+//   - Only when both are at their zero value do we fall through to
+//     debug.ReadBuildInfo() inside Resolve().
 func resolveVersion() string {
 	if Version != "" && Version != "dev" {
-		return Version
+		buildinfo.Version = Version
 	}
-	if info, ok := debug.ReadBuildInfo(); ok {
-		v := info.Main.Version
-		if v != "" && v != "(devel)" {
-			return v
-		}
-	}
-	return Version
+	return buildinfo.Resolve().Version
 }
 
 // newVersionCmd returns the `archai version` command. Output is a

--- a/cmd/archai/version_test.go
+++ b/cmd/archai/version_test.go
@@ -4,12 +4,18 @@ import (
 	"bytes"
 	"strings"
 	"testing"
+
+	"github.com/kgatilin/archai/internal/buildinfo"
 )
 
 // TestVersionCommand verifies `archai version` prints `archai <Version>`.
 func TestVersionCommand(t *testing.T) {
 	orig := Version
-	t.Cleanup(func() { Version = orig })
+	origBI := buildinfo.Version
+	t.Cleanup(func() {
+		Version = orig
+		buildinfo.Version = origBI
+	})
 
 	Version = "v1.2.3-test"
 	cmd := newVersionCmd()
@@ -32,7 +38,11 @@ func TestVersionCommand(t *testing.T) {
 // always start with "archai " and end with a newline.
 func TestVersionCommand_DevFallback(t *testing.T) {
 	orig := Version
-	t.Cleanup(func() { Version = orig })
+	origBI := buildinfo.Version
+	t.Cleanup(func() {
+		Version = orig
+		buildinfo.Version = origBI
+	})
 
 	Version = "dev"
 	cmd := newVersionCmd()
@@ -57,10 +67,33 @@ func TestVersionCommand_DevFallback(t *testing.T) {
 // when Version has been overridden from "dev".
 func TestResolveVersion_NonDev(t *testing.T) {
 	orig := Version
-	t.Cleanup(func() { Version = orig })
+	origBI := buildinfo.Version
+	t.Cleanup(func() {
+		Version = orig
+		buildinfo.Version = origBI
+	})
 
 	Version = "v0.5.0"
 	if got := resolveVersion(); got != "v0.5.0" {
 		t.Fatalf("resolveVersion = %q, want v0.5.0", got)
+	}
+}
+
+// TestResolveVersion_MatchesBuildinfo verifies the CLI and the
+// /api/version endpoint will report the same version string by going
+// through the same buildinfo.Resolve() path.
+func TestResolveVersion_MatchesBuildinfo(t *testing.T) {
+	orig := Version
+	origBI := buildinfo.Version
+	t.Cleanup(func() {
+		Version = orig
+		buildinfo.Version = origBI
+	})
+
+	Version = "v7.7.7"
+	cli := resolveVersion()
+	api := buildinfo.Resolve().Version
+	if cli != api {
+		t.Fatalf("CLI version %q != API version %q", cli, api)
 	}
 }

--- a/internal/adapter/http/api.go
+++ b/internal/adapter/http/api.go
@@ -8,7 +8,32 @@ import (
 	"strings"
 
 	"github.com/kgatilin/archai/internal/adapter/mcp"
+	"github.com/kgatilin/archai/internal/buildinfo"
 )
+
+// handleAPIVersion serves GET /api/version → buildinfo.Info as JSON.
+// The endpoint is read-only, worktree-independent and intentionally
+// shaped so the dashboard footer and machine clients can rely on the
+// same {version, commit, go} keys forever. Method != GET returns 405.
+//
+// The handler reads the cached Info captured at server-construction
+// time (via WithVersion) and falls back to a fresh Resolve() when no
+// version was wired (e.g. in tests).
+func (s *Server) handleAPIVersion(w nethttp.ResponseWriter, r *nethttp.Request) {
+	if r.Method != nethttp.MethodGet {
+		w.Header().Set("Allow", nethttp.MethodGet)
+		nethttp.Error(w, "method not allowed", nethttp.StatusMethodNotAllowed)
+		return
+	}
+	info := s.versionInfo()
+	// Defensive: surface a non-empty version even if WithVersion
+	// stashed a zero-valued Info upstream.
+	if info.Version == "" {
+		info = buildinfo.Resolve()
+	}
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	_ = json.NewEncoder(w).Encode(info)
+}
 
 // registerAPIRoutes wires JSON endpoints that mirror every MCP tool.
 // Each endpoint funnels into mcp.Dispatch so the MCP stdio client (M11

--- a/internal/adapter/http/api_version_test.go
+++ b/internal/adapter/http/api_version_test.go
@@ -1,0 +1,115 @@
+package http
+
+import (
+	"encoding/json"
+	"io"
+	nethttp "net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/kgatilin/archai/internal/buildinfo"
+)
+
+// TestAPIVersion_GET checks the JSON shape and content of /api/version.
+// The endpoint must return the {version, commit, go} keys, no others
+// being a hard requirement, with the version reflecting whatever was
+// wired via WithVersion at construction time.
+func TestAPIVersion_GET(t *testing.T) {
+	ts, _, _ := newAPITestServer(t)
+	// The test server already has /api/version mounted via routes(). We
+	// hit it directly and verify the GO key is non-empty (always set by
+	// debug.ReadBuildInfo inside `go test`).
+
+	resp, err := nethttp.Get(ts.URL + "/api/version")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status: %d", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Fatalf("content-type: %q", ct)
+	}
+	body, _ := io.ReadAll(resp.Body)
+
+	var info buildinfo.Info
+	if err := json.Unmarshal(body, &info); err != nil {
+		t.Fatalf("unmarshal: %v — body=%s", err, body)
+	}
+	if info.Version == "" {
+		t.Fatalf("version empty: body=%s", body)
+	}
+	if info.Go == "" {
+		t.Fatalf("go empty: body=%s", body)
+	}
+
+	// Stable shape: confirm the three keys are present in the raw JSON
+	// so a future struct-tag rename trips the test.
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(body, &raw); err != nil {
+		t.Fatalf("unmarshal raw: %v", err)
+	}
+	for _, k := range []string{"version", "commit", "go"} {
+		if _, ok := raw[k]; !ok {
+			t.Fatalf("missing key %q in %s", k, body)
+		}
+	}
+}
+
+// TestAPIVersion_MethodNotAllowed checks POST returns 405 with an
+// Allow: GET header so clients can probe the endpoint correctly.
+func TestAPIVersion_MethodNotAllowed(t *testing.T) {
+	ts, _, _ := newAPITestServer(t)
+
+	req, err := nethttp.NewRequest(nethttp.MethodPost, ts.URL+"/api/version", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	resp, err := nethttp.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != nethttp.StatusMethodNotAllowed {
+		t.Fatalf("status: %d", resp.StatusCode)
+	}
+	if allow := resp.Header.Get("Allow"); allow != nethttp.MethodGet {
+		t.Fatalf("Allow header: %q", allow)
+	}
+}
+
+// TestAPIVersion_WithVersionInjection ensures WithVersion overrides the
+// resolver, which is the contract main.go relies on to surface the
+// linker-injected build identity.
+func TestAPIVersion_WithVersionInjection(t *testing.T) {
+	ts, state, _ := newAPITestServer(t)
+	_ = ts // ensure baseline server still constructs cleanly
+	_ = state
+
+	// Build a fresh server, inject a synthetic Info, and exercise the
+	// handler directly via httptest.NewRecorder so we don't have to
+	// rewire the listener.
+	srv, err := NewServer(state)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	want := buildinfo.Info{Version: "v9.9.9-test", Commit: "deadbeef", Go: "go-test"}
+	srv.WithVersion(want)
+
+	req := httptest.NewRequest(nethttp.MethodGet, "/api/version", nil)
+	rec := httptest.NewRecorder()
+	srv.handleAPIVersion(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("status: %d body=%s", rec.Code, rec.Body.String())
+	}
+	var got buildinfo.Info
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v — body=%s", err, rec.Body.String())
+	}
+	if got != want {
+		t.Fatalf("info = %+v, want %+v", got, want)
+	}
+}

--- a/internal/adapter/http/assets/styles.css
+++ b/internal/adapter/http/assets/styles.css
@@ -86,6 +86,20 @@ main.content {
     margin: 0 auto;
 }
 
+footer.site-footer {
+    border-top: 1px solid var(--border);
+    padding: 0.5rem 1.5rem;
+    display: flex;
+    justify-content: flex-end;
+    color: var(--muted);
+    font-size: 0.85rem;
+    margin-top: 2rem;
+}
+
+footer.site-footer .version {
+    font-variant-numeric: tabular-nums;
+}
+
 h1, h2, h3 {
     margin-top: 0;
     color: var(--fg);

--- a/internal/adapter/http/handlers.go
+++ b/internal/adapter/http/handlers.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	nethttp "net/http"
 
+	"github.com/kgatilin/archai/internal/buildinfo"
 	"github.com/kgatilin/archai/internal/plugin"
 )
 
@@ -58,6 +59,11 @@ type pageData struct {
 	MultiMode   bool
 	Worktrees   []worktreeOption
 	CurrentPath string // original request path (used by the switcher form)
+	// Version is the build identity rendered by the footer in
+	// templates/base.html. It is the same struct returned by
+	// /api/version so the dashboard footer and the JSON endpoint can
+	// never disagree.
+	Version buildinfo.Info
 }
 
 // searchPageData is the model for the full Search page template. It
@@ -100,6 +106,10 @@ func (s *Server) routes(mux *nethttp.ServeMux) {
 	// D2 → SVG smoke endpoint. Used by M7b-f to render server-side
 	// diagrams; accepts POST with a `d2` form field or raw text body.
 	mux.HandleFunc("/render", s.handleRender)
+
+	// /api/version is worktree-independent: register it at the top
+	// level so single-mode and multi-mode share the same path.
+	mux.HandleFunc("/api/version", s.handleAPIVersion)
 
 	// M13: plugin transports. Routes are mounted before the catch-all
 	// "/" so /api/plugins/<name>/... and /plugins/<name>/assets/... are
@@ -187,6 +197,7 @@ func (s *Server) basePageData(r *nethttp.Request, title, activePath string) page
 		MultiMode:   s.multiMode(),
 		Worktree:    s.currentWorktree(r),
 		CurrentPath: r.URL.Path,
+		Version:     s.versionInfo(),
 	}
 	if s.multiMode() {
 		pd.Worktrees = s.buildWorktreeList(r)

--- a/internal/adapter/http/multi.go
+++ b/internal/adapter/http/multi.go
@@ -19,6 +19,9 @@ func (s *Server) registerMultiRoutes(mux *nethttp.ServeMux) {
 	mux.Handle("/assets/", nethttp.StripPrefix("/assets/", nethttp.FileServer(nethttp.FS(s.assets))))
 	mux.HandleFunc("/render", s.handleRender)
 	mux.HandleFunc("/worktree/select", s.handleWorktreeSelect)
+	// /api/version stays at the top level so its URL is the same in
+	// single- and multi-worktree mode.
+	mux.HandleFunc("/api/version", s.handleAPIVersion)
 
 	// M13: plugin routes live at the top level (not per worktree) so a
 	// single asset bundle / API surface backs every worktree's UI.

--- a/internal/adapter/http/server.go
+++ b/internal/adapter/http/server.go
@@ -28,6 +28,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/kgatilin/archai/internal/buildinfo"
 	"github.com/kgatilin/archai/internal/plugin"
 	"github.com/kgatilin/archai/internal/serve"
 )
@@ -56,6 +57,28 @@ type Server struct {
 	// received by the server. Wired by serve.Serve to drive the
 	// idle-timeout monitor (see ActivityAware in internal/serve).
 	onActivity func()
+
+	// version is the build identity surfaced via /api/version and the
+	// page footer. Defaults to buildinfo.Resolve() when unset so tests
+	// and out-of-band callers see a usable value.
+	version buildinfo.Info
+}
+
+// WithVersion stores the build identity reported by the dashboard
+// footer and the /api/version endpoint. Returns s for chaining.
+// Safe to call before Serve; not safe to call concurrently with Serve.
+func (s *Server) WithVersion(info buildinfo.Info) *Server {
+	s.version = info
+	return s
+}
+
+// versionInfo returns the build identity for s, falling back to a
+// fresh buildinfo.Resolve() when WithVersion was not called.
+func (s *Server) versionInfo() buildinfo.Info {
+	if s.version.Version == "" {
+		return buildinfo.Resolve()
+	}
+	return s.version
 }
 
 // WithPlugins attaches a plugin BootstrapResult to s so its HTTP

--- a/internal/adapter/http/templates/base.html
+++ b/internal/adapter/http/templates/base.html
@@ -31,5 +31,8 @@
 <main class="content">
     {{template "content" .}}
 </main>
+<footer class="site-footer">
+    <span class="version">archai {{.Version.Version}}</span>
+</footer>
 </body>
 </html>{{end}}

--- a/internal/buildinfo/buildinfo.go
+++ b/internal/buildinfo/buildinfo.go
@@ -1,0 +1,73 @@
+// Package buildinfo exposes the version, VCS commit and Go toolchain
+// versions of the running archai binary in a single, JSON-friendly
+// shape. The CLI's `archai version` command and the HTTP /api/version
+// endpoint both render the same Info struct so users never see
+// different values for the same build.
+//
+// Resolution precedence:
+//
+//  1. Linker-injected Version (set via `-X
+//     github.com/kgatilin/archai/internal/buildinfo.Version=v0.1.0`).
+//  2. debug.ReadBuildInfo().Main.Version when (1) is still "dev" and
+//     module info is available (e.g. `go install`).
+//  3. The literal string "dev".
+//
+// Commit is taken from the VCS settings recorded by `go build` (the
+// `vcs.revision` build setting). It is "" when the binary was built
+// outside a VCS checkout (e.g. `go run` from a tarball).
+package buildinfo
+
+import "runtime/debug"
+
+// Version is overridden at build time via:
+//
+//	go build -ldflags "-X github.com/kgatilin/archai/internal/buildinfo.Version=v0.1.0" ./cmd/archai
+//
+// It defaults to "dev" so unversioned builds remain identifiable.
+var Version = "dev"
+
+// Info is the resolved build identity reported by the CLI and HTTP
+// surfaces. Field tags pin the JSON shape so the HTTP contract is
+// stable across refactors.
+type Info struct {
+	Version string `json:"version"`
+	Commit  string `json:"commit"`
+	Go      string `json:"go"`
+}
+
+// Resolve returns the effective build identity. It never returns the
+// zero value: Version always falls back to "dev" and Go always carries
+// the runtime toolchain version. Commit may be empty when no VCS info
+// was embedded at build time.
+func Resolve() Info {
+	info := Info{
+		Version: Version,
+		Go:      goVersion(),
+	}
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		return info
+	}
+	if info.Version == "" || info.Version == "dev" {
+		if v := bi.Main.Version; v != "" && v != "(devel)" {
+			info.Version = v
+		}
+	}
+	for _, s := range bi.Settings {
+		if s.Key == "vcs.revision" {
+			info.Commit = s.Value
+			break
+		}
+	}
+	return info
+}
+
+// goVersion returns the Go toolchain version embedded in the binary,
+// or "unknown" when build info is unavailable. Split out so tests can
+// stub it via Resolve() if needed in the future.
+func goVersion() string {
+	if bi, ok := debug.ReadBuildInfo(); ok && bi.GoVersion != "" {
+		return bi.GoVersion
+	}
+	return "unknown"
+}

--- a/internal/buildinfo/buildinfo_test.go
+++ b/internal/buildinfo/buildinfo_test.go
@@ -1,0 +1,65 @@
+package buildinfo
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestResolve_LinkerVersion confirms the linker-injected Version wins
+// over module info when it has been set to a non-"dev" value.
+func TestResolve_LinkerVersion(t *testing.T) {
+	orig := Version
+	t.Cleanup(func() { Version = orig })
+
+	Version = "v9.9.9-test"
+	got := Resolve()
+	if got.Version != "v9.9.9-test" {
+		t.Fatalf("Version = %q, want v9.9.9-test", got.Version)
+	}
+	if got.Go == "" {
+		t.Fatalf("Go field empty; want runtime version")
+	}
+}
+
+// TestResolve_DevFallback verifies that with Version="dev" Resolve
+// either returns module info (under `go test` it's "(devel)" so we
+// keep "dev") or "dev" itself. The result must never be empty.
+func TestResolve_DevFallback(t *testing.T) {
+	orig := Version
+	t.Cleanup(func() { Version = orig })
+
+	Version = "dev"
+	got := Resolve()
+	if got.Version == "" {
+		t.Fatalf("Version is empty; want non-empty fallback")
+	}
+}
+
+// TestResolve_GoVersion checks the Go field carries a plausible
+// toolchain version (starts with "go" under normal `go test`).
+func TestResolve_GoVersion(t *testing.T) {
+	got := Resolve()
+	if got.Go == "" {
+		t.Fatalf("Go field empty")
+	}
+	// Sanity check: the runtime package and build info typically agree
+	// on the major Go release prefix.
+	if !strings.HasPrefix(got.Go, "go") && got.Go != "unknown" {
+		t.Fatalf("Go = %q, want go-prefixed or 'unknown'", got.Go)
+	}
+	_ = runtime.Version
+}
+
+// TestInfo_JSONShape pins the JSON tag names so the /api/version
+// contract can't drift silently. We re-marshal a known Info and check
+// the field names appear in the output.
+func TestInfo_JSONShape(t *testing.T) {
+	info := Info{Version: "v1", Commit: "abc", Go: "go1.25"}
+	// Trivial round-trip via field access — the JSON tags are checked
+	// by the HTTP API test in internal/adapter/http; this test just
+	// guards struct field presence.
+	if info.Version != "v1" || info.Commit != "abc" || info.Go != "go1.25" {
+		t.Fatalf("field round-trip failed: %+v", info)
+	}
+}


### PR DESCRIPTION
## Summary
- New `internal/buildinfo` package centralises version resolution (linker → ldflags → `runtime/debug.ReadBuildInfo`); CLI and HTTP both call `buildinfo.Resolve()` so they cannot drift.
- `Server.WithVersion(buildinfo.Info)` threads the build identity into the HTTP transport. `main.go` wires it for both single- and multi-worktree factories.
- New top-level `GET /api/version` endpoint returns `{"version":"vX.Y.Z","commit":"<sha>","go":"go1.25.1"}` (stable shape, identical URL in single & multi mode, `POST` → 405 with `Allow: GET`).
- Footer block in `templates/base.html` renders `archai vX.Y.Z` right-aligned with muted styling; `pageData.Version` populated by `basePageData`.
- `var Version = "dev"` retained in `cmd/archai` as a backward-compatible alias for `-X main.Version=...` build scripts.

## Acceptance criteria

- [x] `archai version` prints `archai vX.Y.Z` (existing test rewired against `buildinfo.Version`)
- [x] `GET /api/version` returns the documented JSON shape (`internal/adapter/http/api_version_test.go`)
- [x] Footer renders on every page that extends base.html (M1–M9 surfaces inherit it via `pageData.Version`)
- [x] CLI version and `/api/version` payload match (drift guard `TestResolveVersion_MatchesBuildinfo` + manual end-to-end with `-ldflags "-X .../buildinfo.Version=v0.99.0-bi"`: CLI says `archai v0.99.0-bi`, API responds `{"version":"v0.99.0-bi", ...}`)
- [x] `go build ./...`, `go vet ./...`, `go test ./...` all clean
- [x] No new top-level dependencies (only stdlib `runtime/debug`, `encoding/json`)
- [x] Footer owned here; #73 (theming) is independent

## Test plan
- [x] `go test ./...` (all packages green, including new `internal/buildinfo` and `internal/adapter/http/api_version_test.go`)
- [x] Build with `-X github.com/kgatilin/archai/internal/buildinfo.Version=v0.99.0-bi` and `-X main.Version=v0.99.0-main`; both surfaces (CLI + `/api/version`) report the injected string
- [x] `curl http://127.0.0.1:.../api/version` → JSON; `curl -X POST` → 405

🤖 Generated with [Claude Code](https://claude.com/claude-code)