### PR TITLE
fix(bc): edges from Downstream, label clipping, bc-map-mini preview (#81)

### DIFF
--- a/internal/adapter/http/assets/graph.js
+++ b/internal/adapter/http/assets/graph.js
@@ -200,6 +200,45 @@
         };
     });
 
+    // Bounded-context map (#81). Each node is one BC; the relationship
+    // qualifier (shared-kernel / customer-supplier / conformist / acl /
+    // open-host) is exposed as data on the edge so it can be styled
+    // and surfaced as a label. The optional description is exposed via
+    // a native title tooltip (set in attachInteractions) so wrapping it
+    // into the label can no longer cause clipping.
+    registerView('bc-map', function () {
+        return {
+            layout: { name: pickLayout('elk'), 'elk': { algorithm: 'layered', 'elk.direction': 'RIGHT' }, padding: 20 },
+            style: [
+                baseNodeStyle(),
+                {
+                    selector: 'node[kind = "bc"]',
+                    style: {
+                        'background-color': '#0f766e',
+                        'shape': 'round-rectangle',
+                        'padding': 10,
+                        'font-size': 12,
+                        'color': '#f0fdfa'
+                    }
+                },
+                baseEdgeStyle(),
+                { selector: 'edge', style: { 'label': 'data(relationship)' } },
+                { selector: 'edge[relationship = "shared-kernel"]', style: { 'line-color': '#7c3aed', 'target-arrow-color': '#7c3aed' } },
+                { selector: 'edge[relationship = "customer-supplier"]', style: { 'line-color': '#2563eb', 'target-arrow-color': '#2563eb' } },
+                { selector: 'edge[relationship = "conformist"]', style: { 'line-color': '#9ca3af', 'target-arrow-color': '#9ca3af' } },
+                { selector: 'edge[relationship = "acl"]', style: { 'line-color': '#dc2626', 'target-arrow-color': '#dc2626', 'line-style': 'dashed' } },
+                { selector: 'edge[relationship = "open-host"]', style: { 'line-color': '#16a34a', 'target-arrow-color': '#16a34a' } }
+            ]
+        };
+    });
+
+    // Dashboard mini variant of bc-map; same styling, tighter padding.
+    registerView('bc-map-mini', function () {
+        var full = registry['bc-map']();
+        full.layout = { name: pickLayout('elk'), 'elk': { algorithm: 'layered', 'elk.direction': 'RIGHT' }, padding: 8 };
+        return full;
+    });
+
     // Diff overlay (M8): per-change node, coloured by op, parented by
     // the pseudo-package node the change lives under.
     registerView('diff-overlay', function () {
@@ -232,6 +271,10 @@
             };
             if (n.parent) { data.parent = n.parent; }
             if (n.op) { data.op = n.op; }
+            // #81: description is a separate field on the node so the
+            // front-end can show it as a tooltip without bloating the
+            // label and triggering clipping.
+            if (n.description) { data.description = n.description; }
             elements.push({ group: 'nodes', data: data });
         });
         (payload.edges || []).forEach(function (e, i) {
@@ -245,6 +288,8 @@
             if (e.details) {
                 edgeData.details = e.details;
             }
+            // #81: BC-graph relationship qualifier surfaces on the edge.
+            if (e.relationship) { edgeData.relationship = e.relationship; }
             elements.push({ group: 'edges', data: edgeData });
         });
         return elements;
@@ -273,15 +318,23 @@
             }
         });
         // Hover highlight: fade everything else, accent the neighbourhood.
+        // Also surface the optional `description` field as a native
+        // browser tooltip on the cytoscape container, so BC nodes (#81)
+        // can show their description without inflating the node label.
         cy.on('mouseover', 'node', function (evt) {
             var n = evt.target;
             cy.elements().addClass('cy-faded');
             n.removeClass('cy-faded').addClass('cy-hi');
             n.connectedEdges().removeClass('cy-faded').addClass('cy-hi');
             n.connectedEdges().connectedNodes().removeClass('cy-faded').addClass('cy-hi');
+            var desc = n.data('description');
+            if (desc) {
+                el.setAttribute('title', desc);
+            }
         });
         cy.on('mouseout', 'node', function () {
             cy.elements().removeClass('cy-faded cy-hi');
+            el.removeAttribute('title');
         });
     }
 

--- a/internal/adapter/http/bc.go
+++ b/internal/adapter/http/bc.go
@@ -47,11 +47,13 @@ type bcRefView struct {
 }
 
 // registerBCRoutes mounts the /bc and /bc/{name} handlers plus the
