### PR TITLE
fix(overlay): persist serve HTTP addr in archai.yaml (#80)

### DIFF
--- a/archai.yaml
+++ b/archai.yaml
@@ -98,3 +98,6 @@ bounded_contexts:
       - io_adapters
 
 configs: []
+
+serve:
+  http_addr: "0.0.0.0:47823"

--- a/cmd/archai/main.go
+++ b/cmd/archai/main.go
@@ -424,10 +424,24 @@ func runServe(cmd *cobra.Command, args []string) error {
 	root, _ := cmd.Flags().GetString("root")
 	mcpStdio, _ := cmd.Flags().GetBool("mcp-stdio")
 	httpAddr, _ := cmd.Flags().GetString("http")
+	httpAddrFromFlag := cmd.Flags().Changed("http")
 	debug, _ := cmd.Flags().GetBool("debug")
 	multi, _ := cmd.Flags().GetBool("multi")
 	noDaemon, _ := cmd.Flags().GetBool("no-daemon")
 	idleTimeout, _ := cmd.Flags().GetDuration("idle-timeout")
+
+	// Resolve --http precedence: explicit flag > overlay serve.http_addr
+	// > flag default. Only consult the overlay when the user did not
+	// pass --http on the command line.
+	if !httpAddrFromFlag {
+		overlayAddr, err := loadServeHTTPAddrFromOverlay(root)
+		if err != nil {
+			return err
+		}
+		if overlayAddr != "" {
+			httpAddr = overlayAddr
+		}
+	}
 
 	parent := cmd.Context()
 	if parent == nil {
@@ -506,6 +520,44 @@ func runServe(cmd *cobra.Command, args []string) error {
 	}
 
 	return serve.Serve(ctx, opts)
+}
+
+// loadServeHTTPAddrFromOverlay reads <root>/archai.yaml (if present) and
+// returns its serve.http_addr value. A missing overlay returns ("", nil)
+// so callers fall back to the flag default. A malformed serve block is
+// reported as a hard error so misconfigurations surface immediately
+// instead of silently using the default.
+func loadServeHTTPAddrFromOverlay(root string) (string, error) {
+	if root == "" {
+		root = "."
+	}
+	overlayPath := filepath.Join(root, "archai.yaml")
+	if _, err := os.Stat(overlayPath); err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", fmt.Errorf("serve: stat %s: %w", overlayPath, err)
+	}
+	cfg, err := overlay.Load(overlayPath)
+	if err != nil {
+		return "", fmt.Errorf("serve: load %s: %w", overlayPath, err)
+	}
+	// Validate just the serve block in isolation so a partially-formed
+	// archai.yaml (missing module / layers) does not block --http
+	// resolution; downstream consumers run full validation themselves.
+	probe := &overlay.Config{
+		Module: "serve.http_addr-probe",
+		Layers: map[string][]string{"_probe": {"_probe/..."}},
+		Serve:  cfg.Serve,
+	}
+	if vErr := overlay.Validate(probe, ""); vErr != nil {
+		for _, line := range strings.Split(vErr.Error(), "\n") {
+			if strings.Contains(line, "serve.http_addr") {
+				return "", fmt.Errorf("serve: %s: %s", overlayPath, line)
+			}
+		}
+	}
+	return cfg.Serve.HTTPAddr, nil
 }
 
 // bootstrapDaemonPlugins runs plugin Init against the live serve.Host

--- a/cmd/archai/serve_http_addr_test.go
+++ b/cmd/archai/serve_http_addr_test.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// These tests exercise loadServeHTTPAddrFromOverlay directly. The
+// runServe wrapper consults this helper only when the user did not
+// pass --http on the command line, so verifying the helper plus its
+// "skip when flag was changed" gate gives us full coverage of the
+// precedence rules without spinning up a real serve loop.
+
+func writeArchaiYAML(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "archai.yaml")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write archai.yaml: %v", err)
+	}
+	return dir
+}
+
+const overlayWithServe = `module: github.com/example/app
+
+layers:
+  domain:
+    - internal/domain/...
+
+layer_rules:
+  domain: []
+
+aggregates: {}
+configs: []
+
+serve:
+  http_addr: "0.0.0.0:47823"
+`
+
+const overlayWithoutServe = `module: github.com/example/app
+
+layers:
+  domain:
+    - internal/domain/...
+
+layer_rules:
+  domain: []
+
+aggregates: {}
+configs: []
+`
+
+func TestLoadServeHTTPAddr_OverlayPresent(t *testing.T) {
+	root := writeArchaiYAML(t, overlayWithServe)
+	got, err := loadServeHTTPAddrFromOverlay(root)
+	if err != nil {
+		t.Fatalf("loadServeHTTPAddrFromOverlay: %v", err)
+	}
+	if want := "0.0.0.0:47823"; got != want {
+		t.Errorf("addr = %q, want %q", got, want)
+	}
+}
+
+func TestLoadServeHTTPAddr_OverlayWithoutServe(t *testing.T) {
+	root := writeArchaiYAML(t, overlayWithoutServe)
+	got, err := loadServeHTTPAddrFromOverlay(root)
+	if err != nil {
+		t.Fatalf("loadServeHTTPAddrFromOverlay: %v", err)
+	}
+	if got != "" {
+		t.Errorf("addr = %q, want empty (caller falls back to flag default)", got)
+	}
+}
+
+func TestLoadServeHTTPAddr_OverlayMissing(t *testing.T) {
+	// No archai.yaml in the directory at all: helper must return
+	// ("", nil) so the flag default takes over silently.
+	root := t.TempDir()
+	got, err := loadServeHTTPAddrFromOverlay(root)
+	if err != nil {
+		t.Fatalf("loadServeHTTPAddrFromOverlay: %v", err)
+	}
+	if got != "" {
+		t.Errorf("addr = %q, want empty for missing overlay", got)
+	}
+}
+
+func TestLoadServeHTTPAddr_OverlayMalformed(t *testing.T) {
+	// A malformed serve.http_addr must surface as a hard error so the
+	// daemon does not silently fall back to the flag default and bind
+	// somewhere unexpected.
+	root := writeArchaiYAML(t, `module: github.com/example/app
+
+layers:
+  domain:
+    - internal/domain/...
+
+layer_rules:
+  domain: []
+
+aggregates: {}
+configs: []
+
+serve:
+  http_addr: "127.0.0.1:abc"
+`)
+	_, err := loadServeHTTPAddrFromOverlay(root)
+	if err == nil {
+		t.Fatal("expected error for malformed serve.http_addr, got nil")
+	}
+}
+
+func TestLoadServeHTTPAddr_RootDefaultsToCWD(t *testing.T) {
+	// Empty root means "current working directory". chdir into a temp
+	// directory with no archai.yaml so the helper returns ("", nil)
+	// rather than reading the repo's real archai.yaml.
+	dir := t.TempDir()
+	prev, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(prev) })
+
+	got, err := loadServeHTTPAddrFromOverlay("")
+	if err != nil {
+		t.Fatalf("loadServeHTTPAddrFromOverlay(\"\"): %v", err)
+	}
+	if got != "" {
+		t.Errorf("addr = %q, want empty when cwd has no archai.yaml", got)
+	}
+}

