### PR TITLE
overlay: single 'Model' BC + adapter direction (#82)

### DIFF
--- a/archai.yaml
+++ b/archai.yaml
@@ -4,16 +4,17 @@
 # generated per-package `.arch/` files in this repository are produced from
 # this overlay, so the project demonstrates the tool on its own codebase.
 #
-# Architecture shape:
-#   - `domain` is the extracted package model and shared value vocabulary.
-#   - `model_ops` contains operations over that model: overlay, diff, apply,
-#     and sequence analysis.
-#   - `service` owns the generation/composition use cases and ports.
-#   - `source_adapter` reads/writes external model formats and Go source.
-#   - `runtime` keeps live in-memory state and file watchers.
-#   - `transport` exposes the model to browser and MCP clients.
-#   - `storage` owns target/worktree filesystem state.
-#   - `cli` wires the public command surface.
+# Architecture shape (post-#82):
+#   - The domain is a single bounded context, `model`, that owns the
+#     extracted package model and the operations performed over it
+#     (overlay, diff, apply, sequence). Everything else is an adapter.
+#   - Inbound adapters drive the model from the outside (Go source
+#     extractor, YAML overlay loader). Outbound adapters render the
+#     model to other formats (D2 diagrams, dashboard HTML/JS).
+#     Bidirectional adapters serve and accept commands at runtime
+#     (HTTP server, MCP server).
+#   - Layer rules still describe permitted package-level dependencies
+#     between architectural slices.
 
 module: github.com/kgatilin/archai
 
@@ -60,42 +61,52 @@ aggregates:
     root: "github.com/kgatilin/archai/internal/domain.PackageModel"
   model_ops:
     root: "github.com/kgatilin/archai/internal/overlay.Config"
-  source_adapter:
-    root: "github.com/kgatilin/archai/internal/adapter/golang.Extractor"
-  runtime:
-    root: "github.com/kgatilin/archai/internal/serve.State"
-  transport:
-    root: "github.com/kgatilin/archai/internal/adapter/http.Server"
-  cli:
-    root: "github.com/kgatilin/archai/cmd/root.Execute"
 
 bounded_contexts:
-  model_core:
-    description: "Core domain model and operations"
+  model:
+    name: "Model"
+    description: "The package model and the operations performed over it (overlay, diff, apply, sequence)."
     aggregates:
       - domain
       - model_ops
-  io_adapters:
-    description: "I/O adapters for Go source, YAML, and D2"
-    aggregates:
-      - source_adapter
-    downstream:
-      - model_core
-  serving:
-    description: "HTTP server and MCP adapter"
-    aggregates:
-      - runtime
-      - transport
-    downstream:
-      - model_core
-      - io_adapters
-  cli_entry:
-    description: "CLI entry point and command wiring"
-    aggregates:
-      - cli
-    downstream:
-      - serving
-      - io_adapters
+
+adapters:
+  go_extractor:
+    name: "Go Extractor"
+    direction: inbound
+    description: "Reads Go source and extracts the package model."
+    packages:
+      - internal/adapter/golang/...
+  yaml_overlay:
+    name: "YAML Overlay"
+    direction: inbound
+    description: "Loads archai.yaml and per-package overlay fragments."
+    packages:
+      - internal/adapter/yaml/...
+  d2_emitter:
+    name: "D2 Emitter"
+    direction: outbound
+    description: "Renders the model and overlay into D2 diagram source."
+    packages:
+      - internal/adapter/d2/...
+  dashboard:
+    name: "Dashboard"
+    direction: outbound
+    description: "HTML/JS dashboard that visualises the model in a browser."
+    packages:
+      - internal/adapter/http/...
+  mcp_server:
+    name: "MCP Server"
+    direction: bidirectional
+    description: "Model Context Protocol surface for IDE/agent tooling."
+    packages:
+      - internal/adapter/mcp/...
+  http_server:
+    name: "HTTP Server"
+    direction: bidirectional
+    description: "HTTP API and dashboard host process."
+    packages:
+      - internal/serve/...
 
 configs: []
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -287,49 +287,64 @@ Add a `bounded_contexts:` block to `archai.yaml`:
 # archai.yaml
 
 bounded_contexts:
-  model_core:
-    description: "Core domain model and operations"
+  model:
+    name: "Model"
+    description: "The package model and the operations performed over it."
     aggregates:
       - domain
       - model_ops
 
-  io_adapters:
-    description: "I/O adapters for Go source, YAML, and D2"
-    aggregates:
-      - source_adapter
-    downstream:
-      - model_core
+adapters:
+  go_extractor:
+    name: "Go Extractor"
+    direction: inbound
+    description: "Reads Go source into the model."
+    packages:
+      - internal/adapter/golang/...
 
-  serving:
-    description: "HTTP server and MCP adapter"
-    aggregates:
-      - runtime
-      - transport
-    downstream:
-      - model_core
-      - io_adapters
+  d2_emitter:
+    name: "D2 Emitter"
+    direction: outbound
+    description: "Renders the model into D2 diagram source."
+    packages:
+      - internal/adapter/d2/...
 
-  cli_entry:
-    description: "CLI entry point and command wiring"
-    aggregates:
-      - cli
-    downstream:
-      - serving
-      - io_adapters
+  http_server:
+    name: "HTTP Server"
+    direction: bidirectional
+    description: "HTTP API and dashboard host process."
+    packages:
+      - internal/serve/...
 ```
 
-**Schema reference**
+**Bounded context schema reference**
 
 | Field          | Type             | Required | Description |
 |----------------|------------------|----------|-------------|
+| `name`         | string           | no       | Human-readable display name. Falls back to the map key when empty. |
 | `description`  | string           | no       | Human-readable purpose of the context. |
-| `aggregates`   | list of strings  | no       | Aggregate names (declared in `aggregates:`) that belong to this context. |
+| `aggregates`   | list of strings  | no       | Aggregate names (declared in `aggregates:`) that belong to this context. Each aggregate may belong to at most one bounded context. |
 | `upstream`     | list of strings  | no       | Contexts this context depends on (consumes). |
 | `downstream`   | list of strings  | no       | Contexts that depend on this one (consumers). You may declare the relationship from either side — archai reads both. |
 | `relationship` | string           | no       | Optional context-map pattern label. Common values: `shared-kernel`, `customer-supplier`, `conformist`, `acl`, `open-host`. |
 
-Aggregates and bounded contexts are both optional — you can use layers
-alone, aggregates alone, or the full three-tier model.
+**Adapter schema reference**
+
+Adapters are hexagonal-architecture ports — concrete integration points
+between the domain model and the outside world. Use them when "every
+non-domain aggregate is just an adapter" maps the system more cleanly
+than splitting it into multiple bounded contexts.
+
+| Field         | Type            | Required | Description |
+|---------------|-----------------|----------|-------------|
+| `name`        | string          | no       | Human-readable display name. |
+| `direction`   | string          | yes      | One of `inbound`, `outbound`, `bidirectional`. |
+| `description` | string          | no       | Human-readable summary. |
+| `packages`    | list of strings | no       | Package globs (relative to the module root) implementing the adapter. |
+
+Aggregates, bounded contexts, and adapters are all optional — you can
+use layers alone, layers + aggregates, or the full layered + DDD +
+hexagonal model.
 
 ### 3.6 CI integration
 

--- a/internal/overlay/config.go
+++ b/internal/overlay/config.go
@@ -29,6 +29,7 @@ type Config struct {
 	Aggregates      map[string]Aggregate       `yaml:"aggregates"`
 	Configs         []string                   `yaml:"configs"`
 	BoundedContexts map[string]BoundedContext  `yaml:"bounded_contexts,omitempty"`
+	Adapters        map[string]Adapter         `yaml:"adapters,omitempty"`
 	Serve           ServeConfig                `yaml:"serve,omitempty"`
 }
 
@@ -56,20 +57,53 @@ type Aggregate struct {
 // other contexts.
 //
 // Field semantics:
+//   - Name: optional human-readable display name (e.g. "Model").
+//     When empty, UIs should fall back to the map key.
 //   - Description: optional human-readable summary.
 //   - Aggregates: names of aggregates that belong to this context.
-//     Each must be defined in Config.Aggregates.
+//     Each must be defined in Config.Aggregates. An aggregate may
+//     belong to at most one bounded context.
 //   - Upstream: names of bounded contexts this one depends on.
 //   - Downstream: names of bounded contexts that depend on this one.
 //   - Relationship: optional context-map relationship qualifier.
 //     Allowed values: "shared-kernel", "customer-supplier",
 //     "conformist", "acl", "open-host". Empty means unspecified.
 type BoundedContext struct {
+	Name         string   `yaml:"name,omitempty"`
 	Description  string   `yaml:"description,omitempty"`
 	Aggregates   []string `yaml:"aggregates,omitempty"`
 	Upstream     []string `yaml:"upstream,omitempty"`
 	Downstream   []string `yaml:"downstream,omitempty"`
 	Relationship string   `yaml:"relationship,omitempty"`
+}
+
+// Adapter describes a hexagonal-architecture adapter: a concrete
+// integration point between the domain model and the outside world.
+// Adapters are classified by Direction so consumers (diagrams, the
+// dashboard, lint rules) can render or reason about them as inbound
+// (driving), outbound (driven), or bidirectional ports.
+//
+// Field semantics:
+//   - Name: optional human-readable display name. When empty, UIs
+//     should fall back to the map key.
+//   - Direction: one of "inbound", "outbound", "bidirectional".
+//     Required.
+//   - Description: optional human-readable summary.
+//   - Packages: package globs (relative to the module root) whose
+//     contents implement the adapter. Same syntax as layer globs.
+type Adapter struct {
+	Name        string   `yaml:"name,omitempty"`
+	Direction   string   `yaml:"direction"`
+	Description string   `yaml:"description,omitempty"`
+	Packages    []string `yaml:"packages,omitempty"`
+}
+
+// AdapterDirections is the closed set of allowed values for
+// Adapter.Direction.
+var AdapterDirections = []string{
+	"inbound",
+	"outbound",
+	"bidirectional",
 }
 
 // BoundedContextRelationships is the closed set of allowed

--- a/internal/overlay/load_test.go
+++ b/internal/overlay/load_test.go
@@ -154,6 +154,128 @@ func TestLoad_ServeHTTPAddr_Absent(t *testing.T) {
 	}
 }
 
+func TestLoad_SingleBCOverlay(t *testing.T) {
+	// A single-bounded-context overlay with a human-readable name and an
+	// adapters block must round-trip cleanly through the loader.
+	yaml := `module: github.com/example/app
+
+layers:
+  domain:
+    - internal/domain/...
+
+layer_rules:
+  domain: []
+
+aggregates:
+  domain:
+    root: github.com/example/app/internal/domain.Model
+
+bounded_contexts:
+  model:
+    name: "Model"
+    description: "The package model"
+    aggregates:
+      - domain
+
+adapters:
+  go_extractor:
+    name: "Go Extractor"
+    direction: inbound
+    packages:
+      - internal/adapter/golang/...
+  d2_emitter:
+    direction: outbound
+  http_server:
+    direction: bidirectional
+`
+	path := writeTempFile(t, "archai.yaml", yaml)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load returned unexpected error: %v", err)
+	}
+	if got := len(cfg.BoundedContexts); got != 1 {
+		t.Fatalf("len(BoundedContexts) = %d, want 1", got)
+	}
+	bc, ok := cfg.BoundedContexts["model"]
+	if !ok {
+		t.Fatalf("missing 'model' bounded context: %+v", cfg.BoundedContexts)
+	}
+	if bc.Name != "Model" {
+		t.Errorf("BoundedContexts[model].Name = %q, want Model", bc.Name)
+	}
+	if got := len(cfg.Adapters); got != 3 {
+		t.Fatalf("len(Adapters) = %d, want 3", got)
+	}
+}
+
+func TestLoad_AdapterDirection(t *testing.T) {
+	cases := []string{"inbound", "outbound", "bidirectional"}
+	for _, dir := range cases {
+		t.Run(dir, func(t *testing.T) {
+			yaml := `module: github.com/example/app
+
+layers:
+  domain:
+    - internal/domain/...
+
+layer_rules:
+  domain: []
+
+aggregates: {}
+configs: []
+
+adapters:
+  example:
+    direction: ` + dir + `
+`
+			path := writeTempFile(t, "archai.yaml", yaml)
+			cfg, err := Load(path)
+			if err != nil {
+				t.Fatalf("Load returned unexpected error: %v", err)
+			}
+			ad, ok := cfg.Adapters["example"]
+			if !ok {
+				t.Fatalf("missing 'example' adapter: %+v", cfg.Adapters)
+			}
+			if ad.Direction != dir {
+				t.Errorf("Adapters[example].Direction = %q, want %q", ad.Direction, dir)
+			}
+		})
+	}
+}
+
+func TestLoad_InvalidAdapterDirection(t *testing.T) {
+	// Loader-level: KnownFields(true) accepts any string for `direction`,
+	// but Validate must reject unknown values.
+	goMod := writeGoMod(t, "github.com/example/app")
+	yaml := `module: github.com/example/app
+
+layers:
+  domain:
+    - internal/domain/...
+
+layer_rules:
+  domain: []
+
+aggregates: {}
+configs: []
+
+adapters:
+  bogus:
+    direction: sideways
+`
+	path := writeTempFile(t, "archai.yaml", yaml)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load returned unexpected error: %v", err)
+	}
+	if err := Validate(cfg, goMod); err == nil {
+		t.Fatal("expected validation error for unknown adapter direction, got nil")
+	} else if !strings.Contains(err.Error(), "sideways") {
+		t.Errorf("expected error to mention bad direction, got: %v", err)
+	}
+}
+
 func TestLoadComposed_PackageFragments(t *testing.T) {
 	root := t.TempDir()
 	writeFile(t, filepath.Join(root, "archai.yaml"), `module: github.com/example/app

--- a/internal/overlay/validate.go
+++ b/internal/overlay/validate.go
@@ -113,6 +113,10 @@ func Validate(cfg *Config, goModPath string) error {
 		errs = append(errs, err)
 	}
 
+	// Track which BC each aggregate appears in so we can flag any
+	// aggregate that appears in more than one bounded context.
+	aggToBC := make(map[string]string)
+
 	for _, name := range sortedKeys(cfg.BoundedContexts) {
 		bc := cfg.BoundedContexts[name]
 		if strings.TrimSpace(name) == "" {
@@ -129,6 +133,15 @@ func Validate(cfg *Config, goModPath string) error {
 				errs = append(errs, fmt.Errorf(
 					"overlay: bounded_contexts %q references unknown aggregate %q",
 					name, aggName))
+			}
+			if other, dup := aggToBC[aggName]; dup {
+				if other != name {
+					errs = append(errs, fmt.Errorf(
+						"overlay: aggregate %q appears in multiple bounded_contexts (%q and %q); each aggregate may belong to at most one context",
+						aggName, other, name))
+				}
+			} else {
+				aggToBC[aggName] = name
 			}
 		}
 		for _, ref := range bc.Upstream {
@@ -175,7 +188,40 @@ func Validate(cfg *Config, goModPath string) error {
 		}
 	}
 
+	for _, name := range sortedKeys(cfg.Adapters) {
+		ad := cfg.Adapters[name]
+		if strings.TrimSpace(name) == "" {
+			errs = append(errs, errors.New("overlay: adapters: name must not be empty"))
+			continue
+		}
+		if strings.TrimSpace(ad.Direction) == "" {
+			errs = append(errs, fmt.Errorf(
+				"overlay: adapters %q has empty direction (allowed: %s)",
+				name, strings.Join(AdapterDirections, ", ")))
+		} else if !isAllowedDirection(ad.Direction) {
+			errs = append(errs, fmt.Errorf(
+				"overlay: adapters %q has unknown direction %q (allowed: %s)",
+				name, ad.Direction, strings.Join(AdapterDirections, ", ")))
+		}
+		for _, glob := range ad.Packages {
+			if err := validateGlob("adapter "+name, glob); err != nil {
+				errs = append(errs, err)
+			}
+		}
+	}
+
 	return errors.Join(errs...)
+}
+
+// isAllowedDirection reports whether d is in the closed set of allowed
+// adapter direction qualifiers.
+func isAllowedDirection(d string) bool {
+	for _, allowed := range AdapterDirections {
+		if d == allowed {
+			return true
+		}
+	}
+	return false
 }
 
 // validateServeConfig checks the optional `serve:` block. Empty values

--- a/internal/overlay/validate_test.go
+++ b/internal/overlay/validate_test.go
@@ -250,6 +250,75 @@ func TestValidate_ServeHTTPAddr_Bad(t *testing.T) {
 	}
 }
 
