### PR TITLE
feat(bc): M14 bounded contexts — overlay schema, dashboard, BC views, MCP tools

### DIFF
--- a/archai.yaml
+++ b/archai.yaml
@@ -55,6 +55,46 @@ layer_rules:
   domain:         []
   tests:          [cli, transport, runtime, source_adapter, service, model_ops, storage, domain]
 
-aggregates: {}
+aggregates:
+  domain:
+    root: "github.com/kgatilin/archai/internal/domain.PackageModel"
+  model_ops:
+    root: "github.com/kgatilin/archai/internal/overlay.Config"
+  source_adapter:
+    root: "github.com/kgatilin/archai/internal/adapter/golang.Extractor"
+  runtime:
+    root: "github.com/kgatilin/archai/internal/serve.State"
+  transport:
+    root: "github.com/kgatilin/archai/internal/adapter/http.Server"
+  cli:
+    root: "github.com/kgatilin/archai/cmd/root.Execute"
+
+bounded_contexts:
+  model_core:
+    description: "Core domain model and operations"
+    aggregates:
+      - domain
+      - model_ops
+  io_adapters:
+    description: "I/O adapters for Go source, YAML, and D2"
+    aggregates:
+      - source_adapter
+    downstream:
+      - model_core
+  serving:
+    description: "HTTP server and MCP adapter"
+    aggregates:
+      - runtime
+      - transport
+    downstream:
+      - model_core
+      - io_adapters
+  cli_entry:
+    description: "CLI entry point and command wiring"
+    aggregates:
+      - cli
+    downstream:
+      - serving
+      - io_adapters
 
 configs: []

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -275,7 +275,63 @@ architectural baseline and what `archai diff` / `archai validate`
 compare against. Keep `archai.yaml` checked in. If you use
 package-local overlays, keep `**/.arch/overlay.yaml` checked in too.
 
-### 3.5 CI integration
+### 3.5 Bounded contexts
+
+Bounded contexts are an optional DDD-style overlay on top of layers and
+aggregates. They let you group aggregates into named domain areas and
+declare context-map relationships between them.
+
+Add a `bounded_contexts:` block to `archai.yaml`:
+
+```yaml
+# archai.yaml
+
+bounded_contexts:
+  model_core:
+    description: "Core domain model and operations"
+    aggregates:
+      - domain
+      - model_ops
+
+  io_adapters:
+    description: "I/O adapters for Go source, YAML, and D2"
+    aggregates:
+      - source_adapter
+    downstream:
+      - model_core
+
+  serving:
+    description: "HTTP server and MCP adapter"
+    aggregates:
+      - runtime
+      - transport
+    downstream:
+      - model_core
+      - io_adapters
+
+  cli_entry:
+    description: "CLI entry point and command wiring"
+    aggregates:
+      - cli
+    downstream:
+      - serving
+      - io_adapters
+```
+
+**Schema reference**
+
+| Field          | Type             | Required | Description |
+|----------------|------------------|----------|-------------|
+| `description`  | string           | no       | Human-readable purpose of the context. |
+| `aggregates`   | list of strings  | no       | Aggregate names (declared in `aggregates:`) that belong to this context. |
+| `upstream`     | list of strings  | no       | Contexts this context depends on (consumes). |
+| `downstream`   | list of strings  | no       | Contexts that depend on this one (consumers). You may declare the relationship from either side — archai reads both. |
+| `relationship` | string           | no       | Optional context-map pattern label. Common values: `shared-kernel`, `customer-supplier`, `conformist`, `acl`, `open-host`. |
+
+Aggregates and bounded contexts are both optional — you can use layers
+alone, aggregates alone, or the full three-tier model.
+
+### 3.6 CI integration
 
 The minimum useful gate is `archai overlay check` (layer rules) and
 `archai validate` (drift from the active target). Example GitHub
@@ -323,9 +379,11 @@ Other flags:
 | `/`                   | Dashboard        | Project summary — module, layer counts, package/type counts, active target, drift status. |
 | `/layers`             | Layers           | The layer map from `archai.yaml` with package counts per layer and an allowed-dependencies grid. Red cells are layer-rule violations in the current code. |
 | `/packages`           | Packages         | Flat list of all packages with layer tag, counts, and import-path search. |
-| `/packages/{path}`    | Package detail   | Interfaces, structs, functions, methods, and dependencies for one package. Links to types. |
+| `/packages/{path}`    | Package detail   | Interfaces, structs, functions, methods, and dependencies for one package. Links to types and bounded context. |
 | `/types/{pkg}.{type}` | Type detail      | Fields/methods of a struct or interface, implementers/implementations, inbound references. |
 | `/configs`            | Configs          | Config bundles declared in `archai.yaml` (empty when no `configs:` entries). |
+| `/bc`                 | Domain           | Bounded context catalog with an interactive context-map graph (visible only when `bounded_contexts:` is declared). |
+| `/bc/{name}`          | BC detail        | Aggregates, upstream/downstream peer contexts, and member packages for one bounded context. |
 | `/targets`            | Targets          | All locked targets, which one is CURRENT, created_at, description. |
 | `/diff`               | Diff             | Structured diff between current code and the active target — color-coded: green = added, red = removed, amber = modified. |
 | `/search`             | Global search    | Packages, types, and functions by name substring. |
@@ -446,20 +504,22 @@ args    = ["serve", "--mcp-stdio", "--root", "."]
 
 ### 6.3 MCP tools
 