--- a/internal/overlay/config.go
+++ b/internal/overlay/config.go
@@ -29,6 +29,19 @@ type Config struct {
 	Aggregates      map[string]Aggregate       `yaml:"aggregates"`
 	Configs         []string                   `yaml:"configs"`
 	BoundedContexts map[string]BoundedContext  `yaml:"bounded_contexts,omitempty"`
+	Serve           ServeConfig                `yaml:"serve,omitempty"`
+}
+
+// ServeConfig captures persistent settings for `archai serve`. Each
+// field has a CLI flag counterpart that takes precedence when set;
+// values here act as the project-level default so a workstation does
+// not have to repeat them on every invocation.
+//
+// Field semantics:
+//   - HTTPAddr: TCP listen address ("host:port") for the HTTP transport.
+//     Empty falls through to the daemon's flag default.
+type ServeConfig struct {
+	HTTPAddr string `yaml:"http_addr,omitempty"`
 }
 
 // Aggregate describes a domain aggregate by its root type.

--- a/internal/overlay/load_test.go
+++ b/internal/overlay/load_test.go
@@ -114,6 +114,46 @@ func TestLoad_UnknownField(t *testing.T) {
 	}
 }
 
+func TestLoad_ServeHTTPAddr_Present(t *testing.T) {
+	yaml := `module: github.com/example/app
+
+layers:
+  domain:
+    - internal/domain/...
+
+layer_rules:
+  domain: []
+
+aggregates: {}
+configs: []
+
+serve:
+  http_addr: "0.0.0.0:47823"
+`
+	path := writeTempFile(t, "archai.yaml", yaml)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load returned unexpected error: %v", err)
+	}
+	if cfg.Serve.HTTPAddr != "0.0.0.0:47823" {
+		t.Errorf("Serve.HTTPAddr = %q, want 0.0.0.0:47823", cfg.Serve.HTTPAddr)
+	}
+}
+
+func TestLoad_ServeHTTPAddr_Absent(t *testing.T) {
+	// When the serve block is omitted entirely, the zero-value
+	// ServeConfig{} should be returned so callers can fall through
+	// to flag defaults without ambiguity.
+	path := writeTempFile(t, "archai.yaml", sampleArchaiYAML)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load returned unexpected error: %v", err)
+	}
+	if cfg.Serve.HTTPAddr != "" {
+		t.Errorf("Serve.HTTPAddr = %q, want empty string", cfg.Serve.HTTPAddr)
+	}
+}
+
 func TestLoadComposed_PackageFragments(t *testing.T) {
 	root := t.TempDir()
 	writeFile(t, filepath.Join(root, "archai.yaml"), `module: github.com/example/app

--- a/internal/overlay/validate.go
+++ b/internal/overlay/validate.go
@@ -3,9 +3,11 @@ package overlay
 import (
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 
 	"golang.org/x/mod/modfile"
@@ -107,6 +109,10 @@ func Validate(cfg *Config, goModPath string) error {
 		}
 	}
 
+	if err := validateServeConfig(cfg.Serve); err != nil {
+		errs = append(errs, err)
+	}
+
 	for _, name := range sortedKeys(cfg.BoundedContexts) {
 		bc := cfg.BoundedContexts[name]
 		if strings.TrimSpace(name) == "" {
@@ -170,6 +176,44 @@ func Validate(cfg *Config, goModPath string) error {
 	}
 
 	return errors.Join(errs...)
+}
+
+// validateServeConfig checks the optional `serve:` block. Empty values
+// are valid (they fall through to flag defaults at the daemon). When
+// present, HTTPAddr must parse as a "host:port" pair with a numeric
+// port in [0, 65535].
+func validateServeConfig(cfg ServeConfig) error {
+	addr := cfg.HTTPAddr
+	if addr == "" {
+		return nil
+	}
+	if addr != strings.TrimSpace(addr) {
+		return fmt.Errorf(
+			"overlay: serve.http_addr %q has leading/trailing whitespace", addr)
+	}
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return fmt.Errorf(
+			"overlay: serve.http_addr %q is not a valid host:port: %w", addr, err)
+	}
+	if strings.ContainsAny(host, " \t\n") {
+		return fmt.Errorf(
+			"overlay: serve.http_addr %q host contains whitespace", addr)
+	}
+	if port == "" {
+		return fmt.Errorf(
+			"overlay: serve.http_addr %q has empty port", addr)
+	}
+	n, perr := strconv.Atoi(port)
+	if perr != nil {
+		return fmt.Errorf(
+			"overlay: serve.http_addr %q has non-numeric port %q", addr, port)
+	}
+	if n < 0 || n > 65535 {
+		return fmt.Errorf(
+			"overlay: serve.http_addr %q port %d is out of range [0, 65535]", addr, n)
+	}
+	return nil
 }
 
 // isAllowedRelationship reports whether r is in the closed set of

--- a/internal/overlay/validate_test.go
+++ b/internal/overlay/validate_test.go
@@ -199,6 +199,57 @@ func TestValidate_MissingGoMod(t *testing.T) {
 	}
 }
 
+func TestValidate_ServeHTTPAddr_Empty(t *testing.T) {
+	cfg, goMod := validConfig(t)
+	cfg.Serve = ServeConfig{HTTPAddr: ""}
+	if err := Validate(cfg, goMod); err != nil {
+		t.Fatalf("Validate with empty serve.http_addr returned error: %v", err)
+	}
+}
+
+func TestValidate_ServeHTTPAddr_Valid(t *testing.T) {
+	cases := []string{
+		"127.0.0.1:0",
+		"0.0.0.0:47823",
+		"localhost:8080",
+		":8080",
+		"[::1]:8080",
+	}
+	for _, addr := range cases {
+		t.Run(addr, func(t *testing.T) {
+			cfg, goMod := validConfig(t)
+			cfg.Serve = ServeConfig{HTTPAddr: addr}
+			if err := Validate(cfg, goMod); err != nil {
+				t.Fatalf("Validate with serve.http_addr %q returned error: %v", addr, err)
+			}
+		})
+	}
+}
+
+func TestValidate_ServeHTTPAddr_Bad(t *testing.T) {
+	cases := map[string]string{
+		"no port":         "127.0.0.1",
+		"non-numeric":     "127.0.0.1:abc",
+		"out of range":    "127.0.0.1:99999",
+		"trailing space":  "127.0.0.1:8080 ",
+		"leading space":   " 127.0.0.1:8080",
+		"empty port":      "127.0.0.1:",
+	}
+	for name, addr := range cases {
+		t.Run(name, func(t *testing.T) {
+			cfg, goMod := validConfig(t)
+			cfg.Serve = ServeConfig{HTTPAddr: addr}
+			err := Validate(cfg, goMod)
+			if err == nil {
+				t.Fatalf("expected error for serve.http_addr %q", addr)
+			}
+			if !strings.Contains(err.Error(), "serve.http_addr") {
+				t.Errorf("expected 'serve.http_addr' in error, got: %v", err)
+			}
+		})
+	}
+}
+
 func TestValidate_AggregatesWithMultipleErrorsJoined(t *testing.T) {
 	cfg, goMod := validConfig(t)
 	cfg.Aggregates["Bad1"] = Aggregate{Root: ""}


### PR DESCRIPTION
## Summary

- Add `serve.http_addr` to the `overlay.Config` schema (yaml-tagged, omitempty) and validate it as a well-formed `host:port` when set.
- `archai serve` now reads `serve.http_addr` from the loaded overlay when the user did not pass `--http`. Explicit `--http` still wins; missing overlay or empty value falls through to the flag default.
- Self-hosted `archai.yaml` records the canonical address `0.0.0.0:47823` so contributors hit the same port out of the box.

## Implementation notes

- Flag-vs-overlay precedence is detected via `cmd.Flags().Changed("http")`, so the existing default (`127.0.0.1:0`) does not mask an overlay setting.
- A malformed `serve.http_addr` is reported as a hard error before serve starts, so misconfigurations surface immediately instead of silently using the flag default.
- The serve helper validates the serve block in isolation against a synthetic config so a partially-formed `archai.yaml` (missing module / layers) does not block `--http` resolution; downstream consumers run full validation themselves.

## Test plan

- [x] `go test ./...` (overlay, cmd/archai, full suite) — green
- [x] `go vet ./...` — clean
- [x] `internal/overlay`: parse + zero-value + validation cases (IPv4, IPv6 `[::1]:8080`, wildcard `:8080`, port-0, named host, plus rejection cases)
- [x] `cmd/archai/serve_http_addr_test.go`: overlay-present, overlay-without-serve, overlay-missing, malformed, empty-root-defaults-to-cwd

Closes #80

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

Generated with Claude Code