-// JSON graph API at /api/bc/graph.
+// JSON graph API at /api/bc/graph and the dashboard preview variant at
+// /api/bc/mini.
 func (s *Server) registerBCRoutes(mux *nethttp.ServeMux) {
 	mux.HandleFunc("/bc", s.handleBCList)
 	mux.HandleFunc("/bc/", s.handleBCDetail)
 	mux.HandleFunc("/api/bc/graph", s.handleBCGraph)
+	mux.HandleFunc("/api/bc/mini", s.handleBCGraphMini)
 }
 
 // handleBCList renders /bc — the bounded context catalog.
@@ -132,27 +134,63 @@ func (s *Server) handleBCDetail(w nethttp.ResponseWriter, r *nethttp.Request) {
 // bounded context graph. Nodes represent bounded contexts; edges
 // represent upstream/downstream relationships.
 func (s *Server) handleBCGraph(w nethttp.ResponseWriter, r *nethttp.Request) {
+	s.serveBCGraph(w, r, false)
+}
+
+// handleBCGraphMini serves GET /api/bc/mini — a compact variant of the
+// BC graph used by the dashboard preview card. Mirrors the layer-map
+// mini route (graphs.go).
+func (s *Server) handleBCGraphMini(w nethttp.ResponseWriter, r *nethttp.Request) {
+	s.serveBCGraph(w, r, true)
+}
+
+// serveBCGraph is the shared implementation behind /api/bc/graph and
+// /api/bc/mini. The mini=true flag flips the view tag so the front-end
+// renderer can pick a compact preset.
+func (s *Server) serveBCGraph(w nethttp.ResponseWriter, r *nethttp.Request, mini bool) {
+	view := "bc-map"
+	if mini {
+		view = "bc-map-mini"
+	}
 	snap := s.state.Snapshot()
 	if snap.Overlay == nil {
 		writeJSON(w, graphPayload{
-			Meta:  graphMeta{View: "bc-map", Layout: "elk"},
+			Meta:  graphMeta{View: view, Layout: "elk"},
 			Nodes: []graphNode{},
 			Edges: []graphEdge{},
 		})
 		return
 	}
-	payload := buildBCGraph(snap.Overlay)
-	writeJSON(w, payload)
+	writeJSON(w, buildBCGraph(snap.Overlay, mini))
 }
 
-// buildBCGraph produces the Cytoscape payload for /api/bc/graph.
-// Each bounded context becomes a node; upstream relationships become
-// directed edges. The function avoids duplicate edges by only emitting
-// an edge when the source is alphabetically less than the target, then
-// relying on the upstream/downstream labelling for direction.
-func buildBCGraph(cfg *overlay.Config) graphPayload {
+// buildBCGraph produces the Cytoscape payload for the bounded context
+// graph. Each bounded context becomes a node carrying its name as the
+// primary label and (when present) its description as a separate
+// optional field — the front-end can surface description as a tooltip
+// or wrap it independently, avoiding the clipping problem that
+// concatenating "name\ndescription" caused (#81).
+//
+// Edges are derived from BOTH directions of the BC relationship graph:
+//
+//   - A.Downstream contains B  ->  edge A -> B
+//   - A.Upstream   contains B  ->  edge B -> A
+//
+// The relationship qualifier (BoundedContext.Relationship: shared-kernel
+// / customer-supplier / conformist / acl / open-host) is attached to
+// the edge from the BC that declares the link. Edges are deduplicated
+// by the (source, target, relationship) tuple so symmetrical
+// declarations on both sides do not produce parallel edges.
+//
+// When mini is true the view tag is switched to "bc-map-mini" so the
+// dashboard renderer can apply a compact style preset.
+func buildBCGraph(cfg *overlay.Config, mini bool) graphPayload {
+	view := "bc-map"
+	if mini {
+		view = "bc-map-mini"
+	}
 	out := graphPayload{
-		Meta:  graphMeta{View: "bc-map", Layout: "elk"},
+		Meta:  graphMeta{View: view, Layout: "elk"},
 		Nodes: make([]graphNode, 0, len(cfg.BoundedContexts)),
 		Edges: make([]graphEdge, 0),
 	}
@@ -166,39 +204,45 @@ func buildBCGraph(cfg *overlay.Config) graphPayload {
 
 	for _, name := range names {
 		bc := cfg.BoundedContexts[name]
-		label := name
-		if bc.Description != "" {
-			label = name + "\n" + bc.Description
-		}
 		out.Nodes = append(out.Nodes, graphNode{
-			ID:    "bc:" + name,
-			Label: label,
-			Kind:  "bc",
+			ID:          "bc:" + name,
+			Label:       name,
+			Kind:        "bc",
+			Description: bc.Description,
 		})
 	}
 
-	// Emit edges only from the upstream side to avoid duplicates.
+	// Dedup key: source + "->" + target + "|" + relationship.
 	seen := make(map[string]struct{})
+	addEdge := func(source, target, relationship string) {
+		key := source + "->" + target + "|" + relationship
+		if _, exists := seen[key]; exists {
+			return
+		}
+		seen[key] = struct{}{}
+		out.Edges = append(out.Edges, graphEdge{
+			Source:       "bc:" + source,
+			Target:       "bc:" + target,
+			Kind:         "upstream",
+			Relationship: relationship,
+		})
+	}
+
 	for _, name := range names {
 		bc := cfg.BoundedContexts[name]
+		// A.Downstream contains B  -> A -> B
+		for _, dn := range bc.Downstream {
+			if _, ok := cfg.BoundedContexts[dn]; !ok {
+				continue
+			}
+			addEdge(name, dn, bc.Relationship)
+		}
+		// A.Upstream contains B  -> B -> A
 		for _, up := range bc.Upstream {
 			if _, ok := cfg.BoundedContexts[up]; !ok {
 				continue
 			}
-			edgeID := "bc:" + up + "->bc:" + name
-			reverseID := "bc:" + name + "->bc:" + up
-			if _, exists := seen[edgeID]; exists {
-				continue
-			}
-			if _, exists := seen[reverseID]; exists {
-				continue
-			}
-			seen[edgeID] = struct{}{}
-			out.Edges = append(out.Edges, graphEdge{
-				Source: "bc:" + up,
-				Target: "bc:" + name,
-				Kind:   "upstream",
-			})
+			addEdge(up, name, bc.Relationship)
 		}
 	}
 

--- a/internal/adapter/http/bc_test.go
+++ b/internal/adapter/http/bc_test.go
@@ -54,7 +54,7 @@ func sampleBCPackages() []domain.PackageModel {
 
 func TestBuildBCGraph_NodesAndEdges(t *testing.T) {
 	cfg := sampleBCOverlay()
-	payload := buildBCGraph(cfg)
+	payload := buildBCGraph(cfg, false)
 	if payload.Meta.View != "bc-map" {
 		t.Errorf("meta.view = %q, want bc-map", payload.Meta.View)
 	}
@@ -69,10 +69,37 @@ func TestBuildBCGraph_NodesAndEdges(t *testing.T) {
 		if n.Kind != "bc" {
 			t.Errorf("node %q: want kind=bc, got %q", n.ID, n.Kind)
 		}
+		// Label must NOT contain a newline — name and description
+		// are exposed as separate fields so the front-end can lay
+		// them out without clipping (#81).
+		if strings.Contains(n.Label, "\n") {
+			t.Errorf("node %q: label contains newline (%q); name and description must be separate fields", n.ID, n.Label)
+		}
 	}
 	for _, want := range []string{"bc:core_ctx", "bc:infra_ctx"} {
 		if !nodeIDs[want] {
 			t.Errorf("missing node %q; nodes: %v", want, nodeIDs)
+		}
+	}
+
+	// Description must be carried on the node, not concatenated into
+	// the label.
+	for _, n := range payload.Nodes {
+		switch n.ID {
+		case "bc:core_ctx":
+			if n.Label != "core_ctx" {
+				t.Errorf("core_ctx label = %q, want %q", n.Label, "core_ctx")
+			}
+			if n.Description != "Core domain" {
+				t.Errorf("core_ctx description = %q, want %q", n.Description, "Core domain")
+			}
+		case "bc:infra_ctx":
+			if n.Label != "infra_ctx" {
+				t.Errorf("infra_ctx label = %q, want %q", n.Label, "infra_ctx")
+			}
+			if n.Description != "Infrastructure" {
+				t.Errorf("infra_ctx description = %q, want %q", n.Description, "Infrastructure")
+			}
 		}
 	}
 
@@ -99,9 +126,94 @@ func TestBuildBCGraph_NoDuplicateEdges(t *testing.T) {
 			"b": {Upstream: []string{"a"}},
 		},
 	}
-	payload := buildBCGraph(cfg)
+	payload := buildBCGraph(cfg, false)
 	if len(payload.Edges) > 2 {
 		t.Errorf("expected at most 2 edges (one per direction), got %d", len(payload.Edges))
+	}
+}
+
+// TestBuildBCGraph_DownstreamOnlyEdges verifies that an edge is
+// derived from a Downstream declaration even when no Upstream
+// counterpart exists. A.Downstream contains B  ->  A -> B.
+func TestBuildBCGraph_DownstreamOnlyEdges(t *testing.T) {
+	cfg := &overlay.Config{
+		Module: "example.com/app",
+		BoundedContexts: map[string]overlay.BoundedContext{
+			"a": {Downstream: []string{"b"}},
+			"b": {},
+		},
+	}
+	payload := buildBCGraph(cfg, false)
+	if len(payload.Edges) != 1 {
+		t.Fatalf("expected 1 edge, got %d: %+v", len(payload.Edges), payload.Edges)
+	}
+	e := payload.Edges[0]
+	if e.Source != "bc:a" || e.Target != "bc:b" {
+		t.Errorf("edge: got %s -> %s, want bc:a -> bc:b", e.Source, e.Target)
+	}
+}
+
+// TestBuildBCGraph_MixedUpstreamDownstreamDedup verifies that when
+// both sides declare the same edge symmetrically (A.Downstream=[B]
+// AND B.Upstream=[A]), only one edge is emitted (same relationship).
+func TestBuildBCGraph_MixedUpstreamDownstreamDedup(t *testing.T) {
+	cfg := &overlay.Config{
+		Module: "example.com/app",
+		BoundedContexts: map[string]overlay.BoundedContext{
+			"a": {Downstream: []string{"b"}, Relationship: "customer-supplier"},
+			"b": {Upstream: []string{"a"}, Relationship: "customer-supplier"},
+		},
+	}
+	payload := buildBCGraph(cfg, false)
+	if len(payload.Edges) != 1 {
+		t.Fatalf("expected 1 edge after dedup, got %d: %+v", len(payload.Edges), payload.Edges)
+	}
+	e := payload.Edges[0]
+	if e.Source != "bc:a" || e.Target != "bc:b" {
+		t.Errorf("edge: got %s -> %s, want bc:a -> bc:b", e.Source, e.Target)
+	}
+	if e.Relationship != "customer-supplier" {
+		t.Errorf("edge.relationship = %q, want customer-supplier", e.Relationship)
+	}
+}
+
+// TestBuildBCGraph_RelationshipQualifierPreserved verifies that the
+// relationship qualifier of the BC declaring the link is attached
+// to the edge.
+func TestBuildBCGraph_RelationshipQualifierPreserved(t *testing.T) {
+	// Each edge has exactly one declarer — no symmetrical declarations
+	// — so the relationship attached to each edge is unambiguous.
+	cfg := &overlay.Config{
+		Module: "example.com/app",
+		BoundedContexts: map[string]overlay.BoundedContext{
+			"core":   {Downstream: []string{"infra"}, Relationship: "open-host"},
+			"infra":  {Relationship: "conformist"},
+			"shared": {Downstream: []string{"core"}, Relationship: "shared-kernel"},
+		},
+	}
+	payload := buildBCGraph(cfg, false)
+
+	// Build a lookup of relationships per (source, target).
+	rels := map[string]string{}
+	for _, e := range payload.Edges {
+		rels[e.Source+"->"+e.Target] = e.Relationship
+	}
+
+	if got := rels["bc:core->bc:infra"]; got != "open-host" {
+		t.Errorf("core->infra relationship = %q, want open-host", got)
+	}
+	if got := rels["bc:shared->bc:core"]; got != "shared-kernel" {
+		t.Errorf("shared->core relationship = %q, want shared-kernel", got)
+	}
+}
+
+// TestBuildBCGraph_MiniViewTag verifies that mini=true flips the
+// view tag to "bc-map-mini".
+func TestBuildBCGraph_MiniViewTag(t *testing.T) {
+	cfg := sampleBCOverlay()
+	payload := buildBCGraph(cfg, true)
+	if payload.Meta.View != "bc-map-mini" {
+		t.Errorf("meta.view = %q, want bc-map-mini", payload.Meta.View)
 	}
 }
 
@@ -261,6 +373,34 @@ func TestAPIBCGraph_ReturnsJSONPayload(t *testing.T) {
 	}
 	if p.Meta.View != "bc-map" {
 		t.Errorf("meta.view = %q, want bc-map", p.Meta.View)
+	}
+	if len(p.Nodes) < 2 {
+		t.Errorf("expected at least 2 nodes (one per BC), got %d", len(p.Nodes))
+	}
+}
+
+func TestAPIBCGraphMini_ReturnsMiniViewTag(t *testing.T) {
+	ts, _ := newBCFixtureServer(t)
+	defer ts.Close()
+
+	resp, err := ts.Client().Get(ts.URL + "/api/bc/mini")
+	if err != nil {
+		t.Fatalf("GET /api/bc/mini: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != nethttp.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, body=%s", resp.StatusCode, string(b))
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Errorf("Content-Type = %q, want application/json*", ct)
+	}
+	var p graphPayload
+	if err := json.NewDecoder(resp.Body).Decode(&p); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if p.Meta.View != "bc-map-mini" {
+		t.Errorf("meta.view = %q, want bc-map-mini", p.Meta.View)
 	}
 	if len(p.Nodes) < 2 {
 		t.Errorf("expected at least 2 nodes (one per BC), got %d", len(p.Nodes))

--- a/internal/adapter/http/templates/index.html
+++ b/internal/adapter/http/templates/index.html
@@ -78,6 +78,26 @@
     {{end}}
 </section>
 
+{{if .HasBoundedContexts}}
+<section class="card bc-preview">
+    <h2>Domain map</h2>
+    <a href="/bc" class="diagram-link" aria-label="Open Domain view">
+        <div class="cy-graph bc-map-mini"
+             data-api="/api/bc/mini"
+             data-view="bc-map-mini"
+             data-layout="elk"
+             data-height="220"
+             data-interactive="false"></div>
+    </a>
+    <script src="/assets/vendor/dagre.min.js" defer></script>
+    <script src="/assets/vendor/cytoscape.min.js" defer></script>
+    <script src="/assets/vendor/cytoscape-dagre.js" defer></script>
+    <script src="/assets/vendor/elk.bundled.js" defer></script>
+    <script src="/assets/vendor/cytoscape-elk.js" defer></script>
+    <script src="/assets/graph.js" defer></script>
+</section>
+{{end}}
+
 {{if .PluginMain}}
 <section class="dash-plugin-section">
     <h2>Plugins</h2>

--- a/internal/adapter/http/types.go
+++ b/internal/adapter/http/types.go
@@ -113,6 +113,10 @@ type graphNode struct {
 	// Op is the diff operation ("add" | "remove" | "change") for
 	// nodes produced by the diff overlay. Empty for non-diff graphs.
 	Op string `json:"op,omitempty"`
+	// Description is an optional secondary text. The browser-side
+	// renderer surfaces it as a tooltip / aria-label so the primary
+	// label stays short and unclipped (used by the BC view, #81).
+	Description string `json:"description,omitempty"`
 }
 
 type graphEdge struct {
@@ -121,6 +125,10 @@ type graphEdge struct {
 	Label   string   `json:"label,omitempty"`
 	Kind    string   `json:"kind,omitempty"`
 	Details []string `json:"details,omitempty"`
+	// Relationship qualifies BC-map edges with a DDD context-map
+	// relationship ("shared-kernel" / "customer-supplier" /
+	// "conformist" / "acl" / "open-host"). Empty for other graphs.
+	Relationship string `json:"relationship,omitempty"`
 }
 
 // sequenceEntry is one public-method entry point for which a static


### PR DESCRIPTION
## Summary

Fixes the three issues in #81:

- **Edges from Downstream**: `buildBCGraph` now derives edges from BOTH `Upstream` and `Downstream` declarations. Canonical direction: `A.Downstream contains B` produces `A -> B`; `A.Upstream contains B` produces `B -> A`. The relationship qualifier (`shared-kernel`, `customer-supplier`, `conformist`, `acl`, `open-host`) is attached from the declaring BC, and edges are deduplicated by `(source, target, relationship)` so symmetric declarations don't produce parallel edges.
- **Label clipping**: Node payload now exposes `name` and `description` as separate fields. The front-end renders the name on the node and surfaces the description as a native browser tooltip via the container `title` attribute, eliminating the clipping caused by concatenating `name + "\n" + description`.
- **bc-map-mini preview**: New `/api/bc/mini` route mirrors the existing `layer-map-mini` pattern. Registered a `bc-map-mini` Cytoscape view in `graph.js` and added a Domain map preview card to the dashboard (`index.html`).

## Test plan

- [x] `go test ./...` passes (all packages green)
- [x] `go vet ./...` clean
- [x] Unit tests added: downstream-only edges, mixed dedup, relationship qualifier preserved, mini view tag
- [x] HTTP test added for `/api/bc/mini` returning `bc-map-mini` view tag
- [ ] Manual: load a project with `bounded_contexts` containing `downstream:` and confirm dashboard renders the Domain map preview with edges
- [ ] Manual: hover a BC node and confirm description shows as tooltip without clipping

Closes #81

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>