+func TestValidate_AggregateInMultipleBCs(t *testing.T) {
+	// Each aggregate is allowed in at most one bounded context.
+	cfg, goMod := validConfig(t)
+	cfg.BoundedContexts = map[string]BoundedContext{
+		"alpha": {Aggregates: []string{"Order"}},
+		"beta":  {Aggregates: []string{"Order"}},
+	}
+
+	err := Validate(cfg, goMod)
+	if err == nil {
+		t.Fatal("expected error for aggregate in multiple BCs, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "multiple bounded_contexts") {
+		t.Errorf("expected 'multiple bounded_contexts' in error, got: %v", err)
+	}
+	if !strings.Contains(msg, "Order") {
+		t.Errorf("expected aggregate name in error, got: %v", err)
+	}
+}
+
+func TestValidate_AdapterDirectionValid(t *testing.T) {
+	for _, dir := range []string{"inbound", "outbound", "bidirectional"} {
+		t.Run(dir, func(t *testing.T) {
+			cfg, goMod := validConfig(t)
+			cfg.Adapters = map[string]Adapter{
+				"adp": {Direction: dir, Packages: []string{"internal/foo/..."}},
+			}
+			if err := Validate(cfg, goMod); err != nil {
+				t.Fatalf("Validate returned unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidate_AdapterDirectionInvalid(t *testing.T) {
+	cases := map[string]string{
+		"empty":    "",
+		"unknown":  "sideways",
+		"casing":   "Inbound",
+		"plural":   "inbounds",
+	}
+	for name, dir := range cases {
+		t.Run(name, func(t *testing.T) {
+			cfg, goMod := validConfig(t)
+			cfg.Adapters = map[string]Adapter{
+				"adp": {Direction: dir},
+			}
+			if err := Validate(cfg, goMod); err == nil {
+				t.Fatalf("expected error for direction %q", dir)
+			}
+		})
+	}
+}
+
+func TestValidate_AdapterBadPackageGlob(t *testing.T) {
+	cfg, goMod := validConfig(t)
+	cfg.Adapters = map[string]Adapter{
+		"adp": {Direction: "inbound", Packages: []string{"/abs/path/..."}},
+	}
+	err := Validate(cfg, goMod)
+	if err == nil {
+		t.Fatal("expected error for bad adapter package glob")
+	}
+	if !strings.Contains(err.Error(), "adapter") {
+		t.Errorf("expected 'adapter' in error, got: %v", err)
+	}
+}
+
 func TestValidate_AggregatesWithMultipleErrorsJoined(t *testing.T) {
 	cfg, goMod := validConfig(t)
 	cfg.Aggregates["Bad1"] = Aggregate{Root: ""}


### PR DESCRIPTION
## Summary

Rewrites the self-hosted overlay so archai's own codebase is described as a single bounded context (`model`) plus inbound/outbound/bidirectional adapters, per #82.

- `Config` gains `Adapters map[string]Adapter` with required `Direction` in {inbound, outbound, bidirectional}; `BoundedContext` gains `Name`.
- Validator rejects an aggregate appearing in >1 BC and rejects empty/unknown adapter directions and bad adapter package globs.
- `archai.yaml` collapses the four legacy BCs (`model_core`, `io_adapters`, `serving`, `cli_entry`) into a single `model` BC; transport/runtime/cli surfaces become adapters with explicit direction (`go_extractor`, `yaml_overlay`, `d2_emitter`, `dashboard`, `mcp_server`, `http_server`).
- `docs/user-guide.md` updated with the single-BC example, adapter schema reference, and the at-most-one-context aggregate rule.

Closes #82.

## Test plan

- [x] `go test ./...` — all packages green
- [x] `go vet ./...` — clean
- [x] `make archai-check` — overlay valid, diff empty, validate green
- [x] `archai diagram generate ./... -o /tmp/test.d2` — succeeds
- [x] `archai serve --http 127.0.0.1:47999` + `curl /api/bc/graph` returns a single `bc:model` node, no edges
- [x] Loader tests: single-BC overlay round-trip, adapter direction parsing, invalid-direction rejection
- [x] Validator tests: aggregate-in-multiple-BCs rejected, adapter direction valid/invalid cases, bad adapter glob rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)