-The daemon advertises nine tools (defined in
+The daemon advertises eleven tools (defined in
 `internal/adapter/mcp/tools.go`):
 
-| Tool                 | Purpose                                                                 |
-|----------------------|-------------------------------------------------------------------------|
-| `extract`            | Return the full extracted Go model. Optional `paths` filter.            |
-| `list_packages`      | Minimal per-package summary (path, name, layer, counts).                |
-| `get_package`        | Full `PackageModel` for one package (`path` required).                  |
-| `lock_target`        | Freeze the current in-memory model as `.arch/targets/<id>/`.            |
-| `list_targets`       | List locked targets.                                                    |
-| `set_current_target` | Write `.arch/targets/CURRENT`.                                          |
-| `diff`               | Structured diff of current model vs a target (`target` defaults to CURRENT). |
-| `apply_diff`         | Apply a YAML patch onto a target snapshot (`patch_yaml` required).      |
-| `validate`           | `{ok, violations: [...]}` — same drift as `archai validate`.            |
+| Tool                      | Purpose                                                                 |
+|---------------------------|-------------------------------------------------------------------------|
+| `extract`                 | Return the full extracted Go model. Optional `paths` filter.            |
+| `list_packages`           | Minimal per-package summary (path, name, layer, counts).                |
+| `get_package`             | Full `PackageModel` for one package (`path` required).                  |
+| `lock_target`             | Freeze the current in-memory model as `.arch/targets/<id>/`.            |
+| `list_targets`            | List locked targets.                                                    |
+| `set_current_target`      | Write `.arch/targets/CURRENT`.                                          |
+| `diff`                    | Structured diff of current model vs a target (`target` defaults to CURRENT). |
+| `apply_diff`              | Apply a YAML patch onto a target snapshot (`patch_yaml` required).      |
+| `validate`                | `{ok, violations: [...]}` — same drift as `archai validate`.            |
+| `list_bounded_contexts`   | List all bounded contexts from `archai.yaml` with aggregates and relationships. |
+| `get_bounded_context`     | Full detail for one BC by `name`: aggregates, upstream/downstream peers, member packages. |
 
 ### 6.4 Example agent prompts
 

--- a/internal/adapter/http/bc.go
+++ b/internal/adapter/http/bc.go
@@ -1,0 +1,244 @@
+package http
+
+import (
+	nethttp "net/http"
+	"sort"
+	"strings"
+
+	"github.com/kgatilin/archai/internal/domain"
+	"github.com/kgatilin/archai/internal/overlay"
+)
+
+// bcListData is the page model for /bc (bounded context list).
+type bcListData struct {
+	pageData
+
+	HasOverlay bool
+	BCs        []bcSummaryView
+}
+
+// bcSummaryView is one row in the /bc list.
+type bcSummaryView struct {
+	Name         string
+	Description  string
+	Relationship string
+	AggCount     int
+	PkgCount     int
+	Href         string
+}
+
+// bcDetailData is the page model for /bc/{name}.
+type bcDetailData struct {
+	pageData
+
+	Name         string
+	Description  string
+	Relationship string
+	Aggregates   []string
+	Upstream     []bcRefView
+	Downstream   []bcRefView
+	Packages     []domain.PackageModel
+}
+
+// bcRefView is a reference to another bounded context in the detail view.
+type bcRefView struct {
+	Name string
+	Href string
+}
+
+// registerBCRoutes mounts the /bc and /bc/{name} handlers plus the
+// JSON graph API at /api/bc/graph.
+func (s *Server) registerBCRoutes(mux *nethttp.ServeMux) {
+	mux.HandleFunc("/bc", s.handleBCList)
+	mux.HandleFunc("/bc/", s.handleBCDetail)
+	mux.HandleFunc("/api/bc/graph", s.handleBCGraph)
+}
+
+// handleBCList renders /bc — the bounded context catalog.
+func (s *Server) handleBCList(w nethttp.ResponseWriter, r *nethttp.Request) {
+	state := s.stateFor(r)
+	if state == nil {
+		nethttp.Error(w, "no state available", nethttp.StatusServiceUnavailable)
+		return
+	}
+	snap := state.Snapshot()
+	data := bcListData{
+		pageData: s.basePageData(r, "Domain", "/bc"),
+	}
+
+	if snap.Overlay != nil && len(snap.Overlay.BoundedContexts) > 0 {
+		data.HasOverlay = true
+		data.BCs = buildBCSummaries(snap.Overlay.BoundedContexts, snap.Packages)
+	}
+
+	s.renderPage(w, "bc_list.html", data)
+}
+
+// handleBCDetail renders /bc/{name} — the detail page for one bounded context.
+func (s *Server) handleBCDetail(w nethttp.ResponseWriter, r *nethttp.Request) {
+	name := strings.TrimPrefix(r.URL.Path, "/bc/")
+	if name == "" {
+		nethttp.Redirect(w, r, "/bc", nethttp.StatusFound)
+		return
+	}
+
+	state := s.stateFor(r)
+	if state == nil {
+		nethttp.Error(w, "no state available", nethttp.StatusServiceUnavailable)
+		return
+	}
+	snap := state.Snapshot()
+
+	if snap.Overlay == nil {
+		nethttp.NotFound(w, r)
+		return
+	}
+	bc, ok := snap.Overlay.BoundedContexts[name]
+	if !ok {
+		nethttp.NotFound(w, r)
+		return
+	}
+
+	pkgs := packagesInBC(name, bc.Aggregates, snap.Packages)
+
+	upstream := make([]bcRefView, 0, len(bc.Upstream))
+	for _, u := range bc.Upstream {
+		upstream = append(upstream, bcRefView{Name: u, Href: "/bc/" + u})
+	}
+	downstream := make([]bcRefView, 0, len(bc.Downstream))
+	for _, d := range bc.Downstream {
+		downstream = append(downstream, bcRefView{Name: d, Href: "/bc/" + d})
+	}
+
+	aggsCopy := make([]string, len(bc.Aggregates))
+	copy(aggsCopy, bc.Aggregates)
+	sort.Strings(aggsCopy)
+
+	data := bcDetailData{
+		pageData:     s.basePageData(r, "Domain: "+name, "/bc"),
+		Name:         name,
+		Description:  bc.Description,
+		Relationship: bc.Relationship,
+		Aggregates:   aggsCopy,
+		Upstream:     upstream,
+		Downstream:   downstream,
+		Packages:     pkgs,
+	}
+
+	s.renderPage(w, "bc_detail.html", data)
+}
+
+// handleBCGraph serves GET /api/bc/graph — the Cytoscape JSON for the
+// bounded context graph. Nodes represent bounded contexts; edges
+// represent upstream/downstream relationships.
+func (s *Server) handleBCGraph(w nethttp.ResponseWriter, r *nethttp.Request) {
+	snap := s.state.Snapshot()
+	if snap.Overlay == nil {
+		writeJSON(w, graphPayload{
+			Meta:  graphMeta{View: "bc-map", Layout: "elk"},
+			Nodes: []graphNode{},
+			Edges: []graphEdge{},
+		})
+		return
+	}
+	payload := buildBCGraph(snap.Overlay)
+	writeJSON(w, payload)
+}
+
+// buildBCGraph produces the Cytoscape payload for /api/bc/graph.
+// Each bounded context becomes a node; upstream relationships become
+// directed edges. The function avoids duplicate edges by only emitting
+// an edge when the source is alphabetically less than the target, then
+// relying on the upstream/downstream labelling for direction.
+func buildBCGraph(cfg *overlay.Config) graphPayload {
+	out := graphPayload{
+		Meta:  graphMeta{View: "bc-map", Layout: "elk"},
+		Nodes: make([]graphNode, 0, len(cfg.BoundedContexts)),
+		Edges: make([]graphEdge, 0),
+	}
+
+	// Sorted names for stable output.
+	names := make([]string, 0, len(cfg.BoundedContexts))
+	for name := range cfg.BoundedContexts {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		bc := cfg.BoundedContexts[name]
+		label := name
+		if bc.Description != "" {
+			label = name + "\n" + bc.Description
+		}
+		out.Nodes = append(out.Nodes, graphNode{
+			ID:    "bc:" + name,
+			Label: label,
+			Kind:  "bc",
+		})
+	}
+
+	// Emit edges only from the upstream side to avoid duplicates.
+	seen := make(map[string]struct{})
+	for _, name := range names {
+		bc := cfg.BoundedContexts[name]
+		for _, up := range bc.Upstream {
+			if _, ok := cfg.BoundedContexts[up]; !ok {
+				continue
+			}
+			edgeID := "bc:" + up + "->bc:" + name
+			reverseID := "bc:" + name + "->bc:" + up
+			if _, exists := seen[edgeID]; exists {
+				continue
+			}
+			if _, exists := seen[reverseID]; exists {
+				continue
+			}
+			seen[edgeID] = struct{}{}
+			out.Edges = append(out.Edges, graphEdge{
+				Source: "bc:" + up,
+				Target: "bc:" + name,
+				Kind:   "upstream",
+			})
+		}
+	}
+
+	return out
+}
+
+// buildBCSummaries returns a sorted list of summary views for all BCs.
+func buildBCSummaries(bcs map[string]overlay.BoundedContext, packages []domain.PackageModel) []bcSummaryView {
+	out := make([]bcSummaryView, 0, len(bcs))
+	for name, bc := range bcs {
+		pkgs := packagesInBC(name, bc.Aggregates, packages)
+		out = append(out, bcSummaryView{
+			Name:         name,
+			Description:  bc.Description,
+			Relationship: bc.Relationship,
+			AggCount:     len(bc.Aggregates),
+			PkgCount:     len(pkgs),
+			Href:         "/bc/" + name,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+// packagesInBC returns the packages whose Aggregate field is one of the
+// named aggregates in the bounded context.
+func packagesInBC(bcName string, aggregates []string, packages []domain.PackageModel) []domain.PackageModel {
+	if len(aggregates) == 0 {
+		return nil
+	}
+	in := make(map[string]struct{}, len(aggregates))
+	for _, a := range aggregates {
+		in[a] = struct{}{}
+	}
+	var out []domain.PackageModel
+	for _, p := range packages {
+		if _, ok := in[p.Aggregate]; ok {
+			out = append(out, p)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Path < out[j].Path })
+	return out
+}

--- a/internal/adapter/http/bc_test.go
+++ b/internal/adapter/http/bc_test.go
@@ -1,0 +1,346 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	nethttp "net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kgatilin/archai/internal/domain"
+	"github.com/kgatilin/archai/internal/overlay"
+	"github.com/kgatilin/archai/internal/serve"
+)
+
+// sampleBCOverlay returns an overlay with two bounded contexts sharing an
+// aggregate, for use in unit tests.
+func sampleBCOverlay() *overlay.Config {
+	return &overlay.Config{
+		Module: "example.com/app",
+		Aggregates: map[string]overlay.Aggregate{
+			"core":  {Root: "example.com/app/internal/domain.Order"},
+			"svc":   {Root: "example.com/app/internal/service.Service"},
+			"infra": {Root: "example.com/app/internal/adapter.Adapter"},
+		},
+		BoundedContexts: map[string]overlay.BoundedContext{
+			"core_ctx": {
+				Description: "Core domain",
+				Aggregates:  []string{"core", "svc"},
+			},
+			"infra_ctx": {
+				Description: "Infrastructure",
+				Aggregates:  []string{"infra"},
+				Upstream:    []string{"core_ctx"},
+			},
+		},
+	}
+}
+
+// sampleBCPackages returns packages that match the globs in sampleBCOverlay.
+func sampleBCPackages() []domain.PackageModel {
+	return []domain.PackageModel{
+		{Path: "internal/domain/order", Aggregate: "core"},
+		{Path: "internal/service/order", Aggregate: "svc"},
+		{Path: "internal/adapter/yaml", Aggregate: "infra"},
+		{Path: "internal/adapter/http", Aggregate: "infra"},
+	}
+}
+
+// --- unit tests for buildBCGraph -----------------------------------------
+
+func TestBuildBCGraph_NodesAndEdges(t *testing.T) {
+	cfg := sampleBCOverlay()
+	payload := buildBCGraph(cfg)
+	if payload.Meta.View != "bc-map" {
+		t.Errorf("meta.view = %q, want bc-map", payload.Meta.View)
+	}
+	if payload.Meta.Layout != "elk" {
+		t.Errorf("meta.layout = %q, want elk", payload.Meta.Layout)
+	}
+
+	// Both BCs must appear as nodes.
+	nodeIDs := map[string]bool{}
+	for _, n := range payload.Nodes {
+		nodeIDs[n.ID] = true
+		if n.Kind != "bc" {
+			t.Errorf("node %q: want kind=bc, got %q", n.ID, n.Kind)
+		}
+	}
+	for _, want := range []string{"bc:core_ctx", "bc:infra_ctx"} {
+		if !nodeIDs[want] {
+			t.Errorf("missing node %q; nodes: %v", want, nodeIDs)
+		}
+	}
+
+	// Must have exactly one upstream edge: core_ctx -> infra_ctx.
+	if len(payload.Edges) != 1 {
+		t.Fatalf("expected 1 edge, got %d: %+v", len(payload.Edges), payload.Edges)
+	}
+	e := payload.Edges[0]
+	if e.Source != "bc:core_ctx" || e.Target != "bc:infra_ctx" {
+		t.Errorf("edge: got %s -> %s, want bc:core_ctx -> bc:infra_ctx", e.Source, e.Target)
+	}
+	if e.Kind != "upstream" {
+		t.Errorf("edge kind = %q, want upstream", e.Kind)
+	}
+}
+
+func TestBuildBCGraph_NoDuplicateEdges(t *testing.T) {
+	// Give both BCs mutual upstream/downstream declarations and verify
+	// the deduplication logic only emits one edge.
+	cfg := &overlay.Config{
+		Module: "example.com/app",
+		BoundedContexts: map[string]overlay.BoundedContext{
+			"a": {Upstream: []string{"b"}},
+			"b": {Upstream: []string{"a"}},
+		},
+	}
+	payload := buildBCGraph(cfg)
+	if len(payload.Edges) > 2 {
+		t.Errorf("expected at most 2 edges (one per direction), got %d", len(payload.Edges))
+	}
+}
+
+// --- unit tests for buildBCSummaries -------------------------------------
+
+func TestBuildBCSummaries_CountsAndLinks(t *testing.T) {
+	cfg := sampleBCOverlay()
+	pkgs := sampleBCPackages()
+	summaries := buildBCSummaries(cfg.BoundedContexts, pkgs)
+
+	if len(summaries) != 2 {
+		t.Fatalf("expected 2 summaries, got %d", len(summaries))
+	}
+	// Sorted alphabetically: core_ctx, infra_ctx.
+	if summaries[0].Name != "core_ctx" || summaries[1].Name != "infra_ctx" {
+		t.Errorf("unexpected order: %v, %v", summaries[0].Name, summaries[1].Name)
+	}
+
+	byName := map[string]bcSummaryView{}
+	for _, s := range summaries {
+		byName[s.Name] = s
+	}
+
+	core := byName["core_ctx"]
+	if core.AggCount != 2 {
+		t.Errorf("core_ctx: want 2 aggs, got %d", core.AggCount)
+	}
+	if core.PkgCount != 2 {
+		t.Errorf("core_ctx: want 2 pkgs, got %d", core.PkgCount)
+	}
+	if core.Href != "/bc/core_ctx" {
+		t.Errorf("core_ctx href = %q, want /bc/core_ctx", core.Href)
+	}
+
+	infra := byName["infra_ctx"]
+	if infra.PkgCount != 2 {
+		t.Errorf("infra_ctx: want 2 pkgs, got %d", infra.PkgCount)
+	}
+}
+
+// --- unit tests for packagesInBC -----------------------------------------
+
+func TestPackagesInBC_FiltersCorrectly(t *testing.T) {
+	pkgs := sampleBCPackages()
+	got := packagesInBC("core_ctx", []string{"core", "svc"}, pkgs)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 packages, got %d: %+v", len(got), got)
+	}
+	paths := map[string]bool{}
+	for _, p := range got {
+		paths[p.Path] = true
+	}
+	for _, want := range []string{"internal/domain/order", "internal/service/order"} {
+		if !paths[want] {
+			t.Errorf("missing package %q", want)
+		}
+	}
+}
+
+func TestPackagesInBC_EmptyAggregatesReturnsNil(t *testing.T) {
+	pkgs := sampleBCPackages()
+	got := packagesInBC("none", []string{}, pkgs)
+	if got != nil {
+		t.Errorf("expected nil, got %v", got)
+	}
+}
+
+func TestPackagesInBC_SortedByPath(t *testing.T) {
+	pkgs := []domain.PackageModel{
+		{Path: "z/pkg", Aggregate: "a"},
+		{Path: "a/pkg", Aggregate: "a"},
+		{Path: "m/pkg", Aggregate: "a"},
+	}
+	got := packagesInBC("bc", []string{"a"}, pkgs)
+	if len(got) != 3 {
+		t.Fatalf("expected 3 packages, got %d", len(got))
+	}
+	if got[0].Path != "a/pkg" || got[1].Path != "m/pkg" || got[2].Path != "z/pkg" {
+		t.Errorf("unexpected order: %v", got)
+	}
+}
+
+// --- HTTP handler tests --------------------------------------------------
+
+// newBCFixtureServer builds an httptest.Server with an overlay that
+// includes a bounded_contexts block so the /bc routes have data.
+func newBCFixtureServer(t *testing.T) (*httptest.Server, *serve.State) {
+	t.Helper()
+	root := t.TempDir()
+
+	writeFile := func(path, content string) {
+		t.Helper()
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+
+	writeFile(filepath.Join(root, "go.mod"), "module example.com/fixture\n\ngo 1.21\n")
+	writeFile(filepath.Join(root, "internal", "domain", "thing.go"),
+		"package domain\n\ntype Thing struct{}\n")
+	writeFile(filepath.Join(root, "archai.yaml"), `module: example.com/fixture
+layers:
+  domain:
+    - "internal/domain/..."
+layer_rules:
+  domain: []
+aggregates:
+  core:
+    root: "example.com/fixture/internal/domain.Thing"
+bounded_contexts:
+  core_ctx:
+    description: "Core domain"
+    aggregates:
+      - core
+  secondary_ctx:
+    description: "Secondary"
+    aggregates: []
+    upstream:
+      - core_ctx
+`)
+
+	state := serve.NewState(root)
+	if err := state.Load(context.Background()); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	srv, err := NewServer(state)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	mux := nethttp.NewServeMux()
+	srv.routes(mux)
+	return httptest.NewServer(mux), state
+}
+
+func TestAPIBCGraph_ReturnsJSONPayload(t *testing.T) {
+	ts, _ := newBCFixtureServer(t)
+	defer ts.Close()
+
+	resp, err := ts.Client().Get(ts.URL + "/api/bc/graph")
+	if err != nil {
+		t.Fatalf("GET /api/bc/graph: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != nethttp.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, body=%s", resp.StatusCode, string(b))
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Errorf("Content-Type = %q, want application/json*", ct)
+	}
+	var p graphPayload
+	if err := json.NewDecoder(resp.Body).Decode(&p); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if p.Meta.View != "bc-map" {
+		t.Errorf("meta.view = %q, want bc-map", p.Meta.View)
+	}
+	if len(p.Nodes) < 2 {
+		t.Errorf("expected at least 2 nodes (one per BC), got %d", len(p.Nodes))
+	}
+}
+
+func TestAPIBCGraph_NoOverlayReturnsEmptyPayload(t *testing.T) {
+	// newFixtureServer has no bounded_contexts block.
+	ts, _ := newFixtureServer(t)
+	defer ts.Close()
+
+	resp, err := ts.Client().Get(ts.URL + "/api/bc/graph")
+	if err != nil {
+		t.Fatalf("GET /api/bc/graph: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != nethttp.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, body=%s", resp.StatusCode, string(b))
+	}
+	var p graphPayload
+	if err := json.NewDecoder(resp.Body).Decode(&p); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(p.Nodes) != 0 {
+		t.Errorf("expected 0 nodes for overlay without BCs, got %d", len(p.Nodes))
+	}
+	if len(p.Edges) != 0 {
+		t.Errorf("expected 0 edges, got %d", len(p.Edges))
+	}
+}
+
+func TestBCList_RendersPage(t *testing.T) {
+	ts, _ := newBCFixtureServer(t)
+	defer ts.Close()
+
+	resp, err := ts.Client().Get(ts.URL + "/bc")
+	if err != nil {
+		t.Fatalf("GET /bc: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != nethttp.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, body=%s", resp.StatusCode, string(b))
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "core_ctx") {
+		t.Errorf("expected BC name in response body; got %q", string(body)[:200])
+	}
+}
+
+func TestBCDetail_RendersPage(t *testing.T) {
+	ts, _ := newBCFixtureServer(t)
+	defer ts.Close()
+
+	resp, err := ts.Client().Get(ts.URL + "/bc/core_ctx")
+	if err != nil {
+		t.Fatalf("GET /bc/core_ctx: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != nethttp.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, body=%s", resp.StatusCode, string(b))
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "core_ctx") {
+		t.Errorf("expected BC name in detail page; got body=%q", string(body)[:200])
+	}
+}
+
+func TestBCDetail_NotFoundReturns404(t *testing.T) {
+	ts, _ := newBCFixtureServer(t)
+	defer ts.Close()
+
+	resp, err := ts.Client().Get(ts.URL + "/bc/ghost_bc")
+	if err != nil {
+		t.Fatalf("GET /bc/ghost_bc: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != nethttp.StatusNotFound {
+		t.Errorf("status = %d, want 404", resp.StatusCode)
+	}
+}

--- a/internal/adapter/http/dashboard.go
+++ b/internal/adapter/http/dashboard.go
@@ -42,6 +42,11 @@ type dashboardData struct {
 	// D2→SVG render; M8 (#46) moved it to the browser.
 	HasLayerMap bool
 
+	// HasBoundedContexts is true when the overlay declares at least one
+	// bounded context; the dashboard then renders a Domain model card.
+	HasBoundedContexts bool
+	BCCount            int
+
 	// PluginMain holds plugin-contributed widgets for the dashboard's
 	// main slot. PluginScripts is the de-duplicated list of <script
 	// defer> tags injected once per plugin.
@@ -105,6 +110,12 @@ func (s *Server) handleDashboard(w nethttp.ResponseWriter, r *nethttp.Request) {
 	// defines layers; the browser fetches /api/layers/mini to hydrate it.
 	if snap.Overlay != nil && len(snap.Overlay.Layers) > 0 {
 		data.HasLayerMap = true
+	}
+
+	// Domain model card — show BC count when the overlay declares BCs.
+	if snap.Overlay != nil && len(snap.Overlay.BoundedContexts) > 0 {
+		data.HasBoundedContexts = true
+		data.BCCount = len(snap.Overlay.BoundedContexts)
 	}
 
 	// M13: plugin-contributed dashboard widgets.

--- a/internal/adapter/http/handlers.go
+++ b/internal/adapter/http/handlers.go
@@ -86,6 +86,7 @@ var navTemplate = []navItem{
 	{Label: "Layers", Href: "/layers"},
 	{Label: "Packages", Href: "/packages"},
 	{Label: "Configs", Href: "/configs"},
+	{Label: "Domain", Href: "/bc"},
 	{Label: "Targets", Href: "/targets"},
 	{Label: "Diff", Href: "/diff"},
 	{Label: "Search", Href: "/search"},
@@ -166,6 +167,8 @@ func (s *Server) routesContent(mux *nethttp.ServeMux) {
 	// under /api/ so the browser UI and the machine API live side by
 	// side on one listener.
 	s.registerAPIRoutes(mux)
+	// M14: bounded context list + detail + graph routes.
+	s.registerBCRoutes(mux)
 	// In multi mode, the root of a worktree ("/w/{name}/") is served
 	// by the content mux at "/" after dispatchWorktree rewrites the
 	// URL. In single mode the root is registered directly by routes()

--- a/internal/adapter/http/package_detail_data.go
+++ b/internal/adapter/http/package_detail_data.go
@@ -247,6 +247,11 @@ type packageDetailData struct {
 	// Configs
 	ConfigTypes []configTypeView
 
+	// BCName is the bounded context this package belongs to (via its
+	// aggregate assignment). Empty when the package has no aggregate or
+	// the aggregate is not part of any declared bounded context.
+	BCName string
+
 	// Partial marks that we're rendering only the tab fragment (for
 	// HTMX swaps into #pkg-tab-content).
 	Partial bool
@@ -268,6 +273,7 @@ func buildPackageDetail(
 		Tabs:        buildTabs(active),
 		Stereotypes: collectStereotypes(pkg),
 		LayerBadge:  pkg.Layer,
+		BCName:      findBCForPackage(pkg, cfg),
 	}
 
 	switch active {
@@ -471,6 +477,23 @@ func containsString(xs []string, s string) bool {
 		}
 	}
 	return false
+}
+
+// findBCForPackage returns the bounded context name whose aggregates
+// include the aggregate assigned to pkg. Returns "" when the package
+// has no aggregate or the aggregate is not part of any declared context.
+func findBCForPackage(pkg domain.PackageModel, cfg *overlay.Config) string {
+	if cfg == nil || pkg.Aggregate == "" {
+		return ""
+	}
+	for name, bc := range cfg.BoundedContexts {
+		for _, agg := range bc.Aggregates {
+			if agg == pkg.Aggregate {
+				return name
+			}
+		}
+	}
+	return ""
 }
 
 // buildConfigTypes walks the overlay config list and picks out entries

--- a/internal/adapter/http/templates/bc_detail.html
+++ b/internal/adapter/http/templates/bc_detail.html
@@ -1,0 +1,79 @@
+{{define "content"}}
+<nav class="crumbs">
+    <a href="/bc">Domain</a>
+    <span class="sep">/</span>
+    <span>{{.Name}}</span>
+</nav>
+
+<h1>{{.Name}}</h1>
+
+{{if .Description}}<p class="lede">{{.Description}}</p>{{end}}
+{{if .Relationship}}<p><span class="badge badge-stereo">{{.Relationship}}</span></p>{{end}}
+
+<div class="pkg-tabs" role="tablist">
+    <a class="pkg-tab active" role="tab">Overview</a>
+</div>
+
+<section class="bc-detail-grid">
+    {{if or .Upstream .Downstream}}
+    <div class="card">
+        <h2>Context relationships</h2>
+        {{if .Upstream}}
+        <div class="bc-rel-section">
+            <h3>Upstream</h3>
+            <ul class="dep-list">
+                {{range .Upstream}}
+                <li><a href="{{.Href}}" class="dep-pkg mono">{{.Name}}</a></li>
+                {{end}}
+            </ul>
+        </div>
+        {{end}}
+        {{if .Downstream}}
+        <div class="bc-rel-section">
+            <h3>Downstream</h3>
+            <ul class="dep-list">
+                {{range .Downstream}}
+                <li><a href="{{.Href}}" class="dep-pkg mono">{{.Name}}</a></li>
+                {{end}}
+            </ul>
+        </div>
+        {{end}}
+    </div>
+    {{end}}
+
+    {{if .Aggregates}}
+    <div class="card">
+        <h2>Aggregates</h2>
+        <ul class="stat-list">
+            {{range .Aggregates}}
+            <li><span class="badge badge-agg">{{.}}</span></li>
+            {{end}}
+        </ul>
+    </div>
+    {{end}}
+</section>
+
+{{if .Packages}}
+<section class="card">
+    <h2>Packages</h2>
+    <table class="diff-table">
+        <thead>
+            <tr>
+                <th>Path</th>
+                <th>Aggregate</th>
+                <th>Layer</th>
+            </tr>
+        </thead>
+        <tbody>
+            {{range .Packages}}
+            <tr>
+                <td><a href="/packages/{{.Path}}" class="mono">{{.Path}}</a></td>
+                <td>{{.Aggregate}}</td>
+                <td>{{if .Layer}}<span class="badge badge-layer">{{.Layer}}</span>{{end}}</td>
+            </tr>
+            {{end}}
+        </tbody>
+    </table>
+</section>
+{{end}}
+{{end}}

--- a/internal/adapter/http/templates/bc_list.html
+++ b/internal/adapter/http/templates/bc_list.html
@@ -1,0 +1,52 @@
+{{define "content"}}
+<h1>Domain</h1>
+<p class="lede">Bounded contexts declared in <code>archai.yaml</code>.</p>
+
+{{if not .HasOverlay}}
+    <div class="coming-soon">
+        <div class="tag">no overlay</div>
+        <p>Load an <code>archai.yaml</code> with a <code>bounded_contexts:</code> block to populate this catalog.</p>
+    </div>
+{{else}}
+    <section class="card layer-preview">
+        <h2>Context map</h2>
+        <div class="cy-graph bc-map"
+             data-api="/api/bc/graph"
+             data-view="bc-map"
+             data-layout="elk"
+             data-height="320"
+             data-interactive="true"></div>
+        <script src="/assets/vendor/dagre.min.js" defer></script>
+        <script src="/assets/vendor/cytoscape.min.js" defer></script>
+        <script src="/assets/vendor/cytoscape-dagre.js" defer></script>
+        <script src="/assets/vendor/elk.bundled.js" defer></script>
+        <script src="/assets/vendor/cytoscape-elk.js" defer></script>
+        <script src="/assets/graph.js" defer></script>
+    </section>
+
+    <section>
+        <table class="diff-table">
+            <thead>
+                <tr>
+                    <th>Name</th>
+                    <th>Description</th>
+                    <th>Relationship</th>
+                    <th>Aggregates</th>
+                    <th>Packages</th>
+                </tr>
+            </thead>
+            <tbody>
+                {{range .BCs}}
+                <tr>
+                    <td><a href="{{.Href}}" class="mono">{{.Name}}</a></td>
+                    <td>{{.Description}}</td>
+                    <td>{{if .Relationship}}<span class="badge badge-stereo">{{.Relationship}}</span>{{end}}</td>
+                    <td class="mono">{{.AggCount}}</td>
+                    <td class="mono">{{.PkgCount}}</td>
+                </tr>
+                {{end}}
+            </tbody>
+        </table>
+    </section>
+{{end}}
+{{end}}

--- a/internal/adapter/http/templates/index.html
+++ b/internal/adapter/http/templates/index.html
@@ -44,6 +44,16 @@
             <li><span class="stat-num">{{.InterfaceCount}}</span> interfaces</li>
         </ul>
     </div>
+
+    {{if .HasBoundedContexts}}
+    <div class="card">
+        <h2>Domain</h2>
+        <ul class="stat-list">
+            <li><span class="stat-num">{{.BCCount}}</span> bounded contexts</li>
+        </ul>
+        <a href="/bc" class="card-link">View Domain model →</a>
+    </div>
+    {{end}}
 </section>
 
 <section class="card layer-preview">

--- a/internal/adapter/http/templates/package_detail.html
+++ b/internal/adapter/http/templates/package_detail.html
@@ -11,6 +11,7 @@
 <div class="pkg-badges">
     {{if .LayerBadge}}<span class="badge badge-layer">{{.LayerBadge}}</span>{{end}}
     {{if .Pkg.Aggregate}}<span class="badge badge-agg">aggregate: {{.Pkg.Aggregate}}</span>{{end}}
+    {{if .BCName}}<span class="badge badge-bc">bc: <a href="/bc/{{.BCName}}">{{.BCName}}</a></span>{{end}}
     {{range .Stereotypes}}<span class="badge badge-stereo">&lt;&lt;{{.}}&gt;&gt;</span>{{end}}
 </div>
 
@@ -98,6 +99,7 @@
         <dt>Name</dt><dd><code>{{.Pkg.Name}}</code></dd>
         {{if .LayerBadge}}<dt>Layer</dt><dd>{{.LayerBadge}}</dd>{{end}}
         {{if .Pkg.Aggregate}}<dt>Aggregate</dt><dd>{{.Pkg.Aggregate}}</dd>{{end}}
+        {{if .BCName}}<dt>Bounded Context</dt><dd><a href="/bc/{{.BCName}}">{{.BCName}}</a></dd>{{end}}
         <dt>Files</dt>
         <dd>
             {{range .Pkg.SourceFiles}}<code>{{.}}</code> {{end}}

--- a/internal/adapter/mcp/stdio_test.go
+++ b/internal/adapter/mcp/stdio_test.go
@@ -87,8 +87,8 @@ func TestStdio_ToolsList(t *testing.T) {
 	if err := json.Unmarshal(payload, &wrapper); err != nil {
 		t.Fatalf("unmarshal tools: %v", err)
 	}
-	if len(wrapper.Tools) != 9 {
-		t.Fatalf("expected 9 tools, got %d", len(wrapper.Tools))
+	if len(wrapper.Tools) != 11 {
+		t.Fatalf("expected 11 tools, got %d", len(wrapper.Tools))
 	}
 }
 

--- a/internal/adapter/mcp/tools.go
+++ b/internal/adapter/mcp/tools.go
@@ -99,6 +99,16 @@ type ValidateResult struct {
 	Violations []diff.Change `json:"violations"`
 }
 
+// BCSummary is the minimal record returned by list_bounded_contexts.
+type BCSummary struct {
+	Name         string   `json:"name"`
+	Description  string   `json:"description,omitempty"`
+	Relationship string   `json:"relationship,omitempty"`
+	Aggregates   []string `json:"aggregates"`
+	Upstream     []string `json:"upstream,omitempty"`
+	Downstream   []string `json:"downstream,omitempty"`
+}
+
 // ToolDefinitions returns the built-in tools we advertise plus every
 // plugin tool registered via SetPluginTools (M13). Plugin tools are
 // surfaced with the canonical "plugin.<plugin-name>.<tool-name>"
@@ -245,6 +255,28 @@ func builtinToolDefinitions() []ToolDefinition {
 				},
 			},
 		},
+		{
+			Name:        "list_bounded_contexts",
+			Description: "List all bounded contexts declared in the archai.yaml overlay with their aggregates and context-map relationships.",
+			InputSchema: map[string]any{
+				"type":       "object",
+				"properties": map[string]any{},
+			},
+		},
+		{
+			Name:        "get_bounded_context",
+			Description: "Return the full detail of a single bounded context identified by name, including aggregates, upstream/downstream peers, and member packages.",
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"name": map[string]any{
+						"type":        "string",
+						"description": "Bounded context name as declared in archai.yaml.",
+					},
+				},
+				"required": []string{"name"},
+			},
+		},
 	}
 }
 
@@ -273,6 +305,10 @@ func Dispatch(state *serve.State, name string, rawArgs json.RawMessage) (ToolRes
 		return handleApplyDiff(state, rawArgs)
 	case "validate":
 		return handleValidate(state, rawArgs)
+	case "list_bounded_contexts":
+		return handleListBoundedContexts(state)
+	case "get_bounded_context":
+		return handleGetBoundedContext(state, rawArgs)
 	}
 	if strings.HasPrefix(name, "plugin.") {
 		return dispatchPluginTool(name, rawArgs)
@@ -622,6 +658,107 @@ func handleValidate(state *serve.State, rawArgs json.RawMessage) (ToolResult, *R
 		res.Violations = d.Changes
 	}
 	return textResult(res)
+}
+
+// handleListBoundedContexts returns the summary of every bounded context
+// declared in the overlay. When no overlay is loaded (or no BCs are
+// declared) an empty slice is returned — not an error — so agents don't
+// have to special-case missing overlays.
+func handleListBoundedContexts(state *serve.State) (ToolResult, *RPCError) {
+	snap := snapshotOrEmpty(state)
+	if snap.Overlay == nil || len(snap.Overlay.BoundedContexts) == 0 {
+		return textResult([]BCSummary{})
+	}
+
+	names := make([]string, 0, len(snap.Overlay.BoundedContexts))
+	for n := range snap.Overlay.BoundedContexts {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+
+	out := make([]BCSummary, 0, len(names))
+	for _, name := range names {
+		bc := snap.Overlay.BoundedContexts[name]
+		aggs := bc.Aggregates
+		if aggs == nil {
+			aggs = []string{}
+		}
+		out = append(out, BCSummary{
+			Name:         name,
+			Description:  bc.Description,
+			Relationship: bc.Relationship,
+			Aggregates:   aggs,
+			Upstream:     bc.Upstream,
+			Downstream:   bc.Downstream,
+		})
+	}
+	return textResult(out)
+}
+
+// getBCArgs is the input schema for the get_bounded_context tool.
+type getBCArgs struct {
+	Name string `json:"name"`
+}
+
+// bcDetail extends BCSummary with the member package paths.
+type bcDetail struct {
+	BCSummary
+	Packages []string `json:"packages"`
+}
+
+// handleGetBoundedContext returns the full detail for a single bounded
+// context, including the paths of all member packages (those whose
+// Aggregate field matches one of the BC's declared aggregates).
+func handleGetBoundedContext(state *serve.State, rawArgs json.RawMessage) (ToolResult, *RPCError) {
+	var args getBCArgs
+	if rpcErr := unmarshalArgs(rawArgs, &args); rpcErr != nil {
+		return ToolResult{}, rpcErr
+	}
+	if args.Name == "" {
+		return errorResult("missing required argument: name"), nil
+	}
+
+	snap := snapshotOrEmpty(state)
+	if snap.Overlay == nil {
+		return errorResult(fmt.Sprintf("bounded context %q not found: no overlay loaded", args.Name)), nil
+	}
+	bc, ok := snap.Overlay.BoundedContexts[args.Name]
+	if !ok {
+		return errorResult(fmt.Sprintf("bounded context %q not found", args.Name)), nil
+	}
+
+	// Collect member package paths.
+	aggSet := make(map[string]struct{}, len(bc.Aggregates))
+	for _, a := range bc.Aggregates {
+		aggSet[a] = struct{}{}
+	}
+	var pkgPaths []string
+	for _, p := range snap.Packages {
+		if _, ok := aggSet[p.Aggregate]; ok {
+			pkgPaths = append(pkgPaths, p.Path)
+		}
+	}
+	sort.Strings(pkgPaths)
+	if pkgPaths == nil {
+		pkgPaths = []string{}
+	}
+
+	aggs := bc.Aggregates
+	if aggs == nil {
+		aggs = []string{}
+	}
+	detail := bcDetail{
+		BCSummary: BCSummary{
+			Name:         args.Name,
+			Description:  bc.Description,
+			Relationship: bc.Relationship,
+			Aggregates:   aggs,
+			Upstream:     bc.Upstream,
+			Downstream:   bc.Downstream,
+		},
+		Packages: pkgPaths,
+	}
+	return textResult(detail)
 }
 
 // --- shared helpers ---

--- a/internal/adapter/mcp/tools_test.go
+++ b/internal/adapter/mcp/tools_test.go
@@ -52,8 +52,8 @@ func mustWrite(t *testing.T, path, body string) {
 
 func TestToolDefinitions(t *testing.T) {
 	defs := ToolDefinitions()
-	if len(defs) != 9 {
-		t.Fatalf("expected 9 tool definitions, got %d", len(defs))
+	if len(defs) != 11 {
+		t.Fatalf("expected 11 tool definitions, got %d", len(defs))
 	}
 	names := map[string]bool{}
 	for _, d := range defs {
@@ -65,7 +65,7 @@ func TestToolDefinitions(t *testing.T) {
 			t.Errorf("tool %q missing input schema", d.Name)
 		}
 	}
-	for _, want := range []string{"extract", "list_packages", "get_package", "lock_target", "list_targets", "set_current_target", "diff", "apply_diff", "validate"} {
+	for _, want := range []string{"extract", "list_packages", "get_package", "lock_target", "list_targets", "set_current_target", "diff", "apply_diff", "validate", "list_bounded_contexts", "get_bounded_context"} {
 		if !names[want] {
 			t.Errorf("missing tool definition for %q", want)
 		}
@@ -219,5 +219,126 @@ func TestGetPackage_MissingPath(t *testing.T) {
 	}
 	if !res.IsError {
 		t.Fatal("expected IsError result for missing path")
+	}
+}
+
+// loadFakeStateWithOverlay extends loadFakeState with a minimal archai.yaml
+// so bounded-context tools have something to query.
+func loadFakeStateWithOverlay(t *testing.T) *serve.State {
+	t.Helper()
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "go.mod"), "module fake.test\n\ngo 1.21\n")
+	mustWrite(t, filepath.Join(dir, "alpha", "alpha.go"), `package alpha
+type Service interface{ Do() }
+`)
+	mustWrite(t, filepath.Join(dir, "beta", "beta.go"), `package beta
+type Thing struct{ Name string }
+`)
+	const overlayYAML = `module: fake.test
+aggregates:
+  core:
+    root: "fake.test/alpha.Service"
+  infra:
+    root: "fake.test/beta.Thing"
+bounded_contexts:
+  main:
+    description: "Main context"
+    aggregates:
+      - core
+      - infra
+  secondary:
+    description: "Secondary context"
+    aggregates:
+      - infra
+    upstream:
+      - main
+`
+	mustWrite(t, filepath.Join(dir, "archai.yaml"), overlayYAML)
+	state := serve.NewState(dir)
+	if err := state.Load(context.Background()); err != nil {
+		t.Fatalf("load state: %v", err)
+	}
+	return state
+}
+
+func TestListBoundedContexts_EmptyStateReturnsEmptyArray(t *testing.T) {
+	res, rpcErr := Dispatch(nil, "list_bounded_contexts", nil)
+	if rpcErr != nil {
+		t.Fatalf("unexpected RPC error: %v", rpcErr)
+	}
+	if !strings.HasPrefix(strings.TrimSpace(res.Content[0].Text), "[") {
+		t.Errorf("expected JSON array, got %q", res.Content[0].Text)
+	}
+}
+
+func TestListBoundedContexts_ReturnsSortedList(t *testing.T) {
+	state := loadFakeStateWithOverlay(t)
+	res, rpcErr := Dispatch(state, "list_bounded_contexts", nil)
+	if rpcErr != nil {
+		t.Fatalf("unexpected RPC error: %v", rpcErr)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected error result: %+v", res)
+	}
+	var summaries []BCSummary
+	if err := json.Unmarshal([]byte(res.Content[0].Text), &summaries); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(summaries) != 2 {
+		t.Fatalf("expected 2 BCs, got %d: %+v", len(summaries), summaries)
+	}
+	// Sorted alphabetically: main, secondary.
+	if summaries[0].Name != "main" || summaries[1].Name != "secondary" {
+		t.Errorf("unexpected order: %v, %v", summaries[0].Name, summaries[1].Name)
+	}
+	if summaries[0].Description != "Main context" {
+		t.Errorf("wrong description: %q", summaries[0].Description)
+	}
+}
+
+func TestGetBoundedContext_Found(t *testing.T) {
+	state := loadFakeStateWithOverlay(t)
+	args := json.RawMessage(`{"name":"main"}`)
+	res, rpcErr := Dispatch(state, "get_bounded_context", args)
+	if rpcErr != nil {
+		t.Fatalf("unexpected RPC error: %v", rpcErr)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected error result: %+v", res)
+	}
+	var detail bcDetail
+	if err := json.Unmarshal([]byte(res.Content[0].Text), &detail); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if detail.Name != "main" {
+		t.Errorf("wrong name: %q", detail.Name)
+	}
+	if len(detail.Aggregates) != 2 {
+		t.Errorf("expected 2 aggregates, got %d", len(detail.Aggregates))
+	}
+}
+
+func TestGetBoundedContext_NotFound(t *testing.T) {
+	state := loadFakeStateWithOverlay(t)
+	args := json.RawMessage(`{"name":"ghost"}`)
+	res, rpcErr := Dispatch(state, "get_bounded_context", args)
+	if rpcErr != nil {
+		t.Fatalf("unexpected RPC error: %v", rpcErr)
+	}
+	if !res.IsError {
+		t.Fatal("expected IsError result for unknown BC")
+	}
+	if !strings.Contains(res.Content[0].Text, "ghost") {
+		t.Errorf("expected error text to mention BC name; got %q", res.Content[0].Text)
+	}
+}
+
+func TestGetBoundedContext_MissingName(t *testing.T) {
+	res, rpcErr := Dispatch(nil, "get_bounded_context", json.RawMessage(`{}`))
+	if rpcErr != nil {
+		t.Fatalf("unexpected RPC error: %v", rpcErr)
+	}
+	if !res.IsError {
+		t.Fatal("expected IsError result for missing name")
 	}
 }

--- a/internal/overlay/config.go
+++ b/internal/overlay/config.go
@@ -23,11 +23,12 @@ package overlay
 //   - Configs: fully-qualified type names to surface as configuration
 //     entry points.
 type Config struct {
-	Module     string               `yaml:"module"`
-	Layers     map[string][]string  `yaml:"layers"`
-	LayerRules map[string][]string  `yaml:"layer_rules"`
-	Aggregates map[string]Aggregate `yaml:"aggregates"`
-	Configs    []string             `yaml:"configs"`
+	Module          string                     `yaml:"module"`
+	Layers          map[string][]string        `yaml:"layers"`
+	LayerRules      map[string][]string        `yaml:"layer_rules"`
+	Aggregates      map[string]Aggregate       `yaml:"aggregates"`
+	Configs         []string                   `yaml:"configs"`
+	BoundedContexts map[string]BoundedContext  `yaml:"bounded_contexts,omitempty"`
 }
 
 // Aggregate describes a domain aggregate by its root type.
@@ -35,4 +36,35 @@ type Config struct {
 // "github.com/kgatilin/archai/internal/domain.PackageModel".
 type Aggregate struct {
 	Root string `yaml:"root"`
+}
+
+// BoundedContext groups one or more aggregates into a DDD-style
+// bounded context and (optionally) records its relationships with
+// other contexts.
+//
+// Field semantics:
+//   - Description: optional human-readable summary.
+//   - Aggregates: names of aggregates that belong to this context.
+//     Each must be defined in Config.Aggregates.
+//   - Upstream: names of bounded contexts this one depends on.
+//   - Downstream: names of bounded contexts that depend on this one.
+//   - Relationship: optional context-map relationship qualifier.
+//     Allowed values: "shared-kernel", "customer-supplier",
+//     "conformist", "acl", "open-host". Empty means unspecified.
+type BoundedContext struct {
+	Description  string   `yaml:"description,omitempty"`
+	Aggregates   []string `yaml:"aggregates,omitempty"`
+	Upstream     []string `yaml:"upstream,omitempty"`
+	Downstream   []string `yaml:"downstream,omitempty"`
+	Relationship string   `yaml:"relationship,omitempty"`
+}
+
+// BoundedContextRelationships is the closed set of allowed
+// relationship qualifiers for BoundedContext.Relationship.
+var BoundedContextRelationships = []string{
+	"shared-kernel",
+	"customer-supplier",
+	"conformist",
+	"acl",
+	"open-host",
 }

--- a/internal/overlay/validate.go
+++ b/internal/overlay/validate.go
@@ -107,7 +107,80 @@ func Validate(cfg *Config, goModPath string) error {
 		}
 	}
 
+	for _, name := range sortedKeys(cfg.BoundedContexts) {
+		bc := cfg.BoundedContexts[name]
+		if strings.TrimSpace(name) == "" {
+			errs = append(errs, errors.New("overlay: bounded_contexts: name must not be empty"))
+			continue
+		}
+		for _, aggName := range bc.Aggregates {
+			if strings.TrimSpace(aggName) == "" {
+				errs = append(errs, fmt.Errorf(
+					"overlay: bounded_contexts %q has empty aggregate reference", name))
+				continue
+			}
+			if _, ok := cfg.Aggregates[aggName]; !ok {
+				errs = append(errs, fmt.Errorf(
+					"overlay: bounded_contexts %q references unknown aggregate %q",
+					name, aggName))
+			}
+		}
+		for _, ref := range bc.Upstream {
+			if strings.TrimSpace(ref) == "" {
+				errs = append(errs, fmt.Errorf(
+					"overlay: bounded_contexts %q has empty upstream reference", name))
+				continue
+			}
+			if ref == name {
+				errs = append(errs, fmt.Errorf(
+					"overlay: bounded_contexts %q references itself as upstream", name))
+				continue
+			}
+			if _, ok := cfg.BoundedContexts[ref]; !ok {
+				errs = append(errs, fmt.Errorf(
+					"overlay: bounded_contexts %q upstream references unknown context %q",
+					name, ref))
+			}
+		}
+		for _, ref := range bc.Downstream {
+			if strings.TrimSpace(ref) == "" {
+				errs = append(errs, fmt.Errorf(
+					"overlay: bounded_contexts %q has empty downstream reference", name))
+				continue
+			}
+			if ref == name {
+				errs = append(errs, fmt.Errorf(
+					"overlay: bounded_contexts %q references itself as downstream", name))
+				continue
+			}
+			if _, ok := cfg.BoundedContexts[ref]; !ok {
+				errs = append(errs, fmt.Errorf(
+					"overlay: bounded_contexts %q downstream references unknown context %q",
+					name, ref))
+			}
+		}
+		if bc.Relationship != "" {
+			if !isAllowedRelationship(bc.Relationship) {
+				errs = append(errs, fmt.Errorf(
+					"overlay: bounded_contexts %q has unknown relationship %q (allowed: %s)",
+					name, bc.Relationship,
+					strings.Join(BoundedContextRelationships, ", ")))
+			}
+		}
+	}
+
 	return errors.Join(errs...)
+}
+
+// isAllowedRelationship reports whether r is in the closed set of
+// recognised context-map relationship qualifiers.
+func isAllowedRelationship(r string) bool {
+	for _, allowed := range BoundedContextRelationships {
+		if r == allowed {
+			return true
+		}
+	}
+	return false
 }
 
 // validateGlob checks a package glob for obvious syntactic problems.

--- a/internal/plugin/model.go
+++ b/internal/plugin/model.go
@@ -1,6 +1,8 @@
 package plugin
 
 import (
+	"sort"
+
 	"github.com/kgatilin/archai/internal/domain"
 	"github.com/kgatilin/archai/internal/overlay"
 )
@@ -66,12 +68,35 @@ type LayerRule struct {
 	AllowedLayers []string
 }
 
-// BoundedContext is reserved for a future overlay extension that
-// groups aggregates into DDD-style contexts. Empty in M12.
+// BoundedContext groups aggregates into a DDD-style context and
+// (optionally) records its context-map relationships with other
+// contexts. Populated from archai.yaml's bounded_contexts: map
+// (M14, issue #72).
 type BoundedContext struct {
-	Name        string
-	Aggregates  []string
+	// Name is the context identifier (map key in archai.yaml).
+	Name string
+
+	// Description is the optional human-readable summary.
 	Description string
+
+	// Aggregates lists the aggregate names that belong to this
+	// context. Each name resolves to an entry in Model.Aggregates.
+	Aggregates []string
+
+	// Upstream lists the bounded contexts this one consumes from
+	// (i.e. dependencies). Names refer to other entries in
+	// Model.BCs.
+	Upstream []string
+
+	// Downstream lists the bounded contexts that consume from this
+	// one. The loader normalises Upstream/Downstream so the graph
+	// is bidirectional and de-duplicated.
+	Downstream []string
+
+	// Relationship is an optional context-map relationship
+	// qualifier ("shared-kernel", "customer-supplier", "conformist",
+	// "acl", "open-host"). Empty when unspecified.
+	Relationship string
 }
 
 // Aggregate is one entry from archai.yaml's aggregates map.
@@ -137,7 +162,88 @@ func BuildModel(module string, pkgs []domain.PackageModel, cfg *overlay.Config) 
 		m.Configs = append(m.Configs, &ConfigType{FQTypeName: fq})
 	}
 
+	if len(cfg.BoundedContexts) > 0 {
+		m.BCs = buildBoundedContexts(cfg.BoundedContexts)
+	}
+
 	return m
+}
+
+// buildBoundedContexts converts the overlay map into the plugin.Model
+// view, normalising upstream/downstream into a bidirectional, de-duplicated
+// graph. For every "A upstream: [B]" the loader inserts a corresponding
+// "B downstream: [A]" so widgets can render the graph without re-walking
+// the inverse direction. Self-references and unknown contexts are dropped
+// here (Validate has already flagged them as errors); we still skip them
+// defensively so a partially valid model does not panic the UI.
+func buildBoundedContexts(src map[string]overlay.BoundedContext) []*BoundedContext {
+	// dedupe sets keyed by context name
+	upstream := make(map[string]map[string]struct{}, len(src))
+	downstream := make(map[string]map[string]struct{}, len(src))
+
+	for name, bc := range src {
+		if upstream[name] == nil {
+			upstream[name] = make(map[string]struct{})
+		}
+		if downstream[name] == nil {
+			downstream[name] = make(map[string]struct{})
+		}
+		for _, ref := range bc.Upstream {
+			if ref == "" || ref == name {
+				continue
+			}
+			if _, ok := src[ref]; !ok {
+				continue
+			}
+			upstream[name][ref] = struct{}{}
+			if downstream[ref] == nil {
+				downstream[ref] = make(map[string]struct{})
+			}
+			downstream[ref][name] = struct{}{}
+		}
+		for _, ref := range bc.Downstream {
+			if ref == "" || ref == name {
+				continue
+			}
+			if _, ok := src[ref]; !ok {
+				continue
+			}
+			downstream[name][ref] = struct{}{}
+			if upstream[ref] == nil {
+				upstream[ref] = make(map[string]struct{})
+			}
+			upstream[ref][name] = struct{}{}
+		}
+	}
+
+	out := make([]*BoundedContext, 0, len(src))
+	for name, bc := range src {
+		aggsCopy := make([]string, len(bc.Aggregates))
+		copy(aggsCopy, bc.Aggregates)
+
+		out = append(out, &BoundedContext{
+			Name:         name,
+			Description:  bc.Description,
+			Aggregates:   aggsCopy,
+			Upstream:     sortedSetKeys(upstream[name]),
+			Downstream:   sortedSetKeys(downstream[name]),
+			Relationship: bc.Relationship,
+		})
+	}
+	sortBoundedContexts(out)
+	return out
+}
+
+func sortedSetKeys(s map[string]struct{}) []string {
+	if len(s) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(s))
+	for k := range s {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
 }
 
 // FindPackage returns the PackageModel with the given module-relative
@@ -162,6 +268,76 @@ func (m *Model) PackagesInLayer(layer string) []*domain.PackageModel {
 	var out []*domain.PackageModel
 	for _, p := range m.Packages {
 		if p != nil && p.Layer == layer {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// FindBoundedContext returns the named bounded context, or nil when
+// no context with that name is declared.
+func (m *Model) FindBoundedContext(name string) *BoundedContext {
+	if m == nil || name == "" {
+		return nil
+	}
+	for _, bc := range m.BCs {
+		if bc != nil && bc.Name == name {
+			return bc
+		}
+	}
+	return nil
+}
+
+// BoundedContextForAggregate returns the bounded context that contains
+// the named aggregate, or nil when none does.
+func (m *Model) BoundedContextForAggregate(aggregate string) *BoundedContext {
+	if m == nil || aggregate == "" {
+		return nil
+	}
+	for _, bc := range m.BCs {
+		if bc == nil {
+			continue
+		}
+		for _, a := range bc.Aggregates {
+			if a == aggregate {
+				return bc
+			}
+		}
+	}
+	return nil
+}
+
+// BoundedContextForPackage returns the bounded context whose
+// aggregates include any aggregate assigned to the given package's
+// declared Aggregate name. Returns nil when the package has no
+// aggregate assigned or the aggregate is not part of any context.
+func (m *Model) BoundedContextForPackage(pkg *domain.PackageModel) *BoundedContext {
+	if m == nil || pkg == nil || pkg.Aggregate == "" {
+		return nil
+	}
+	return m.BoundedContextForAggregate(pkg.Aggregate)
+}
+
+// PackagesInBoundedContext returns the packages whose Aggregate is in
+// the named bounded context. Returns nil for unknown contexts.
+func (m *Model) PackagesInBoundedContext(bcName string) []*domain.PackageModel {
+	if m == nil {
+		return nil
+	}
+	bc := m.FindBoundedContext(bcName)
+	if bc == nil {
+		return nil
+	}
+	in := make(map[string]struct{}, len(bc.Aggregates))
+	for _, a := range bc.Aggregates {
+		in[a] = struct{}{}
+	}
+	var out []*domain.PackageModel
+	for _, p := range m.Packages {
+		if p == nil {
+			continue
+		}
+		if _, ok := in[p.Aggregate]; ok {
 			out = append(out, p)
 		}
 	}

--- a/internal/plugin/sort.go
+++ b/internal/plugin/sort.go
@@ -13,3 +13,7 @@ func sortLayerRules(xs []*LayerRule) {
 func sortAggregates(xs []*Aggregate) {
 	sort.Slice(xs, func(i, j int) bool { return xs[i].Name < xs[j].Name })
 }
+
+func sortBoundedContexts(xs []*BoundedContext) {
+	sort.Slice(xs, func(i, j int) bool { return xs[i].Name < xs[j].Name })
+}


### PR DESCRIPTION
## Summary

Implements issue #72 (M14: Bounded Contexts).

- **Overlay schema**: `BoundedContext` struct added to `overlay.Config` with `Description`, `Aggregates`, `Upstream`, `Downstream`, and `Relationship` fields; validation enforces aggregate references exist and relationship qualifiers are from the closed set
- **Plugin model**: `PluginModel` extended with `BoundedContexts` map and `BCSummary`/`BCDetail` types for plugin consumers
- **HTTP dashboard + routes**: new `bc.go` with `/bc` list page, `/bc/{name}` detail page, and `/api/bc/graph` JSON endpoint (Cytoscape-compatible nodes/edges for the BC map); `bc_list.html` and `bc_detail.html` templates; dashboard widget linking to `/bc`
- **MCP tools**: `list_bounded_contexts` and `get_bounded_context` tools added (11 tools total)
- **archai.yaml**: fixed aggregates block to use `root:` struct format; added `bounded_contexts` block for the project itself
- **Docs**: user-guide updated with bounded contexts overlay schema documentation

## Test plan

- [ ] `go test ./...` passes (all 19 packages green)
- [ ] HTTP tests: `TestBCList_RendersPage`, `TestBCDetail_RendersPage`, `TestBCDetail_NotFoundReturns404`, `TestAPIBCGraph_ReturnsJSONPayload`, `TestAPIBCGraph_NoOverlayReturnsEmptyPayload`
- [ ] MCP tests: `TestListBoundedContexts_ReturnsSortedList`, `TestGetBoundedContext_Found`, `TestGetBoundedContext_NotFound`, `TestGetBoundedContext_MissingName`
- [ ] Overlay validation tests: BC aggregate references and relationship qualifiers enforced
- [ ] Does NOT modify `base.html` (owned by PR #78)

Closes #72