### PR TITLE
feat(#87): polish package Overview as diagram-first

### DIFF
--- a/internal/adapter/http/assets/styles.css
+++ b/internal/adapter/http/assets/styles.css
@@ -959,15 +959,22 @@ nav.pkg-tabs {
     color: var(--fg);
 }
 
-dl.pkg-meta-list {
-    display: grid;
-    grid-template-columns: max-content 1fr;
-    column-gap: 0.75rem;
-    row-gap: 0.25rem;
-    font-size: 0.9rem;
+.pkg-overview-files {
+    margin: 0.75rem 0 0;
+    font-size: 0.85rem;
+    color: var(--muted);
+    overflow-wrap: anywhere;
+    word-break: break-word;
 }
-dl.pkg-meta-list dt { color: var(--muted); }
-dl.pkg-meta-list dd { margin: 0; }
+.pkg-overview-files-label {
+    margin-right: 0.4rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    font-size: 0.75rem;
+}
+.pkg-overview-files code {
+    margin-right: 0.4rem;
+}
 
 ul.symbol-list {
     list-style: none;
@@ -1194,8 +1201,7 @@ code,
 .search-name,
 nav.crumbs,
 .pkg-path-muted,
-.diff-table .col-path,
-dl.pkg-meta-list dd {
+.diff-table .col-path {
     overflow-wrap: anywhere;
     word-break: break-word;
 }

--- a/internal/adapter/http/templates/package_detail.html
+++ b/internal/adapter/http/templates/package_detail.html
@@ -94,17 +94,12 @@
          data-layout="dagre"
          data-mode="{{.Mode}}"
          data-height="420"></div>
-    <dl class="pkg-meta-list">
-        <dt>Path</dt><dd><code>{{.Pkg.Path}}</code></dd>
-        <dt>Name</dt><dd><code>{{.Pkg.Name}}</code></dd>
-        {{if .LayerBadge}}<dt>Layer</dt><dd>{{.LayerBadge}}</dd>{{end}}
-        {{if .Pkg.Aggregate}}<dt>Aggregate</dt><dd>{{.Pkg.Aggregate}}</dd>{{end}}
-        {{if .BCName}}<dt>Bounded Context</dt><dd><a href="/bc/{{.BCName}}">{{.BCName}}</a></dd>{{end}}
-        <dt>Files</dt>
-        <dd>
-            {{range .Pkg.SourceFiles}}<code>{{.}}</code> {{end}}
-        </dd>
-    </dl>
+    {{if .Pkg.SourceFiles}}
+    <p class="pkg-overview-files">
+        <span class="pkg-overview-files-label">Files:</span>
+        {{range .Pkg.SourceFiles}}<code>{{.}}</code> {{end}}
+    </p>
+    {{end}}
 </div>
 <script src="/assets/vendor/dagre.min.js" defer></script>
 <script src="/assets/vendor/cytoscape.min.js" defer></script>


### PR DESCRIPTION
## Summary

Finishes the package Overview polish for #87 by making it a true
diagram-first surface. The Cytoscape graph already carries all the
useful semantic detail (public/full toggle, mode-aware filtering,
constructor/factory labels with args + return kind, left-justified
labels) thanks to prior work on main; the remaining gap was the
duplicate sidebar meta-list rendered under the diagram, which made
the tab feel like a mixed list/detail page rather than a diagram.

This PR:
- Drops the `<dl class=\"pkg-meta-list\">` block from `tab-overview` —
  Path/Name are in the page title + breadcrumbs, Layer/Aggregate/BC
  are already in the badge row, so repeating them was pure noise.
- Keeps the unique bit (source files) as a small de-emphasised
  footer under the diagram (`.pkg-overview-files`).
- Removes the now-unused `dl.pkg-meta-list` CSS rules.

## Acceptance criteria mapping

- [x] Public API mode hides unexported symbols/members — `internal/adapter/http/graphs.go:222-225` + `visibleOverviewMethods`/`visibleOverviewFields` (already on main).
- [x] Full detail mode includes unexported symbols/members — `graphs.go:217-220`, tests in `graphs_test.go:313-334` (already on main).
- [x] Constructor/factory nodes show input arguments and return types — `functionOverviewLabel` `graphs.go:361-383`, test `graphs_test.go:308` (already on main).
- [x] Return labels distinguish interface vs struct vs value — `overviewTypeKind` `graphs.go:515-529`, `returnOverviewLine:466` (already on main).
- [x] Labels are left-justified/readable in Cytoscape — `assets/graph.js:138` (`text-justification: 'left'`) (already on main).
- [x] `go test ./internal/adapter/http` and `go test ./...` pass — verified locally.
- [x] Overview is diagram-first, not a mixed list/detail page — this PR.

Closes #87

## Test plan

- [x] `go test ./...` passes (full suite green).
- [x] `go vet ./...` clean.
- [ ] Manual: visit `/packages/<path>` Overview tab, confirm the diagram is the dominant element and the only meta below it is the small Files line.
- [ ] Manual: toggle Public API / Full detail, confirm exported-only vs full members render and meta toggle persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)