### PR TITLE
feat(#90): unify browser graphs around shared display config

### DIFF
--- a/internal/adapter/http/assets/graph.js
+++ b/internal/adapter/http/assets/graph.js
@@ -10,6 +10,41 @@
 // The script is tolerant: when Cytoscape or a layout plugin is missing,
 // we fall back to a cose layout (cytoscape built-in) or display a short
 // hint so the page is never blank.
+//
+// ============================================================================
+// SHARED GRAPH STYLE — SINGLE SOURCE OF TRUTH (#90)
+// ============================================================================
+// All browser diagrams (type-detail, layer-map, layer-map-mini,
+// package-overview, bc-map, bc-map-mini, diff-overlay) share one
+// D2-like visual language defined by `defaultGraphDisplay()` below:
+//
+//   - palette       : neutral ink/border/panel colours and accents
+//   - semantic      : named colours for kind/edge meaning (green=allowed,
+//                     red=violation, etc.)
+//   - node.d2       : the shared base node style (white panel,
+//                     heavy ink border, wrapped left-justified label)
+//   - node.layer    : compound layer container style (top-centered title)
+//   - node.packageChip / kinds.packageContainer{,Soft} : compound
+//                     package container variants
+//   - edge.d2       : the shared base edge style (bezier arrow, ink
+//                     label on white background)
+//   - kinds         : per-kind border colour / shape adjustments (only
+//                     semantic differences, never a separate preset)
+//   - edges         : edge styles by kind (allowed / violation / ...)
+//   - relationships : BC-map relationship qualifiers (#81)
+//   - hover         : the single `.cy-hover` accent applied on mouseover
+//
+// To change the look of every browser graph, edit `defaultGraphDisplay()`.
+// To add semantic meaning for a new kind / edge type, add an entry to
+// `kinds` / `edges` / `relationships` and reference it from the relevant
+// view's `registerView(...)` call below.
+//
+// IMPORTANT: views must NOT introduce their own dark/fill node/edge
+// preset, override the shared base style with arbitrary colours, or
+// duplicate any style block. The HTTP adapter tests guard against
+// that — see `TestLayerGraphStyleUsesSharedD2LikePreset` and
+// `TestDashboardDomainGraphStyleUsesCytoscapeD2LikePreset`.
+// ============================================================================
 (function () {
     'use strict';
 
@@ -164,6 +199,22 @@
                     'text-justification': 'center',
                     'text-max-width': 180,
                     'width': 190,
+                    'height': 'label'
+                },
+                layerMini: {
+                    'background-color': 'palette.panel',
+                    'background-opacity': 1,
+                    'border-color': 'palette.border',
+                    'border-width': 3,
+                    'shape': 'round-rectangle',
+                    'text-valign': 'center',
+                    'text-halign': 'center',
+                    'padding': 10,
+                    'font-size': 11,
+                    'font-weight': 700,
+                    'color': 'palette.ink',
+                    'text-justification': 'center',
+                    'width': 'label',
                     'height': 'label'
                 }
             },
@@ -456,13 +507,15 @@
 
     // Dashboard mini layer-map: layers only, no children, no
     // interactions (click-through navigates to /layers via the parent
-    // <a>).
+    // <a>). Uses the shared `layerMini` node variant defined in
+    // graphDisplay.node so the dashboard mini map stays visually in
+    // line with the rest of the system (#90).
     registerView('layer-map-mini', function () {
         return {
             layout: layeredLayout('DOWN', 16),
             style: [
                 d2LikeNodeStyle(),
-                nodeStyle('d2', 'node[kind = "layer"]', { 'border-color': 'palette.border' }),
+                nodeStyle('layerMini', 'node[kind = "layer"]'),
                 d2LikeEdgeStyle('vertical'),
                 kindEdgeStyle('allowed'),
                 kindEdgeStyle('violation'),


### PR DESCRIPTION
## Summary

Unifies all Cytoscape browser graph views around the shared D2-like display
config exposed by `defaultGraphDisplay()` in `graph.js`. Views now differ only
in semantic kind/color — there are no per-view dark/fill style preset overrides.

The last ad-hoc base-style override (the dashboard mini layer map) was promoted
to a named `layerMini` node variant in the shared dictionary, so every view
goes through `nodeStyle(...)`/`edgeStyle(...)` against the same source of truth.

A documentation block at the top of `graph.js` now declares it the single
source of truth for graph styling and points future style changes at
`defaultGraphDisplay()` rather than per-view overrides.

## Acceptance criteria

- [x] No browser graph view uses a separate dark/fill style preset
- [x] All graph views share base node/edge style config from `graphDisplay`
- [x] Export PNG uses the same white panel background (`palette.panel`)
- [x] Toolbar buttons/selects render consistently for buttons and links
- [x] Labels readable: left-justified for class/function, centered for layer/package
- [x] Hover behavior stable: only clickable nodes highlight
- [x] Arrows visible across compound package/layer containers
- [x] Documented where future graph style changes should be made (top of `graph.js`)
- [x] `go test ./internal/adapter/http` and `go test ./...` pass

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./...` green (including `TestLayerGraphStyleUsesSharedD2LikePreset` and `TestDashboardDomainGraphStyleUsesCytoscapeD2LikePreset`)
- [ ] Manual: open dashboard, package overview, layer map, type detail, BC list, diff overlay; confirm consistent white panel, heavy ink borders, readable labels, working hover/export

Closes #90

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)