### PR TITLE
feat(#101): tools/archai-java-analyzer — JavaParser JAR emitting JavaFacts JSON

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@
 # Per-worktree runtime state (M9): CURRENT pointer + serve.json record
 # live here so parallel worktrees don't collide on ports or target ids.
 .arch/.worktree/
+
+# Java analyzer (issue #101) build output
+tools/archai-java-analyzer/target/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-.PHONY: build test clean install version archai-generate archai-baseline archai-check archai-smoke
+.PHONY: build build-all test clean install version \
+        java-analyzer java-analyzer-test java-analyzer-clean \
+        archai-generate archai-baseline archai-check archai-smoke
 
 # VERSION is stamped into the binary at build time via -ldflags. By
 # default it is derived from `git describe` so unreleased builds show
@@ -10,9 +12,31 @@ ARCHAI ?= bin/archai
 ARCHAI_PACKAGES ?= ./...
 ARCHAI_TARGET ?= self-hosted
 
+# Java analyzer (issue #101): separate sub-project under tools/, only built
+# explicitly via `make java-analyzer` or `make build-all`. Default `make
+# build` stays Go-only — Go-only users don't need a JVM.
+JAVA_ANALYZER_DIR := tools/archai-java-analyzer
+JAVA_ANALYZER_JAR := $(JAVA_ANALYZER_DIR)/target/archai-java-analyzer.jar
+MVN ?= mvn
+
 build:
 	@mkdir -p bin
 	go build -ldflags "$(LDFLAGS)" -o bin/archai ./cmd/archai
+
+# build-all: Go binary + Java analyzer JAR. Use this on releases that bundle
+# the JAR alongside the binary; CI invokes it for tagged builds.
+build-all: build java-analyzer
+	@echo "built: bin/archai + $(JAVA_ANALYZER_JAR)"
+
+java-analyzer:
+	$(MVN) -f $(JAVA_ANALYZER_DIR)/pom.xml -DskipTests package
+	@echo "built: $(JAVA_ANALYZER_JAR)"
+
+java-analyzer-test:
+	$(MVN) -f $(JAVA_ANALYZER_DIR)/pom.xml test
+
+java-analyzer-clean:
+	$(MVN) -f $(JAVA_ANALYZER_DIR)/pom.xml clean
 
 install:
 	go install -ldflags "$(LDFLAGS)" ./cmd/archai
@@ -47,3 +71,4 @@ archai-smoke: build
 
 clean:
 	rm -rf bin/
+	rm -rf $(JAVA_ANALYZER_DIR)/target/

--- a/tools/archai-java-analyzer/README.md
+++ b/tools/archai-java-analyzer/README.md
@@ -1,0 +1,152 @@
+# archai-java-analyzer
+
+JavaParser-based source analyzer that emits `JavaFacts` JSON for the archai
+Go-side Java adapter. Part of [issue #100][epic] / [#101][ticket].
+
+[epic]: https://github.com/kgatilin/archai/issues/100
+[ticket]: https://github.com/kgatilin/archai/issues/101
+
+## What it does
+
+Walks one or more Java source roots and prints a JSON document describing
+every package / class / interface / enum / record / annotation found:
+modifiers, fields, methods (with parameters, return type, throws, calls),
+imports, and annotations. The shape is intentionally Java-native — see
+[SCHEMA.md](./SCHEMA.md). All archai-domain interpretation (stereotypes,
+hexagonal mapping) lives in the Go translator (`internal/adapter/java/`,
+issue #102), not here.
+
+## Requirements
+
+- JVM 17 or newer (Linux / macOS supported).
+- Maven 3.9+ to build from source.
+
+## Build
+
+```sh
+mvn -f tools/archai-java-analyzer/pom.xml package
+# → tools/archai-java-analyzer/target/archai-java-analyzer.jar
+```
+
+From the archai repo root, the convenience target is:
+
+```sh
+make java-analyzer        # build only
+make build-all            # build Go binary + JAR side-by-side
+```
+
+The default `make build` stays Go-only (preserves «no JVM needed for Go-only
+users»).
+
+## Run
+
+```sh
+java -jar tools/archai-java-analyzer/target/archai-java-analyzer.jar \
+    path/to/src/main/java > facts.json
+```
+
+Multiple source roots are accepted. JSON is printed to stdout; progress and
+errors go to stderr; exit code is 0 on success, 1 on hard failure.
+
+### Flags
+
+| Flag                     | Effect                                                  |
+|--------------------------|---------------------------------------------------------|
+| `--pretty`               | Pretty-print JSON (default: minified, single line).     |
+| `--include-private`      | Include private members (default).                       |
+| `--no-include-private`   | Skip private members.                                    |
+| `--version`              | Print schema version and exit.                           |
+| `-h`, `--help`           | Show usage.                                              |
+
+### Hard failures vs warnings
+
+- Missing or non-existent CLI argument → exit 1, message on stderr.
+- Empty source root → exit 0, valid JavaFacts with empty `classes`.
+- Unparseable single file in an otherwise valid tree → recorded under
+  `parse_warnings` in the JSON, run continues.
+- All files unparseable → exit 1, warnings printed to stderr.
+
+## JavaFacts schema (v1)
+
+See [SCHEMA.md](./SCHEMA.md) for the full contract. At a glance:
+
+```json
+{
+  "schema": "javafacts/v1",
+  "src_roots": ["..."],
+  "packages": ["com.example"],
+  "classes": [
+    {
+      "fqn": "com.example.Greeter",
+      "kind": "class",
+      "modifiers": ["public"],
+      "fields": [...], "methods": [...]
+    }
+  ],
+  "imports": [{"from": "...", "to_class": "...", "kind": "class"}],
+  "parse_warnings": []
+}
+```
+
+Output is deterministic: classes sorted by `fqn`, imports sorted, packages
+sorted, members in source order, no timestamps.
+
+## Tests
+
+```sh
+mvn -f tools/archai-java-analyzer/pom.xml test
+```
+
+Golden fixtures live under `src/test/resources/golden/<name>/` and pair a
+small Java source tree with an `expected.json`. The `AnalyzerTest`
+JUnit test factory runs every fixture and compares byte-for-byte.
+
+To regenerate golden files after an intentional schema change:
+
+```sh
+mvn -f tools/archai-java-analyzer/pom.xml -Darchai.update-golden=true test
+```
+
+Re-running without the flag confirms determinism.
+
+Current fixtures:
+
+| Fixture                      | What it covers                                |
+|------------------------------|-----------------------------------------------|
+| `simple-class`               | Single class, fields, methods, calls, imports |
+| `interface-with-default`     | Interface modifiers + default method bodies   |
+| `record`                     | Record kind, components-as-fields             |
+| `sealed-and-enums`           | `sealed`, `permits`, enum constants           |
+| `inheritance`                | `extends`, `implements`, multi-file package   |
+
+## Layout
+
+```
+tools/archai-java-analyzer/
+├── pom.xml                                     # Maven build (shade fat-jar)
+├── README.md                                   # this file
+├── SCHEMA.md                                   # JavaFacts schema
+└── src/
+    ├── main/java/io/archai/javaanalyzer/
+    │   ├── Main.java                           # CLI entry
+    │   ├── Analyzer.java                       # JavaParser walk → facts
+    │   ├── facts/                              # JavaFacts data classes
+    │   └── json/Writer.java                    # Jackson serializer
+    └── test/
+        ├── java/io/archai/javaanalyzer/        # JUnit 5 tests
+        └── resources/golden/                   # input + expected.json pairs
+```
+
+## Notes for downstream consumers (issue #102)
+
+- The JAR exits 1 only on hard failure. Empty `classes` + non-empty
+  `parse_warnings` always means «every file failed»; the Go side does not
+  need to second-guess this.
+- `to_class` on calls is best-effort textual scope. The Go translator can
+  resolve to module-relative FQNs by joining with the analyzed package set.
+- `external: true` on a `JavaCall` is reserved for future use; v1 always
+  emits `false`. The translator decides external-ness based on the analyzed
+  set.
+- Field/method/parameter ordering inside a class is source-order — stable
+  because JavaParser parses deterministically. Cross-class order is
+  alphabetical FQN.

--- a/tools/archai-java-analyzer/SCHEMA.md
+++ b/tools/archai-java-analyzer/SCHEMA.md
@@ -1,0 +1,183 @@
+# JavaFacts JSON schema
+
+`schema: "javafacts/v1"` — emitted by `archai-java-analyzer.jar`. Consumed by
+`internal/adapter/java/` on the Go side (issue #102). Bump the version on any
+breaking change to this contract.
+
+## Design principles
+
+1. **AST-shape, not archai-shape.** The Java analyzer is intentionally
+   semantically dumb: it dumps what the AST tells it. No archai stereotypes,
+   no domain mapping, no hexagonal vocabulary. All semantic interpretation
+   lives in the Go translator.
+2. **Empty arrays explicit.** Empty collections always serialise as `[]`,
+   never omitted — keeps the downstream parser simple.
+3. **Deterministic ordering.** Classes sort by FQN. Imports sort by
+   `(from, to_class, kind)`. Members within a class follow source order
+   (already deterministic per parsed file). Packages sort alphabetically.
+4. **Best-effort resolution.** Where JavaParser's symbol solver succeeds the
+   `to_class` and annotation `fqn` fields carry resolved fully-qualified
+   names; otherwise the textual form as written is preserved. The Go
+   translator decides what to do with unresolved references.
+
+## Top-level shape
+
+```json
+{
+  "schema": "javafacts/v1",
+  "src_roots": ["src/main/java"],
+  "packages": ["com.example", "com.example.util"],
+  "classes": [ /* JavaClass… */ ],
+  "imports":  [ /* JavaImport… */ ],
+  "parse_warnings": [ /* ParseWarning… */ ]
+}
+```
+
+| Field            | Type            | Meaning                                                                 |
+|------------------|-----------------|-------------------------------------------------------------------------|
+| `schema`         | string          | Schema version. Always `javafacts/v1` for this revision.                |
+| `src_roots`      | `[]string`      | Source roots passed on the CLI, in input order.                         |
+| `packages`       | `[]string`      | All Java package names encountered, sorted alphabetically.              |
+| `classes`        | `[]JavaClass`   | Type declarations (top-level + nested). Sorted by `fqn`.                |
+| `imports`        | `[]JavaImport`  | One entry per `import` statement.                                       |
+| `parse_warnings` | `[]ParseWarning`| Non-fatal parse problems. Empty array on a fully clean run.             |
+
+## `JavaClass`
+
+```json
+{
+  "fqn": "com.example.Greeter",
+  "package": "com.example",
+  "name": "Greeter",
+  "kind": "class|interface|enum|record|annotation",
+  "modifiers": ["public", "final"],
+  "type_parameters": ["T extends Number"],
+  "extends": "com.example.Base",
+  "implements": ["com.example.Runnable"],
+  "permits": [],
+  "source_file": "com/example/Greeter.java",
+  "doc": "javadoc text with leading * stripped",
+  "annotations": [ /* JavaAnnotation… */ ],
+  "fields":  [ /* JavaField… */ ],
+  "methods": [ /* JavaMethod… */ ],
+  "enum_constants": []
+}
+```
+
+Notes:
+- **Nested types** are emitted as siblings with `Outer.Inner` in `name` and
+  `pkg.Outer.Inner` in `fqn`. `kind` reflects the nested declaration's own
+  kind.
+- **Interface super-interfaces** (Java's `interface A extends B, C`) populate
+  `implements`, not `extends` — keeps a single edge collection downstream.
+  `extends` on an interface is always empty. Documented choice; the Go
+  translator interprets `implements` on a `kind:"interface"` as
+  super-interfaces.
+- **Records** populate `fields` from their components (record components are
+  always private+final). The canonical and any explicit constructors land in
+  `methods`.
+- **Modifiers** preserve declared order (matches source).
+- **`source_file`** is relative to the matching `src_roots[]` entry, with
+  forward-slash separators regardless of host OS — keeps output portable
+  across Linux/macOS golden tests.
+- **`doc`** has the leading `*` (and one optional space) stripped from each
+  javadoc body line; lines join with `\n`. Empty when no javadoc is present.
+
+## `JavaField`
+
+```json
+{ "name": "x", "type": "int", "modifiers": ["private","final"],
+  "annotations": [], "doc": "" }
+```
+
+One entry per declared name: `int x, y;` → two `JavaField` entries.
+
+## `JavaMethod`
+
+```json
+{
+  "name": "m",
+  "kind": "method|constructor",
+  "modifiers": ["public"],
+  "type_parameters": ["T"],
+  "params": [ /* JavaParam… */ ],
+  "returns": "void",
+  "throws": ["java.io.IOException"],
+  "annotations": [],
+  "doc": "",
+  "calls": [ /* JavaCall… */ ]
+}
+```
+
+Constructors set `kind:"constructor"` and `returns:"void"`; their `name`
+matches the enclosing class's simple name. Static initialisers are not
+emitted (out of scope for v1).
+
+## `JavaParam`
+
+```json
+{ "name": "tricks", "type": "List<String>", "varargs": false,
+  "modifiers": [], "annotations": [] }
+```
+
+Varargs parameters set `"varargs": true`; the `type` is the element type
+(`String` for `String... args`).
+
+## `JavaCall`
+
+```json
+{ "to_class": "Math", "to_method": "sqrt", "static": true, "external": false }
+```
+
+| Field       | Meaning                                                                              |
+|-------------|--------------------------------------------------------------------------------------|
+| `to_class`  | Receiver textual scope (resolved FQN if symbol solver succeeded). Empty for unqualified calls. |
+| `to_method` | Method name as written.                                                              |
+| `static`    | Heuristic — `true` when `to_class` looks like a Type (uppercase, no dot).            |
+| `external`  | `true` when the receiver couldn't be resolved to the analyzed source set. v1 leaves this `false`; the Go translator may flip it after applying the analyzed-package set. |
+
+## `JavaImport`
+
+```json
+{ "from": "com.example.Greeter", "to_class": "java.util.Objects", "kind": "class" }
+```
+
+`kind` ∈ {`class`, `static`, `wildcard`, `static_wildcard`}. `from` is the
+FQN of the compilation unit's primary class; `to_class` is the imported
+symbol's textual form (FQN for normal imports, `pkg.*` for wildcards).
+
+## `JavaAnnotation`
+
+```json
+{ "fqn": "java.lang.Override", "args": [] }
+```
+
+`args` carry the textual form of annotation members:
+- Single-member: `@Path("/users")` → `args: ["\"/users\""]`
+- Normal: `@Mapping(method=GET, path="/x")` → `args: ["method=GET", "path=\"/x\""]`
+- Marker: `@Override` → `args: []`
+
+No type resolution on argument values — downstream pattern-matches on the
+textual form.
+
+## `ParseWarning`
+
+```json
+{ "file": "src/com/Broken.java", "message": "expected ';'" }
+```
+
+Non-fatal. Emitted when JavaParser cannot parse a single file but the run
+has at least one successful file. If every file fails, the analyzer exits
+with code 1 and prints the warnings to stderr instead.
+
+## What's not in v1
+
+- Static initialiser blocks
+- Resolved annotation argument values (only textual)
+- Cross-JAR type resolution (only same-source-set resolution attempted)
+- Method-body fact other than method calls (no field reads, control flow,
+  lambda targets)
+- Generic type substitutions (parameter types stay as written, e.g.
+  `List<String>` rather than `java.util.List<java.lang.String>`)
+
+These are explicit follow-ups, captured as TODOs in code where relevant.

--- a/tools/archai-java-analyzer/pom.xml
+++ b/tools/archai-java-analyzer/pom.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>io.archai</groupId>
+  <artifactId>archai-java-analyzer</artifactId>
+  <version>0.1.0</version>
+  <packaging>jar</packaging>
+
+  <name>archai-java-analyzer</name>
+  <description>
+    JavaParser-based source analyzer that emits JavaFacts JSON for the archai
+    Go-side adapter. Java side is intentionally semantically dumb: it dumps
+    the AST shape without applying any archai-domain concepts.
+  </description>
+
+  <properties>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+    <javaparser.version>3.26.2</javaparser.version>
+    <jackson.version>2.18.2</jackson.version>
+    <junit.version>5.11.4</junit.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.github.javaparser</groupId>
+      <artifactId>javaparser-symbol-solver-core</artifactId>
+      <version>${javaparser.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <finalName>archai-java-analyzer</finalName>
+
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.13.0</version>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.5.2</version>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.6.0</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
+              <shadedArtifactAttached>false</shadedArtifactAttached>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <manifestEntries>
+                    <Main-Class>io.archai.javaanalyzer.Main</Main-Class>
+                    <Implementation-Title>archai-java-analyzer</Implementation-Title>
+                    <Implementation-Version>${project.version}</Implementation-Version>
+                  </manifestEntries>
+                </transformer>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+              </transformers>
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                    <exclude>module-info.class</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/tools/archai-java-analyzer/src/main/java/io/archai/javaanalyzer/Analyzer.java
+++ b/tools/archai-java-analyzer/src/main/java/io/archai/javaanalyzer/Analyzer.java
@@ -1,0 +1,544 @@
+package io.archai.javaanalyzer;
+
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ParseResult;
+import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.ImportDeclaration;
+import com.github.javaparser.ast.Modifier;
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.body.AnnotationDeclaration;
+import com.github.javaparser.ast.body.BodyDeclaration;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.ConstructorDeclaration;
+import com.github.javaparser.ast.body.EnumConstantDeclaration;
+import com.github.javaparser.ast.body.EnumDeclaration;
+import com.github.javaparser.ast.body.FieldDeclaration;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.body.Parameter;
+import com.github.javaparser.ast.body.RecordDeclaration;
+import com.github.javaparser.ast.body.TypeDeclaration;
+import com.github.javaparser.ast.body.VariableDeclarator;
+import com.github.javaparser.ast.expr.AnnotationExpr;
+import com.github.javaparser.ast.expr.MemberValuePair;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.expr.NormalAnnotationExpr;
+import com.github.javaparser.ast.expr.SingleMemberAnnotationExpr;
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
+import com.github.javaparser.ast.type.ReferenceType;
+import com.github.javaparser.ast.type.TypeParameter;
+import com.github.javaparser.utils.SourceRoot;
+
+import io.archai.javaanalyzer.facts.JavaAnnotation;
+import io.archai.javaanalyzer.facts.JavaCall;
+import io.archai.javaanalyzer.facts.JavaClass;
+import io.archai.javaanalyzer.facts.JavaFacts;
+import io.archai.javaanalyzer.facts.JavaField;
+import io.archai.javaanalyzer.facts.JavaImport;
+import io.archai.javaanalyzer.facts.JavaMethod;
+import io.archai.javaanalyzer.facts.JavaParam;
+import io.archai.javaanalyzer.facts.ParseWarning;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+/**
+ * Walks one or more source roots with JavaParser and collects {@link
+ * JavaFacts}.
+ *
+ * <p>The analyzer is intentionally semantically dumb: it dumps what the AST
+ * tells it. Schema interpretation (stereotypes, archai-domain mapping) lives
+ * in the Go translator, never here.
+ *
+ * <p>JavaParser's symbol solver is configured per-root with a {@link
+ * com.github.javaparser.symbolsolver.resolution.typesolvers.JavaParserTypeSolver}
+ * + {@link com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver}
+ * so resolution works inside the analyzed source set and falls back to
+ * runtime-classpath types (i.e. {@code java.*}). Anything outside both is
+ * left as the textual form and marked {@link JavaCall#isExternal()}.
+ *
+ * <p>Output ordering: classes sorted by FQN, members within a class kept in
+ * source order (deterministic per file), imports sorted, packages sorted.
+ */
+public final class Analyzer {
+
+    private final boolean includePrivate;
+
+    public Analyzer() {
+        this(true);
+    }
+
+    public Analyzer(boolean includePrivate) {
+        this.includePrivate = includePrivate;
+    }
+
+    /**
+     * Analyze the given source roots and return the merged {@link JavaFacts}.
+     *
+     * @param srcRoots one or more directories containing Java source
+     * @return populated {@link JavaFacts}
+     * @throws IOException if a root cannot be read
+     */
+    public JavaFacts analyze(List<Path> srcRoots) throws IOException {
+        JavaFacts facts = new JavaFacts();
+
+        // Record src_roots in input order — keeps origin information visible
+        // to the downstream consumer without forcing canonical paths.
+        for (Path root : srcRoots) {
+            facts.getSrcRoots().add(root.toString());
+        }
+
+        // Resolved roots used for relative-path computation in source_file.
+        List<Path> rootsAbs = new ArrayList<>(srcRoots.size());
+        for (Path root : srcRoots) {
+            rootsAbs.add(root.toAbsolutePath().normalize());
+        }
+
+        TreeSet<String> packages = new TreeSet<>();
+        List<JavaClass> classes = new ArrayList<>();
+        List<JavaImport> imports = new ArrayList<>();
+        List<ParseWarning> warnings = new ArrayList<>();
+
+        ParserConfiguration parserConfig = new ParserConfiguration()
+            .setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17);
+
+        for (int i = 0; i < srcRoots.size(); i++) {
+            Path root = srcRoots.get(i);
+            if (!Files.isDirectory(root)) {
+                warnings.add(new ParseWarning(root.toString(), "src-root is not a directory"));
+                continue;
+            }
+
+            SourceRoot sourceRoot = new SourceRoot(root, parserConfig);
+            // Don't re-write input on close.
+            sourceRoot.setPrinter(cu -> cu.toString());
+
+            List<ParseResult<CompilationUnit>> results = sourceRoot.tryToParseParallelized();
+
+            Path rootAbs = rootsAbs.get(i);
+
+            for (ParseResult<CompilationUnit> result : results) {
+                if (!result.isSuccessful() || result.getResult().isEmpty()) {
+                    String file = result.getResult()
+                        .flatMap(CompilationUnit::getStorage)
+                        .map(s -> s.getPath().toString())
+                        .orElse("<unknown>");
+                    String msg = result.getProblems().stream()
+                        .map(p -> p.getMessage())
+                        .collect(Collectors.joining("; "));
+                    if (msg.isEmpty()) {
+                        msg = "parse failed";
+                    }
+                    warnings.add(new ParseWarning(file, msg));
+                    continue;
+                }
+
+                CompilationUnit cu = result.getResult().get();
+                processCompilationUnit(cu, rootAbs, packages, classes, imports);
+            }
+        }
+
+        // Deterministic ordering — classes by FQN, imports by (from, to_class, kind).
+        classes.sort(Comparator.comparing(JavaClass::getFqn));
+        imports.sort(Comparator
+            .comparing(JavaImport::getFrom)
+            .thenComparing(JavaImport::getToClass)
+            .thenComparing(JavaImport::getKind));
+
+        facts.getPackages().addAll(packages);
+        facts.getClasses().addAll(classes);
+        facts.getImports().addAll(imports);
+        facts.getParseWarnings().addAll(warnings);
+
+        return facts;
+    }
+
+    private void processCompilationUnit(
+        CompilationUnit cu,
+        Path rootAbs,
+        TreeSet<String> packages,
+        List<JavaClass> classes,
+        List<JavaImport> imports
+    ) {
+        String pkg = cu.getPackageDeclaration()
+            .map(p -> p.getNameAsString())
+            .orElse("");
+
+        if (!pkg.isEmpty()) {
+            packages.add(pkg);
+        }
+
+        String sourceFile = relativiseSource(cu, rootAbs);
+
+        // Primary class FQN — used as the "from" attribution for imports.
+        // Fall back to package name if a CU somehow has no top-level type.
+        String primaryFqn = cu.getTypes().stream()
+            .findFirst()
+            .map(t -> joinFqn(pkg, t.getNameAsString()))
+            .orElse(pkg);
+
+        // Imports — captured per CU and attributed to the primary class.
+        for (ImportDeclaration imp : cu.getImports()) {
+            JavaImport ji = new JavaImport();
+            ji.setFrom(primaryFqn);
+            ji.setToClass(imp.getNameAsString());
+            String kind;
+            if (imp.isStatic() && imp.isAsterisk()) {
+                kind = "static_wildcard";
+            } else if (imp.isStatic()) {
+                kind = "static";
+            } else if (imp.isAsterisk()) {
+                kind = "wildcard";
+            } else {
+                kind = "class";
+            }
+            ji.setKind(kind);
+            imports.add(ji);
+        }
+
+        // Top-level type declarations (and their nested types).
+        for (TypeDeclaration<?> td : cu.getTypes()) {
+            collectType(td, pkg, sourceFile, classes);
+        }
+    }
+
+    /**
+     * Recursively collect a top-level or nested type declaration into the
+     * facts list. Nested types are emitted as separate classes with
+     * {@code Outer.Inner} as the simple name and {@code pkg.Outer.Inner} as
+     * the FQN — keeps a flat class list while preserving nesting in the FQN.
+     */
+    private void collectType(
+        TypeDeclaration<?> td,
+        String pkg,
+        String sourceFile,
+        List<JavaClass> classes
+    ) {
+        if (!includePrivate && hasModifier(td, Modifier.Keyword.PRIVATE)) {
+            return;
+        }
+
+        JavaClass jc = new JavaClass();
+
+        String simpleName = computeNestedName(td);
+        jc.setName(simpleName);
+        jc.setPackage(pkg);
+        jc.setFqn(joinFqn(pkg, simpleName));
+        jc.setSourceFile(sourceFile);
+
+        if (td instanceof ClassOrInterfaceDeclaration coid) {
+            jc.setKind(coid.isInterface() ? "interface" : "class");
+            jc.getTypeParameters().addAll(typeParamsToStrings(coid.getTypeParameters()));
+
+            if (!coid.isInterface() && !coid.getExtendedTypes().isEmpty()) {
+                jc.setExtends(coid.getExtendedTypes(0).getNameWithScope());
+            }
+            if (coid.isInterface()) {
+                // Interfaces use 'extends' for super-interfaces; record them as implements
+                // is reserved for class -> interface, so super-interfaces of interfaces
+                // go into 'implements' to keep one shape downstream. Document in SCHEMA.md.
+                for (ClassOrInterfaceType t : coid.getExtendedTypes()) {
+                    jc.getImplements().add(t.getNameWithScope());
+                }
+            } else {
+                for (ClassOrInterfaceType t : coid.getImplementedTypes()) {
+                    jc.getImplements().add(t.getNameWithScope());
+                }
+            }
+            for (ClassOrInterfaceType t : coid.getPermittedTypes()) {
+                jc.getPermits().add(t.getNameWithScope());
+            }
+        } else if (td instanceof EnumDeclaration ed) {
+            jc.setKind("enum");
+            for (ClassOrInterfaceType t : ed.getImplementedTypes()) {
+                jc.getImplements().add(t.getNameWithScope());
+            }
+            for (EnumConstantDeclaration c : ed.getEntries()) {
+                jc.getEnumConstants().add(c.getNameAsString());
+            }
+        } else if (td instanceof RecordDeclaration rd) {
+            jc.setKind("record");
+            jc.getTypeParameters().addAll(typeParamsToStrings(rd.getTypeParameters()));
+            for (ClassOrInterfaceType t : rd.getImplementedTypes()) {
+                jc.getImplements().add(t.getNameWithScope());
+            }
+            // Record components surface as fields — they are part of the record's
+            // public API and downstream needs them.
+            for (Parameter p : rd.getParameters()) {
+                JavaField f = new JavaField();
+                f.setName(p.getNameAsString());
+                f.setType(p.getType().asString());
+                f.getModifiers().add("final");
+                f.getModifiers().add("private");
+                f.getAnnotations().addAll(annotationsOf(p.getAnnotations()));
+                jc.getFields().add(f);
+            }
+        } else if (td instanceof AnnotationDeclaration) {
+            jc.setKind("annotation");
+        } else {
+            jc.setKind("class");
+        }
+
+        // Modifiers — preserve declared order from JavaParser (matches source
+        // order) but stable since AST is deterministic.
+        for (Modifier m : td.getModifiers()) {
+            jc.getModifiers().add(m.getKeyword().asString());
+        }
+
+        // Annotations on the type itself.
+        jc.getAnnotations().addAll(annotationsOf(td.getAnnotations()));
+
+        // Doc comment — first line trimmed, full body preserved with single
+        // {@code \n} line separators.
+        td.getJavadocComment()
+            .ifPresent(c -> jc.setDoc(stripJavadoc(c.getContent())));
+
+        // Body declarations: fields, methods, constructors. Order preserved
+        // from source.
+        List<? extends BodyDeclaration<?>> members = td.getMembers();
+        for (BodyDeclaration<?> member : members) {
+            if (member instanceof FieldDeclaration fd) {
+                if (!includePrivate && fd.isPrivate()) {
+                    continue;
+                }
+                List<String> mods = modifiersToStrings(fd.getModifiers());
+                List<JavaAnnotation> anns = annotationsOf(fd.getAnnotations());
+                String doc = fd.getJavadocComment().map(c -> stripJavadoc(c.getContent())).orElse("");
+                for (VariableDeclarator v : fd.getVariables()) {
+                    JavaField f = new JavaField();
+                    f.setName(v.getNameAsString());
+                    f.setType(v.getType().asString());
+                    f.getModifiers().addAll(mods);
+                    f.getAnnotations().addAll(anns);
+                    f.setDoc(doc);
+                    jc.getFields().add(f);
+                }
+            } else if (member instanceof MethodDeclaration md) {
+                if (!includePrivate && md.isPrivate()) {
+                    continue;
+                }
+                jc.getMethods().add(buildMethod(md));
+            } else if (member instanceof ConstructorDeclaration cd) {
+                if (!includePrivate && cd.isPrivate()) {
+                    continue;
+                }
+                jc.getMethods().add(buildConstructor(cd));
+            } else if (member instanceof TypeDeclaration<?> nested) {
+                // Nested type — emit as a sibling class with Outer.Inner naming.
+                collectType(nested, pkg, sourceFile, classes);
+            }
+            // Initializers and other members are intentionally skipped (out of
+            // scope for v1).
+        }
+
+        classes.add(jc);
+    }
+
+    private JavaMethod buildMethod(MethodDeclaration md) {
+        JavaMethod jm = new JavaMethod();
+        jm.setName(md.getNameAsString());
+        jm.setKind("method");
+        jm.getModifiers().addAll(modifiersToStrings(md.getModifiers()));
+        jm.getTypeParameters().addAll(typeParamsToStrings(md.getTypeParameters()));
+        jm.setReturns(md.getType().asString());
+        for (Parameter p : md.getParameters()) {
+            jm.getParams().add(buildParam(p));
+        }
+        for (ReferenceType t : md.getThrownExceptions()) {
+            jm.getThrows().add(t.asString());
+        }
+        jm.getAnnotations().addAll(annotationsOf(md.getAnnotations()));
+        md.getJavadocComment().ifPresent(c -> jm.setDoc(stripJavadoc(c.getContent())));
+        jm.getCalls().addAll(extractCalls(md));
+        return jm;
+    }
+
+    private JavaMethod buildConstructor(ConstructorDeclaration cd) {
+        JavaMethod jm = new JavaMethod();
+        jm.setName(cd.getNameAsString());
+        jm.setKind("constructor");
+        jm.getModifiers().addAll(modifiersToStrings(cd.getModifiers()));
+        jm.getTypeParameters().addAll(typeParamsToStrings(cd.getTypeParameters()));
+        jm.setReturns("void");
+        for (Parameter p : cd.getParameters()) {
+            jm.getParams().add(buildParam(p));
+        }
+        for (ReferenceType t : cd.getThrownExceptions()) {
+            jm.getThrows().add(t.asString());
+        }
+        jm.getAnnotations().addAll(annotationsOf(cd.getAnnotations()));
+        cd.getJavadocComment().ifPresent(c -> jm.setDoc(stripJavadoc(c.getContent())));
+        jm.getCalls().addAll(extractCalls(cd));
+        return jm;
+    }
+
+    private JavaParam buildParam(Parameter p) {
+        JavaParam jp = new JavaParam();
+        jp.setName(p.getNameAsString());
+        jp.setType(p.getType().asString());
+        jp.setVarargs(p.isVarArgs());
+        jp.getModifiers().addAll(modifiersToStrings(p.getModifiers()));
+        jp.getAnnotations().addAll(annotationsOf(p.getAnnotations()));
+        return jp;
+    }
+
+    /**
+     * Extract method calls from a method body. Resolution is best-effort:
+     * if the symbol solver is not configured (the default in v1), the call
+     * receiver is captured textually and {@link JavaCall#isExternal()} is
+     * left {@code false} — Go side decides.
+     *
+     * <p>TODO: wire JavaParser symbol solver in a follow-up so {@code
+     * to_class} is the resolved FQN when the receiver type lives in the
+     * analyzed source set. For v1 the textual scope is enough to enable the
+     * Go translator to do same-package matching.
+     */
+    private List<JavaCall> extractCalls(Node bodyOwner) {
+        List<JavaCall> out = new ArrayList<>();
+        bodyOwner.findAll(MethodCallExpr.class).forEach(call -> {
+            JavaCall jc = new JavaCall();
+            jc.setToMethod(call.getNameAsString());
+            jc.setToClass(call.getScope()
+                .map(Object::toString)
+                .orElse(""));
+            // Static-ness: best-effort textual heuristic — if the receiver
+            // looks like a Type (starts uppercase) treat as static. The Go
+            // side can refine this once #102 wires symbol resolution.
+            String scope = jc.getToClass();
+            jc.setStatic(!scope.isEmpty()
+                && Character.isUpperCase(scope.charAt(0))
+                && scope.indexOf('.') < 0);
+            // External flag: left false in v1 since we do not resolve. The
+            // translator (Go side) can flip it based on the analyzed
+            // package set.
+            jc.setExternal(false);
+            out.add(jc);
+        });
+        // Calls follow source order (findAll is depth-first, document order)
+        // — keeps output deterministic without further sorting.
+        return out;
+    }
+
+    private List<JavaAnnotation> annotationsOf(NodeList<AnnotationExpr> nodeList) {
+        List<JavaAnnotation> out = new ArrayList<>();
+        for (AnnotationExpr a : nodeList) {
+            JavaAnnotation ja = new JavaAnnotation();
+            ja.setFqn(a.getNameAsString());
+            if (a instanceof SingleMemberAnnotationExpr sm) {
+                ja.getArgs().add(sm.getMemberValue().toString());
+            } else if (a instanceof NormalAnnotationExpr nm) {
+                for (MemberValuePair mvp : nm.getPairs()) {
+                    ja.getArgs().add(mvp.getNameAsString() + "=" + mvp.getValue().toString());
+                }
+            }
+            out.add(ja);
+        }
+        return out;
+    }
+
+    private static List<String> modifiersToStrings(NodeList<Modifier> mods) {
+        List<String> out = new ArrayList<>(mods.size());
+        for (Modifier m : mods) {
+            out.add(m.getKeyword().asString());
+        }
+        return out;
+    }
+
+    private static List<String> typeParamsToStrings(NodeList<TypeParameter> params) {
+        List<String> out = new ArrayList<>(params.size());
+        for (TypeParameter p : params) {
+            String s = p.getNameAsString();
+            if (!p.getTypeBound().isEmpty()) {
+                s += " extends " + p.getTypeBound().stream()
+                    .map(Object::toString)
+                    .collect(Collectors.joining(" & "));
+            }
+            out.add(s);
+        }
+        return out;
+    }
+
+    private static boolean hasModifier(TypeDeclaration<?> td, Modifier.Keyword kw) {
+        for (Modifier m : td.getModifiers()) {
+            if (m.getKeyword() == kw) return true;
+        }
+        return false;
+    }
+
+    /**
+     * Build the simple name for a possibly-nested type. Top-level: just the
+     * simple name. Nested: dot-joined chain through enclosing type names.
+     */
+    private static String computeNestedName(TypeDeclaration<?> td) {
+        List<String> parts = new ArrayList<>();
+        Node current = td;
+        while (current != null) {
+            if (current instanceof TypeDeclaration<?> t) {
+                parts.add(0, t.getNameAsString());
+            }
+            current = current.getParentNode().orElse(null);
+        }
+        return String.join(".", parts);
+    }
+
+    private static String joinFqn(String pkg, String name) {
+        if (pkg == null || pkg.isEmpty()) return name;
+        return pkg + "." + name;
+    }
+
+    /**
+     * Strip the leading {@code *} (and optional space) that JavaParser
+     * preserves on each line of a javadoc body. Lines are trimmed, leading
+     * blanks dropped, and the result rejoined with {@code "\n"} so output
+     * is portable across platforms.
+     */
+    private static String stripJavadoc(String raw) {
+        if (raw == null || raw.isEmpty()) return "";
+        String[] lines = raw.split("\\r?\\n", -1);
+        List<String> out = new ArrayList<>(lines.length);
+        for (String line : lines) {
+            String trimmed = line.trim();
+            if (trimmed.startsWith("*")) {
+                trimmed = trimmed.substring(1);
+                if (trimmed.startsWith(" ")) {
+                    trimmed = trimmed.substring(1);
+                } else {
+                    // Strip exactly one space if present; otherwise keep
+                    // remainder verbatim.
+                    trimmed = trimmed.stripLeading();
+                }
+            }
+            out.add(trimmed);
+        }
+        // Trim leading/trailing blank lines but preserve blank lines inside
+        // the body so paragraph breaks survive.
+        int start = 0;
+        while (start < out.size() && out.get(start).isEmpty()) start++;
+        int end = out.size();
+        while (end > start && out.get(end - 1).isEmpty()) end--;
+        return String.join("\n", out.subList(start, end));
+    }
+
+    private static String relativiseSource(CompilationUnit cu, Path rootAbs) {
+        Optional<CompilationUnit.Storage> storage = cu.getStorage();
+        if (storage.isEmpty()) return "";
+        Path file = storage.get().getPath().toAbsolutePath().normalize();
+        String s;
+        try {
+            s = rootAbs.relativize(file).toString();
+        } catch (IllegalArgumentException e) {
+            s = file.toString();
+        }
+        // Normalise to forward slashes so output is portable across OS
+        // boundaries — golden tests run on Linux and macOS without divergence.
+        return s.replace(java.io.File.separatorChar, '/');
+    }
+}

--- a/tools/archai-java-analyzer/src/main/java/io/archai/javaanalyzer/Main.java
+++ b/tools/archai-java-analyzer/src/main/java/io/archai/javaanalyzer/Main.java
@@ -1,0 +1,138 @@
+package io.archai.javaanalyzer;
+
+import io.archai.javaanalyzer.facts.JavaFacts;
+import io.archai.javaanalyzer.json.Writer;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * CLI entry — {@code java -jar archai-java-analyzer.jar [flags] <src-root>...}
+ *
+ * <p>Stdout: JavaFacts JSON. Stderr: progress / errors. Exit 0 on success,
+ * 1 on hard failure. Single unparseable files surface as
+ * {@code parse_warnings} entries inside the JSON, not as fatal errors.
+ *
+ * <p>Flags:
+ * <ul>
+ *   <li>{@code --pretty} — pretty-print JSON output (default: minified)</li>
+ *   <li>{@code --include-private} / {@code --no-include-private} — include
+ *       private members (default: include)</li>
+ *   <li>{@code --help} / {@code -h} — usage</li>
+ *   <li>{@code --version} — schema and analyzer version</li>
+ * </ul>
+ */
+public final class Main {
+
+    private Main() {}
+
+    public static void main(String[] args) {
+        int exit = run(args);
+        System.exit(exit);
+    }
+
+    /**
+     * Run the CLI and return the intended exit code. Split out from {@code
+     * main} so tests can drive it without {@code System.exit} unwinding the
+     * JVM.
+     */
+    public static int run(String[] args) {
+        boolean pretty = false;
+        boolean includePrivate = true;
+        List<Path> roots = new ArrayList<>();
+
+        for (int i = 0; i < args.length; i++) {
+            String a = args[i];
+            switch (a) {
+                case "--pretty" -> pretty = true;
+                case "--include-private" -> includePrivate = true;
+                case "--no-include-private" -> includePrivate = false;
+                case "-h", "--help" -> {
+                    printUsage(System.out);
+                    return 0;
+                }
+                case "--version" -> {
+                    System.out.println("archai-java-analyzer schema=" + JavaFacts.SCHEMA_VERSION);
+                    return 0;
+                }
+                default -> {
+                    if (a.startsWith("-")) {
+                        System.err.println("unknown flag: " + a);
+                        printUsage(System.err);
+                        return 1;
+                    }
+                    roots.add(Paths.get(a));
+                }
+            }
+        }
+
+        if (roots.isEmpty()) {
+            System.err.println("error: at least one src-root required");
+            printUsage(System.err);
+            return 1;
+        }
+
+        // Hard-fail check: every root must exist. A missing root is a CLI
+        // misuse, not a parse warning.
+        for (Path r : roots) {
+            if (!Files.exists(r)) {
+                System.err.println("error: src-root does not exist: " + r);
+                return 1;
+            }
+        }
+
+        Analyzer analyzer = new Analyzer(includePrivate);
+        JavaFacts facts;
+        try {
+            facts = analyzer.analyze(roots);
+        } catch (IOException e) {
+            System.err.println("error: " + e.getMessage());
+            return 1;
+        }
+
+        // Hard-fail: not a single file parsed and we have no class output.
+        // Distinguishes "empty source tree" from "tree of unparseable files":
+        // if every file produced a parse_warning AND no class was extracted,
+        // exit 1 — the consumer would otherwise see an empty document and
+        // assume success.
+        if (facts.getClasses().isEmpty() && !facts.getParseWarnings().isEmpty()) {
+            System.err.println("error: no parsable Java source found across "
+                + roots.size() + " root(s); " + facts.getParseWarnings().size()
+                + " warning(s)");
+            for (var w : facts.getParseWarnings()) {
+                System.err.println("  " + w.getFile() + ": " + w.getMessage());
+            }
+            return 1;
+        }
+
+        Writer writer = new Writer();
+        try {
+            if (pretty) {
+                writer.writePretty(facts, System.out);
+            } else {
+                writer.writeCompact(facts, System.out);
+            }
+        } catch (IOException e) {
+            System.err.println("error: writing JSON: " + e.getMessage());
+            return 1;
+        }
+        return 0;
+    }
+
+    private static void printUsage(java.io.PrintStream out) {
+        out.println("usage: java -jar archai-java-analyzer.jar [flags] <src-root>...");
+        out.println();
+        out.println("flags:");
+        out.println("  --pretty                pretty-print JSON (default: minified)");
+        out.println("  --include-private       include private members (default)");
+        out.println("  --no-include-private    skip private members");
+        out.println("  --version               print schema version");
+        out.println("  -h, --help              show this help");
+        out.println();
+        out.println("Output: JavaFacts JSON on stdout. Errors on stderr. Exit 0 on success, 1 on failure.");
+    }
+}

--- a/tools/archai-java-analyzer/src/main/java/io/archai/javaanalyzer/facts/JavaAnnotation.java
+++ b/tools/archai-java-analyzer/src/main/java/io/archai/javaanalyzer/facts/JavaAnnotation.java
@@ -1,0 +1,29 @@
+package io.archai.javaanalyzer.facts;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * An annotation attached to a class/field/method/parameter.
+ *
+ * <p>{@link #fqn} is the resolved fully-qualified name when the symbol
+ * solver succeeds; otherwise it's the textual form as written. {@link #args}
+ * are the raw textual values of annotation members (no type resolution) —
+ * sufficient for downstream pattern-matching like {@code @Path("/users")}.
+ */
+@JsonInclude(JsonInclude.Include.ALWAYS)
+@JsonPropertyOrder({"fqn", "args"})
+public final class JavaAnnotation {
+
+    private String fqn = "";
+    private List<String> args = new ArrayList<>();
+
+    public String getFqn() { return fqn; }
+    public void setFqn(String fqn) { this.fqn = fqn; }
+
+    public List<String> getArgs() { return args; }
+    public void setArgs(List<String> args) { this.args = args; }
+}

--- a/tools/archai-java-analyzer/src/main/java/io/archai/javaanalyzer/facts/JavaCall.java
+++ b/tools/archai-java-analyzer/src/main/java/io/archai/javaanalyzer/facts/JavaCall.java
@@ -1,0 +1,40 @@
+package io.archai.javaanalyzer.facts;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+/**
+ * A static call edge — one method invocation captured inside another method's
+ * body.
+ *
+ * <p>Resolution is best-effort: when JavaParser's symbol solver cannot resolve
+ * the receiver type, {@link #toClass} falls back to the textual form
+ * ("Receiver" or empty for unqualified calls) and {@link #external} is set.
+ * Downstream consumers (Go translator) decide what to do with unresolved
+ * edges.
+ */
+@JsonInclude(JsonInclude.Include.ALWAYS)
+@JsonPropertyOrder({"to_class", "to_method", "static", "external"})
+public final class JavaCall {
+
+    private String toClass = "";
+    private String toMethod = "";
+    private boolean isStatic;
+    private boolean external;
+
+    @JsonProperty("to_class")
+    public String getToClass() { return toClass; }
+    public void setToClass(String toClass) { this.toClass = toClass; }
+
+    @JsonProperty("to_method")
+    public String getToMethod() { return toMethod; }
+    public void setToMethod(String toMethod) { this.toMethod = toMethod; }
+
+    @JsonProperty("static")
+    public boolean isStatic() { return isStatic; }
+    public void setStatic(boolean aStatic) { isStatic = aStatic; }
+
+    public boolean isExternal() { return external; }
+    public void setExternal(boolean external) { this.external = external; }
+}

--- a/tools/archai-java-analyzer/src/main/java/io/archai/javaanalyzer/facts/JavaClass.java
+++ b/tools/archai-java-analyzer/src/main/java/io/archai/javaanalyzer/facts/JavaClass.java
@@ -1,0 +1,103 @@
+package io.archai.javaanalyzer.facts;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * One Java type declaration — class, interface, enum, record, or annotation.
+ *
+ * <p>Fields stay close to JavaParser's AST output. Resolution to FQN happens
+ * via JavaParser's symbol solver when possible; otherwise the simple name as
+ * written in source is preserved (and {@link #external} marks it as such).
+ */
+@JsonInclude(JsonInclude.Include.ALWAYS)
+@JsonPropertyOrder({
+    "fqn",
+    "package",
+    "name",
+    "kind",
+    "modifiers",
+    "type_parameters",
+    "extends",
+    "implements",
+    "permits",
+    "source_file",
+    "doc",
+    "annotations",
+    "fields",
+    "methods",
+    "enum_constants"
+})
+public final class JavaClass {
+
+    private String fqn = "";
+    private String pkg = "";
+    private String name = "";
+    private String kind = "class";
+    private List<String> modifiers = new ArrayList<>();
+    private List<String> typeParameters = new ArrayList<>();
+    private String extends_ = "";
+    private List<String> implements_ = new ArrayList<>();
+    private List<String> permits = new ArrayList<>();
+    private String sourceFile = "";
+    private String doc = "";
+    private List<JavaAnnotation> annotations = new ArrayList<>();
+    private List<JavaField> fields = new ArrayList<>();
+    private List<JavaMethod> methods = new ArrayList<>();
+    private List<String> enumConstants = new ArrayList<>();
+
+    public String getFqn() { return fqn; }
+    public void setFqn(String fqn) { this.fqn = fqn; }
+
+    @JsonProperty("package")
+    public String getPackage() { return pkg; }
+    public void setPackage(String pkg) { this.pkg = pkg; }
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+
+    public String getKind() { return kind; }
+    public void setKind(String kind) { this.kind = kind; }
+
+    public List<String> getModifiers() { return modifiers; }
+    public void setModifiers(List<String> modifiers) { this.modifiers = modifiers; }
+
+    @JsonProperty("type_parameters")
+    public List<String> getTypeParameters() { return typeParameters; }
+    public void setTypeParameters(List<String> typeParameters) { this.typeParameters = typeParameters; }
+
+    @JsonProperty("extends")
+    public String getExtends() { return extends_; }
+    public void setExtends(String extends_) { this.extends_ = extends_; }
+
+    @JsonProperty("implements")
+    public List<String> getImplements() { return implements_; }
+    public void setImplements(List<String> implements_) { this.implements_ = implements_; }
+
+    public List<String> getPermits() { return permits; }
+    public void setPermits(List<String> permits) { this.permits = permits; }
+
+    @JsonProperty("source_file")
+    public String getSourceFile() { return sourceFile; }
+    public void setSourceFile(String sourceFile) { this.sourceFile = sourceFile; }
+
+    public String getDoc() { return doc; }
+    public void setDoc(String doc) { this.doc = doc; }
+
+    public List<JavaAnnotation> getAnnotations() { return annotations; }
+    public void setAnnotations(List<JavaAnnotation> annotations) { this.annotations = annotations; }
+
+    public List<JavaField> getFields() { return fields; }
+    public void setFields(List<JavaField> fields) { this.fields = fields; }
+
+    public List<JavaMethod> getMethods() { return methods; }
+    public void setMethods(List<JavaMethod> methods) { this.methods = methods; }
+
+    @JsonProperty("enum_constants")
+    public List<String> getEnumConstants() { return enumConstants; }
+    public void setEnumConstants(List<String> enumConstants) { this.enumConstants = enumConstants; }
+}

--- a/tools/archai-java-analyzer/src/main/java/io/archai/javaanalyzer/facts/JavaFacts.java
+++ b/tools/archai-java-analyzer/src/main/java/io/archai/javaanalyzer/facts/JavaFacts.java
@@ -1,0 +1,88 @@
+package io.archai.javaanalyzer.facts;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Top-level JavaFacts document — the entire output of one analyzer run.
+ *
+ * <p>Fields are explicitly initialised to empty collections so JSON
+ * serialisation always emits {@code []} rather than omitting the field —
+ * this keeps the downstream Go parser simple and predictable.
+ *
+ * <p>Schema version is emitted in the {@code schema} field; bump it on any
+ * breaking change to the JavaFacts contract.
+ */
+@JsonInclude(JsonInclude.Include.ALWAYS)
+@JsonPropertyOrder({
+    "schema",
+    "src_roots",
+    "packages",
+    "classes",
+    "imports",
+    "parse_warnings"
+})
+public final class JavaFacts {
+
+    public static final String SCHEMA_VERSION = "javafacts/v1";
+
+    private String schema = SCHEMA_VERSION;
+    private List<String> srcRoots = new ArrayList<>();
+    private List<String> packages = new ArrayList<>();
+    private List<JavaClass> classes = new ArrayList<>();
+    private List<JavaImport> imports = new ArrayList<>();
+    private List<ParseWarning> parseWarnings = new ArrayList<>();
+
+    public String getSchema() {
+        return schema;
+    }
+
+    public void setSchema(String schema) {
+        this.schema = schema;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("src_roots")
+    public List<String> getSrcRoots() {
+        return srcRoots;
+    }
+
+    public void setSrcRoots(List<String> srcRoots) {
+        this.srcRoots = srcRoots;
+    }
+
+    public List<String> getPackages() {
+        return packages;
+    }
+
+    public void setPackages(List<String> packages) {
+        this.packages = packages;
+    }
+
+    public List<JavaClass> getClasses() {
+        return classes;
+    }
+
+    public void setClasses(List<JavaClass> classes) {
+        this.classes = classes;
+    }
+
+    public List<JavaImport> getImports() {
+        return imports;
+    }
+
+    public void setImports(List<JavaImport> imports) {
+        this.imports = imports;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("parse_warnings")
+    public List<ParseWarning> getParseWarnings() {
+        return parseWarnings;
+    }
+
+    public void setParseWarnings(List<ParseWarning> parseWarnings) {
+        this.parseWarnings = parseWarnings;
+    }
+}

--- a/tools/archai-java-analyzer/src/main/java/io/archai/javaanalyzer/facts/JavaField.java
+++ b/tools/archai-java-analyzer/src/main/java/io/archai/javaanalyzer/facts/JavaField.java
@@ -1,0 +1,37 @@
+package io.archai.javaanalyzer.facts;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A single Java field declaration. One {@code int x, y;} expands into two
+ * {@link JavaField} entries — JavaFacts always names one field per entry.
+ */
+@JsonInclude(JsonInclude.Include.ALWAYS)
+@JsonPropertyOrder({"name", "type", "modifiers", "annotations", "doc"})
+public final class JavaField {
+
+    private String name = "";
+    private String type = "";
+    private List<String> modifiers = new ArrayList<>();
+    private List<JavaAnnotation> annotations = new ArrayList<>();
+    private String doc = "";
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+
+    public String getType() { return type; }
+    public void setType(String type) { this.type = type; }
+
+    public List<String> getModifiers() { return modifiers; }
+    public void setModifiers(List<String> modifiers) { this.modifiers = modifiers; }
+
+    public List<JavaAnnotation> getAnnotations() { return annotations; }
+    public void setAnnotations(List<JavaAnnotation> annotations) { this.annotations = annotations; }
+
+    public String getDoc() { return doc; }
+    public void setDoc(String doc) { this.doc = doc; }
+}

--- a/tools/archai-java-analyzer/src/main/java/io/archai/javaanalyzer/facts/JavaImport.java
+++ b/tools/archai-java-analyzer/src/main/java/io/archai/javaanalyzer/facts/JavaImport.java
@@ -1,0 +1,31 @@
+package io.archai.javaanalyzer.facts;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+/**
+ * One {@code import} statement, attributed to its source compilation unit's
+ * primary class FQN.
+ *
+ * <p>Kind is one of {@code class}, {@code static}, {@code wildcard},
+ * {@code static_wildcard}.
+ */
+@JsonInclude(JsonInclude.Include.ALWAYS)
+@JsonPropertyOrder({"from", "to_class", "kind"})
+public final class JavaImport {
+
+    private String from = "";
+    private String toClass = "";
+    private String kind = "class";
+
+    public String getFrom() { return from; }
+    public void setFrom(String from) { this.from = from; }
+
+    @JsonProperty("to_class")
+    public String getToClass() { return toClass; }
+    public void setToClass(String toClass) { this.toClass = toClass; }
+
+    public String getKind() { return kind; }
+    public void setKind(String kind) { this.kind = kind; }
+}

--- a/tools/archai-java-analyzer/src/main/java/io/archai/javaanalyzer/facts/JavaMethod.java
+++ b/tools/archai-java-analyzer/src/main/java/io/archai/javaanalyzer/facts/JavaMethod.java
@@ -1,0 +1,74 @@
+package io.archai.javaanalyzer.facts;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A method (or constructor) declaration on a {@link JavaClass}.
+ *
+ * <p>Constructors set {@link #kind} to {@code "constructor"}; instance methods
+ * to {@code "method"}; static initialisers are not emitted (out of scope for
+ * v1 — tracked as future work).
+ */
+@JsonInclude(JsonInclude.Include.ALWAYS)
+@JsonPropertyOrder({
+    "name",
+    "kind",
+    "modifiers",
+    "type_parameters",
+    "params",
+    "returns",
+    "throws",
+    "annotations",
+    "doc",
+    "calls"
+})
+public final class JavaMethod {
+
+    private String name = "";
+    private String kind = "method";
+    private List<String> modifiers = new ArrayList<>();
+    private List<String> typeParameters = new ArrayList<>();
+    private List<JavaParam> params = new ArrayList<>();
+    private String returns = "void";
+    private List<String> throws_ = new ArrayList<>();
+    private List<JavaAnnotation> annotations = new ArrayList<>();
+    private String doc = "";
+    private List<JavaCall> calls = new ArrayList<>();
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+
+    public String getKind() { return kind; }
+    public void setKind(String kind) { this.kind = kind; }
+
+    public List<String> getModifiers() { return modifiers; }
+    public void setModifiers(List<String> modifiers) { this.modifiers = modifiers; }
+
+    @JsonProperty("type_parameters")
+    public List<String> getTypeParameters() { return typeParameters; }
+    public void setTypeParameters(List<String> typeParameters) { this.typeParameters = typeParameters; }
+
+    public List<JavaParam> getParams() { return params; }
+    public void setParams(List<JavaParam> params) { this.params = params; }
+
+    public String getReturns() { return returns; }
+    public void setReturns(String returns) { this.returns = returns; }
+
+    @JsonProperty("throws")
+    public List<String> getThrows() { return throws_; }
+    public void setThrows(List<String> throws_) { this.throws_ = throws_; }
+
+    public List<JavaAnnotation> getAnnotations() { return annotations; }
+    public void setAnnotations(List<JavaAnnotation> annotations) { this.annotations = annotations; }
+
+    public String getDoc() { return doc; }
+    public void setDoc(String doc) { this.doc = doc; }
+
+    public List<JavaCall> getCalls() { return calls; }
+    public void setCalls(List<JavaCall> calls) { this.calls = calls; }
+}

--- a/tools/archai-java-analyzer/src/main/java/io/archai/javaanalyzer/facts/JavaParam.java
+++ b/tools/archai-java-analyzer/src/main/java/io/archai/javaanalyzer/facts/JavaParam.java
@@ -1,0 +1,39 @@
+package io.archai.javaanalyzer.facts;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A formal parameter on a method or constructor.
+ *
+ * <p>Varargs parameters are flagged via {@link #varargs}; their {@link #type}
+ * is the element type (e.g. {@code String} for {@code String... args}).
+ */
+@JsonInclude(JsonInclude.Include.ALWAYS)
+@JsonPropertyOrder({"name", "type", "varargs", "modifiers", "annotations"})
+public final class JavaParam {
+
+    private String name = "";
+    private String type = "";
+    private boolean varargs;
+    private List<String> modifiers = new ArrayList<>();
+    private List<JavaAnnotation> annotations = new ArrayList<>();
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+
+    public String getType() { return type; }
+    public void setType(String type) { this.type = type; }
+
+    public boolean isVarargs() { return varargs; }
+    public void setVarargs(boolean varargs) { this.varargs = varargs; }
+
+    public List<String> getModifiers() { return modifiers; }
+    public void setModifiers(List<String> modifiers) { this.modifiers = modifiers; }
+
+    public List<JavaAnnotation> getAnnotations() { return annotations; }
+    public void setAnnotations(List<JavaAnnotation> annotations) { this.annotations = annotations; }
+}

--- a/tools/archai-java-analyzer/src/main/java/io/archai/javaanalyzer/facts/ParseWarning.java
+++ b/tools/archai-java-analyzer/src/main/java/io/archai/javaanalyzer/facts/ParseWarning.java
@@ -1,0 +1,32 @@
+package io.archai.javaanalyzer.facts;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+/**
+ * A non-fatal parse problem encountered while walking the source tree —
+ * typically a single unparseable file in an otherwise valid root.
+ *
+ * <p>Hard failures (e.g. no parsable file at all) bypass JavaFacts and exit
+ * the process with code 1.
+ */
+@JsonInclude(JsonInclude.Include.ALWAYS)
+@JsonPropertyOrder({"file", "message"})
+public final class ParseWarning {
+
+    private String file = "";
+    private String message = "";
+
+    public ParseWarning() {}
+
+    public ParseWarning(String file, String message) {
+        this.file = file;
+        this.message = message;
+    }
+
+    public String getFile() { return file; }
+    public void setFile(String file) { this.file = file; }
+
+    public String getMessage() { return message; }
+    public void setMessage(String message) { this.message = message; }
+}

--- a/tools/archai-java-analyzer/src/main/java/io/archai/javaanalyzer/json/Writer.java
+++ b/tools/archai-java-analyzer/src/main/java/io/archai/javaanalyzer/json/Writer.java
@@ -1,0 +1,107 @@
+package io.archai.javaanalyzer.json;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.util.DefaultIndenter;
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+import io.archai.javaanalyzer.facts.JavaFacts;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Serializes {@link JavaFacts} to deterministic JSON.
+ *
+ * <p>Two modes:
+ * <ul>
+ *   <li><b>compact</b> (default): single-line minified output. One trailing
+ *       newline so shell pipelines aren't surprised.</li>
+ *   <li><b>pretty</b> ({@code --pretty}): two-space indent, system-default
+ *       line separator coerced to {@code "\n"} so output is byte-for-byte
+ *       reproducible across platforms — important for golden tests on CI.</li>
+ * </ul>
+ *
+ * <p>Field ordering is fixed via {@code @JsonPropertyOrder} on the data
+ * classes; the writer just respects that. Empty collections always emit
+ * as {@code []} ({@code @JsonInclude.Include.ALWAYS}).
+ */
+public final class Writer {
+
+    private final ObjectMapper mapper;
+
+    public Writer() {
+        this.mapper = new ObjectMapper();
+        // Sort map entries alphabetically when we serialise maps. Our domain
+        // model uses lists with explicit ordering, but this guards against
+        // any future map fields slipping in.
+        mapper.configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, false);
+        mapper.configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
+        // No timestamps anywhere — nothing in JavaFacts is a date, but be
+        // explicit so future additions don't accidentally introduce
+        // non-determinism.
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        // Don't auto-close the target stream when the generator closes —
+        // we control stdout/test buffers ourselves and want trailing
+        // bytes (newline) to land before close.
+        mapper.disable(SerializationFeature.CLOSE_CLOSEABLE);
+        mapper.getFactory().disable(JsonGenerator.Feature.AUTO_CLOSE_TARGET);
+    }
+
+    /**
+     * Write {@code facts} to {@code out} in compact (minified) form.
+     */
+    public void writeCompact(JavaFacts facts, OutputStream out) throws IOException {
+        ObjectWriter writer = mapper.writer();
+        writer.writeValue(out, facts);
+        out.write('\n');
+        out.flush();
+    }
+
+    /**
+     * Write {@code facts} to {@code out} in pretty form (2-space indent,
+     * {@code \n} line separator).
+     */
+    public void writePretty(JavaFacts facts, OutputStream out) throws IOException {
+        DefaultPrettyPrinter pp = new DefaultPrettyPrinter();
+        DefaultIndenter indenter = new DefaultIndenter("  ", "\n");
+        pp.indentArraysWith(indenter);
+        pp.indentObjectsWith(indenter);
+
+        try (JsonGenerator gen = mapper.getFactory().createGenerator(out)) {
+            gen.setPrettyPrinter(pp);
+            mapper.writeValue(gen, facts);
+        }
+        out.write('\n');
+        out.flush();
+    }
+
+    /**
+     * Convenience for tests: serialise to a UTF-8 string in pretty form.
+     */
+    public String toPrettyString(JavaFacts facts) throws IOException {
+        java.io.ByteArrayOutputStream buf = new java.io.ByteArrayOutputStream();
+        writePretty(facts, buf);
+        return buf.toString(StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Convenience for tests: serialise to a UTF-8 string in compact form.
+     */
+    public String toCompactString(JavaFacts facts) throws IOException {
+        java.io.ByteArrayOutputStream buf = new java.io.ByteArrayOutputStream();
+        writeCompact(facts, buf);
+        return buf.toString(StandardCharsets.UTF_8);
+    }
+
+    /** Wrap a {@link PrintStream} (e.g. {@code System.out}) for writers that
+     * accept {@link OutputStream}. */
+    public static OutputStream wrap(PrintStream stream) {
+        return stream;
+    }
+}

--- a/tools/archai-java-analyzer/src/test/java/io/archai/javaanalyzer/AnalyzerTest.java
+++ b/tools/archai-java-analyzer/src/test/java/io/archai/javaanalyzer/AnalyzerTest.java
@@ -1,0 +1,124 @@
+package io.archai.javaanalyzer;
+
+import io.archai.javaanalyzer.facts.JavaFacts;
+import io.archai.javaanalyzer.json.Writer;
+
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Golden-fixture tests. For every {@code <fixture>/src/} directory under
+ * {@code src/test/resources/golden/}, the analyzer is run and the output
+ * compared byte-for-byte to {@code <fixture>/expected.json}.
+ *
+ * <p>The {@code src_roots} field is normalised to the bare {@code "src"}
+ * string so the golden file is portable across machines (the absolute path
+ * is otherwise machine-specific).
+ *
+ * <p>Run with {@code -Darchai.update-golden=true} to regenerate
+ * {@code expected.json} files in place after intentional schema changes.
+ */
+final class AnalyzerTest {
+
+    @TestFactory
+    Stream<DynamicTest> goldenFixtures() throws IOException, URISyntaxException {
+        URL goldenUrl = getClass().getClassLoader().getResource("golden");
+        assertNotNull(goldenUrl, "golden resources directory must exist on classpath");
+        Path goldenDir = Paths.get(goldenUrl.toURI());
+
+        // Resolve the source-tree golden dir so update-golden writes back to
+        // the working tree, not the build output dir under target/.
+        // Maven puts test resources under target/test-classes/; walk up to
+        // src/test/resources/golden.
+        Path sourceGoldenDir = resolveSourceGoldenDir(goldenDir);
+
+        List<Path> fixtures;
+        try (var stream = Files.list(goldenDir)) {
+            fixtures = stream
+                .filter(Files::isDirectory)
+                .sorted(Comparator.comparing(Path::getFileName))
+                .toList();
+        }
+
+        boolean updateGolden = Boolean.getBoolean("archai.update-golden");
+
+        List<DynamicTest> tests = new ArrayList<>(fixtures.size());
+        for (Path fixture : fixtures) {
+            Path sourceFixture = sourceGoldenDir.resolve(fixture.getFileName().toString());
+            tests.add(DynamicTest.dynamicTest(fixture.getFileName().toString(), () -> {
+                runFixture(fixture, sourceFixture, updateGolden);
+            }));
+        }
+        return tests.stream();
+    }
+
+    private void runFixture(Path fixture, Path sourceFixture, boolean updateGolden) throws IOException {
+        Path src = fixture.resolve("src");
+        // Read goldens from the source tree so they're not stale from a
+        // previous test-classes copy; write updates back to the source tree.
+        Path expected = sourceFixture.resolve("expected.json");
+
+        Analyzer analyzer = new Analyzer();
+        JavaFacts facts = analyzer.analyze(List.of(src));
+
+        // Normalise src_roots to the bare basename so the golden file is
+        // portable: tests pass an absolute path, but the expected JSON
+        // records only "src".
+        facts.setSrcRoots(List.of(src.getFileName().toString()));
+
+        Writer writer = new Writer();
+        String actual = writer.toPrettyString(facts);
+
+        if (updateGolden || !Files.exists(expected)) {
+            Files.writeString(expected, actual);
+            // First-time generation is a soft pass — re-run to confirm
+            // determinism.
+            return;
+        }
+
+        String expectedContent = Files.readString(expected);
+        assertEquals(expectedContent, actual,
+            "golden mismatch for fixture " + fixture.getFileName()
+            + " — re-run with -Darchai.update-golden=true if intentional");
+    }
+
+    /**
+     * Walk up from {@code target/test-classes/golden} to the
+     * {@code src/test/resources/golden} working-tree directory. Falls back
+     * to the input path if the heuristic doesn't match — non-Maven layouts
+     * just won't get update-golden support.
+     */
+    private static Path resolveSourceGoldenDir(Path classpathGolden) {
+        Path candidate = classpathGolden;
+        // Expected layout: <project>/target/test-classes/golden
+        Path target = candidate.getParent();           // test-classes
+        if (target == null) return candidate;
+        Path projectBuild = target.getParent();        // target
+        if (projectBuild == null) return candidate;
+        Path projectRoot = projectBuild.getParent();   // <project>
+        if (projectRoot == null) return candidate;
+        Path source = projectRoot
+            .resolve("src")
+            .resolve("test")
+            .resolve("resources")
+            .resolve("golden");
+        if (Files.isDirectory(source)) {
+            return source;
+        }
+        return candidate;
+    }
+}

--- a/tools/archai-java-analyzer/src/test/java/io/archai/javaanalyzer/MainTest.java
+++ b/tools/archai-java-analyzer/src/test/java/io/archai/javaanalyzer/MainTest.java
@@ -1,0 +1,113 @@
+package io.archai.javaanalyzer;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Smoke tests for the {@link Main} CLI entry — exit codes, stdout/stderr
+ * routing, error paths.
+ */
+final class MainTest {
+
+    private PrintStream origOut;
+    private PrintStream origErr;
+    private ByteArrayOutputStream out;
+    private ByteArrayOutputStream err;
+
+    @BeforeEach
+    void capture() {
+        origOut = System.out;
+        origErr = System.err;
+        out = new ByteArrayOutputStream();
+        err = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(out, true, StandardCharsets.UTF_8));
+        System.setErr(new PrintStream(err, true, StandardCharsets.UTF_8));
+    }
+
+    @AfterEach
+    void restore() {
+        System.setOut(origOut);
+        System.setErr(origErr);
+    }
+
+    @Test
+    void missingRoot_exitsOne() {
+        int code = Main.run(new String[]{});
+        assertEquals(1, code);
+        assertTrue(err.toString(StandardCharsets.UTF_8).contains("at least one src-root"));
+    }
+
+    @Test
+    void nonExistentRoot_exitsOne() {
+        int code = Main.run(new String[]{"/path/that/does/not/exist/anywhere/__archai__"});
+        assertEquals(1, code);
+        assertTrue(err.toString(StandardCharsets.UTF_8).contains("does not exist"));
+    }
+
+    @Test
+    void unknownFlag_exitsOne() {
+        int code = Main.run(new String[]{"--bogus"});
+        assertEquals(1, code);
+        assertTrue(err.toString(StandardCharsets.UTF_8).contains("unknown flag"));
+    }
+
+    @Test
+    void help_exitsZero() {
+        int code = Main.run(new String[]{"--help"});
+        assertEquals(0, code);
+        assertTrue(out.toString(StandardCharsets.UTF_8).contains("usage:"));
+    }
+
+    @Test
+    void version_exitsZero() {
+        int code = Main.run(new String[]{"--version"});
+        assertEquals(0, code);
+        assertTrue(out.toString(StandardCharsets.UTF_8).contains("javafacts/v1"));
+    }
+
+    @Test
+    void simpleClassFixture_emitsValidJson() throws URISyntaxException, IOException {
+        Path src = goldenSrc("simple-class");
+        int code = Main.run(new String[]{"--pretty", src.toString()});
+        assertEquals(0, code);
+
+        String json = out.toString(StandardCharsets.UTF_8);
+        assertTrue(json.contains("\"schema\" : \"javafacts/v1\""));
+        assertTrue(json.contains("\"fqn\" : \"com.example.Greeter\""));
+        // Stdout must end with a single trailing newline so shell pipelines
+        // (e.g. `> facts.json`) work cleanly.
+        assertTrue(json.endsWith("\n"));
+    }
+
+    @Test
+    void compactOutput_isSingleLine() throws URISyntaxException, IOException {
+        Path src = goldenSrc("simple-class");
+        int code = Main.run(new String[]{src.toString()});
+        assertEquals(0, code);
+
+        String json = out.toString(StandardCharsets.UTF_8).strip();
+        assertEquals(-1, json.indexOf('\n'),
+            "compact output must be single-line, got:\n" + json);
+    }
+
+    private Path goldenSrc(String fixture) throws URISyntaxException {
+        URL url = getClass().getClassLoader().getResource("golden/" + fixture + "/src");
+        assertNotNull(url, "fixture " + fixture + " missing");
+        return Paths.get(url.toURI());
+    }
+}

--- a/tools/archai-java-analyzer/src/test/resources/golden/inheritance/expected.json
+++ b/tools/archai-java-analyzer/src/test/resources/golden/inheritance/expected.json
@@ -1,0 +1,251 @@
+{
+  "schema" : "javafacts/v1",
+  "src_roots" : [
+    "src"
+  ],
+  "packages" : [
+    "com.example"
+  ],
+  "classes" : [
+    {
+      "fqn" : "com.example.Animal",
+      "package" : "com.example",
+      "name" : "Animal",
+      "kind" : "class",
+      "modifiers" : [
+        "public",
+        "abstract"
+      ],
+      "type_parameters" : [ ],
+      "extends" : "",
+      "implements" : [ ],
+      "permits" : [ ],
+      "source_file" : "com/example/Animal.java",
+      "doc" : "Abstract base — exercises extends + abstract modifier.",
+      "annotations" : [ ],
+      "fields" : [
+        {
+          "name" : "name",
+          "type" : "String",
+          "modifiers" : [
+            "protected",
+            "final"
+          ],
+          "annotations" : [ ],
+          "doc" : ""
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "Animal",
+          "kind" : "constructor",
+          "modifiers" : [
+            "protected"
+          ],
+          "type_parameters" : [ ],
+          "params" : [
+            {
+              "name" : "name",
+              "type" : "String",
+              "varargs" : false,
+              "modifiers" : [ ],
+              "annotations" : [ ]
+            }
+          ],
+          "returns" : "void",
+          "throws" : [ ],
+          "annotations" : [ ],
+          "doc" : "",
+          "calls" : [ ]
+        },
+        {
+          "name" : "sound",
+          "kind" : "method",
+          "modifiers" : [
+            "public",
+            "abstract"
+          ],
+          "type_parameters" : [ ],
+          "params" : [ ],
+          "returns" : "String",
+          "throws" : [ ],
+          "annotations" : [ ],
+          "doc" : "",
+          "calls" : [ ]
+        },
+        {
+          "name" : "describe",
+          "kind" : "method",
+          "modifiers" : [
+            "public"
+          ],
+          "type_parameters" : [ ],
+          "params" : [ ],
+          "returns" : "String",
+          "throws" : [ ],
+          "annotations" : [ ],
+          "doc" : "",
+          "calls" : [
+            {
+              "to_class" : "",
+              "to_method" : "sound",
+              "static" : false,
+              "external" : false
+            }
+          ]
+        }
+      ],
+      "enum_constants" : [ ]
+    },
+    {
+      "fqn" : "com.example.Dog",
+      "package" : "com.example",
+      "name" : "Dog",
+      "kind" : "class",
+      "modifiers" : [
+        "public"
+      ],
+      "type_parameters" : [ ],
+      "extends" : "Animal",
+      "implements" : [
+        "Trainable"
+      ],
+      "permits" : [ ],
+      "source_file" : "com/example/Dog.java",
+      "doc" : "",
+      "annotations" : [ ],
+      "fields" : [ ],
+      "methods" : [
+        {
+          "name" : "Dog",
+          "kind" : "constructor",
+          "modifiers" : [
+            "public"
+          ],
+          "type_parameters" : [ ],
+          "params" : [
+            {
+              "name" : "name",
+              "type" : "String",
+              "varargs" : false,
+              "modifiers" : [ ],
+              "annotations" : [ ]
+            }
+          ],
+          "returns" : "void",
+          "throws" : [ ],
+          "annotations" : [ ],
+          "doc" : "",
+          "calls" : [ ]
+        },
+        {
+          "name" : "sound",
+          "kind" : "method",
+          "modifiers" : [
+            "public"
+          ],
+          "type_parameters" : [ ],
+          "params" : [ ],
+          "returns" : "String",
+          "throws" : [ ],
+          "annotations" : [
+            {
+              "fqn" : "Override",
+              "args" : [ ]
+            }
+          ],
+          "doc" : "",
+          "calls" : [ ]
+        },
+        {
+          "name" : "learn",
+          "kind" : "method",
+          "modifiers" : [
+            "public"
+          ],
+          "type_parameters" : [ ],
+          "params" : [
+            {
+              "name" : "tricks",
+              "type" : "List<String>",
+              "varargs" : false,
+              "modifiers" : [ ],
+              "annotations" : [ ]
+            }
+          ],
+          "returns" : "void",
+          "throws" : [ ],
+          "annotations" : [
+            {
+              "fqn" : "Override",
+              "args" : [ ]
+            }
+          ],
+          "doc" : "",
+          "calls" : [
+            {
+              "to_class" : "System.out",
+              "to_method" : "println",
+              "static" : false,
+              "external" : false
+            }
+          ]
+        }
+      ],
+      "enum_constants" : [ ]
+    },
+    {
+      "fqn" : "com.example.Trainable",
+      "package" : "com.example",
+      "name" : "Trainable",
+      "kind" : "interface",
+      "modifiers" : [
+        "public"
+      ],
+      "type_parameters" : [ ],
+      "extends" : "",
+      "implements" : [ ],
+      "permits" : [ ],
+      "source_file" : "com/example/Trainable.java",
+      "doc" : "",
+      "annotations" : [ ],
+      "fields" : [ ],
+      "methods" : [
+        {
+          "name" : "learn",
+          "kind" : "method",
+          "modifiers" : [ ],
+          "type_parameters" : [ ],
+          "params" : [
+            {
+              "name" : "tricks",
+              "type" : "List<String>",
+              "varargs" : false,
+              "modifiers" : [ ],
+              "annotations" : [ ]
+            }
+          ],
+          "returns" : "void",
+          "throws" : [ ],
+          "annotations" : [ ],
+          "doc" : "",
+          "calls" : [ ]
+        }
+      ],
+      "enum_constants" : [ ]
+    }
+  ],
+  "imports" : [
+    {
+      "from" : "com.example.Dog",
+      "to_class" : "java.util.List",
+      "kind" : "class"
+    },
+    {
+      "from" : "com.example.Trainable",
+      "to_class" : "java.util.List",
+      "kind" : "class"
+    }
+  ],
+  "parse_warnings" : [ ]
+}

--- a/tools/archai-java-analyzer/src/test/resources/golden/inheritance/src/com/example/Animal.java
+++ b/tools/archai-java-analyzer/src/test/resources/golden/inheritance/src/com/example/Animal.java
@@ -1,0 +1,18 @@
+package com.example;
+
+/**
+ * Abstract base — exercises extends + abstract modifier.
+ */
+public abstract class Animal {
+    protected final String name;
+
+    protected Animal(String name) {
+        this.name = name;
+    }
+
+    public abstract String sound();
+
+    public String describe() {
+        return name + " says " + sound();
+    }
+}

--- a/tools/archai-java-analyzer/src/test/resources/golden/inheritance/src/com/example/Dog.java
+++ b/tools/archai-java-analyzer/src/test/resources/golden/inheritance/src/com/example/Dog.java
@@ -1,0 +1,22 @@
+package com.example;
+
+import java.util.List;
+
+public class Dog extends Animal implements Trainable {
+
+    public Dog(String name) {
+        super(name);
+    }
+
+    @Override
+    public String sound() {
+        return "woof";
+    }
+
+    @Override
+    public void learn(List<String> tricks) {
+        for (String trick : tricks) {
+            System.out.println(name + " learned " + trick);
+        }
+    }
+}

--- a/tools/archai-java-analyzer/src/test/resources/golden/inheritance/src/com/example/Trainable.java
+++ b/tools/archai-java-analyzer/src/test/resources/golden/inheritance/src/com/example/Trainable.java
@@ -1,0 +1,7 @@
+package com.example;
+
+import java.util.List;
+
+public interface Trainable {
+    void learn(List<String> tricks);
+}

--- a/tools/archai-java-analyzer/src/test/resources/golden/interface-with-default/expected.json
+++ b/tools/archai-java-analyzer/src/test/resources/golden/interface-with-default/expected.json
@@ -1,0 +1,80 @@
+{
+  "schema" : "javafacts/v1",
+  "src_roots" : [
+    "src"
+  ],
+  "packages" : [
+    "com.example"
+  ],
+  "classes" : [
+    {
+      "fqn" : "com.example.Talker",
+      "package" : "com.example",
+      "name" : "Talker",
+      "kind" : "interface",
+      "modifiers" : [
+        "public"
+      ],
+      "type_parameters" : [ ],
+      "extends" : "",
+      "implements" : [ ],
+      "permits" : [ ],
+      "source_file" : "com/example/Talker.java",
+      "doc" : "Interface with a default method — exercises method modifiers and\ninterface-level dispatch.",
+      "annotations" : [ ],
+      "fields" : [ ],
+      "methods" : [
+        {
+          "name" : "voice",
+          "kind" : "method",
+          "modifiers" : [ ],
+          "type_parameters" : [ ],
+          "params" : [ ],
+          "returns" : "String",
+          "throws" : [ ],
+          "annotations" : [ ],
+          "doc" : "",
+          "calls" : [ ]
+        },
+        {
+          "name" : "shout",
+          "kind" : "method",
+          "modifiers" : [
+            "default"
+          ],
+          "type_parameters" : [ ],
+          "params" : [
+            {
+              "name" : "msg",
+              "type" : "String",
+              "varargs" : false,
+              "modifiers" : [ ],
+              "annotations" : [ ]
+            }
+          ],
+          "returns" : "String",
+          "throws" : [ ],
+          "annotations" : [ ],
+          "doc" : "",
+          "calls" : [
+            {
+              "to_class" : "voice()",
+              "to_method" : "toUpperCase",
+              "static" : false,
+              "external" : false
+            },
+            {
+              "to_class" : "",
+              "to_method" : "voice",
+              "static" : false,
+              "external" : false
+            }
+          ]
+        }
+      ],
+      "enum_constants" : [ ]
+    }
+  ],
+  "imports" : [ ],
+  "parse_warnings" : [ ]
+}

--- a/tools/archai-java-analyzer/src/test/resources/golden/interface-with-default/src/com/example/Talker.java
+++ b/tools/archai-java-analyzer/src/test/resources/golden/interface-with-default/src/com/example/Talker.java
@@ -1,0 +1,14 @@
+package com.example;
+
+/**
+ * Interface with a default method — exercises method modifiers and
+ * interface-level dispatch.
+ */
+public interface Talker {
+
+    String voice();
+
+    default String shout(String msg) {
+        return voice().toUpperCase() + ": " + msg;
+    }
+}

--- a/tools/archai-java-analyzer/src/test/resources/golden/record/expected.json
+++ b/tools/archai-java-analyzer/src/test/resources/golden/record/expected.json
@@ -1,0 +1,83 @@
+{
+  "schema" : "javafacts/v1",
+  "src_roots" : [
+    "src"
+  ],
+  "packages" : [
+    "com.example"
+  ],
+  "classes" : [
+    {
+      "fqn" : "com.example.Point",
+      "package" : "com.example",
+      "name" : "Point",
+      "kind" : "record",
+      "modifiers" : [
+        "public"
+      ],
+      "type_parameters" : [ ],
+      "extends" : "",
+      "implements" : [ ],
+      "permits" : [ ],
+      "source_file" : "com/example/Point.java",
+      "doc" : "2D point — records expose components as fields.",
+      "annotations" : [ ],
+      "fields" : [
+        {
+          "name" : "x",
+          "type" : "double",
+          "modifiers" : [
+            "final",
+            "private"
+          ],
+          "annotations" : [ ],
+          "doc" : ""
+        },
+        {
+          "name" : "y",
+          "type" : "double",
+          "modifiers" : [
+            "final",
+            "private"
+          ],
+          "annotations" : [ ],
+          "doc" : ""
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "distance",
+          "kind" : "method",
+          "modifiers" : [
+            "public"
+          ],
+          "type_parameters" : [ ],
+          "params" : [
+            {
+              "name" : "other",
+              "type" : "Point",
+              "varargs" : false,
+              "modifiers" : [ ],
+              "annotations" : [ ]
+            }
+          ],
+          "returns" : "double",
+          "throws" : [ ],
+          "annotations" : [ ],
+          "doc" : "",
+          "calls" : [
+            {
+              "to_class" : "Math",
+              "to_method" : "sqrt",
+              "static" : true,
+              "external" : false
+            }
+          ]
+        }
+      ],
+      "enum_constants" : [ ]
+    }
+  ],
+  "imports" : [ ],
+  "parse_warnings" : [ ]
+}

--- a/tools/archai-java-analyzer/src/test/resources/golden/record/src/com/example/Point.java
+++ b/tools/archai-java-analyzer/src/test/resources/golden/record/src/com/example/Point.java
@@ -1,0 +1,13 @@
+package com.example;
+
+/**
+ * 2D point — records expose components as fields.
+ */
+public record Point(double x, double y) {
+
+    public double distance(Point other) {
+        double dx = x - other.x;
+        double dy = y - other.y;
+        return Math.sqrt(dx * dx + dy * dy);
+    }
+}

--- a/tools/archai-java-analyzer/src/test/resources/golden/sealed-and-enums/expected.json
+++ b/tools/archai-java-analyzer/src/test/resources/golden/sealed-and-enums/expected.json
@@ -1,0 +1,268 @@
+{
+  "schema" : "javafacts/v1",
+  "src_roots" : [
+    "src"
+  ],
+  "packages" : [
+    "com.example"
+  ],
+  "classes" : [
+    {
+      "fqn" : "com.example.Circle",
+      "package" : "com.example",
+      "name" : "Circle",
+      "kind" : "class",
+      "modifiers" : [
+        "public",
+        "final"
+      ],
+      "type_parameters" : [ ],
+      "extends" : "",
+      "implements" : [
+        "Shape"
+      ],
+      "permits" : [ ],
+      "source_file" : "com/example/Circle.java",
+      "doc" : "",
+      "annotations" : [ ],
+      "fields" : [
+        {
+          "name" : "radius",
+          "type" : "double",
+          "modifiers" : [
+            "private",
+            "final"
+          ],
+          "annotations" : [ ],
+          "doc" : ""
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "Circle",
+          "kind" : "constructor",
+          "modifiers" : [
+            "public"
+          ],
+          "type_parameters" : [ ],
+          "params" : [
+            {
+              "name" : "radius",
+              "type" : "double",
+              "varargs" : false,
+              "modifiers" : [ ],
+              "annotations" : [ ]
+            }
+          ],
+          "returns" : "void",
+          "throws" : [ ],
+          "annotations" : [ ],
+          "doc" : "",
+          "calls" : [ ]
+        },
+        {
+          "name" : "area",
+          "kind" : "method",
+          "modifiers" : [
+            "public"
+          ],
+          "type_parameters" : [ ],
+          "params" : [ ],
+          "returns" : "double",
+          "throws" : [ ],
+          "annotations" : [
+            {
+              "fqn" : "Override",
+              "args" : [ ]
+            }
+          ],
+          "doc" : "",
+          "calls" : [ ]
+        }
+      ],
+      "enum_constants" : [ ]
+    },
+    {
+      "fqn" : "com.example.Color",
+      "package" : "com.example",
+      "name" : "Color",
+      "kind" : "enum",
+      "modifiers" : [
+        "public"
+      ],
+      "type_parameters" : [ ],
+      "extends" : "",
+      "implements" : [ ],
+      "permits" : [ ],
+      "source_file" : "com/example/Color.java",
+      "doc" : "Enum with explicit constructor — exercises enum kind + enum_constants.",
+      "annotations" : [ ],
+      "fields" : [
+        {
+          "name" : "hex",
+          "type" : "String",
+          "modifiers" : [
+            "private",
+            "final"
+          ],
+          "annotations" : [ ],
+          "doc" : ""
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "Color",
+          "kind" : "constructor",
+          "modifiers" : [ ],
+          "type_parameters" : [ ],
+          "params" : [
+            {
+              "name" : "hex",
+              "type" : "String",
+              "varargs" : false,
+              "modifiers" : [ ],
+              "annotations" : [ ]
+            }
+          ],
+          "returns" : "void",
+          "throws" : [ ],
+          "annotations" : [ ],
+          "doc" : "",
+          "calls" : [ ]
+        },
+        {
+          "name" : "hex",
+          "kind" : "method",
+          "modifiers" : [
+            "public"
+          ],
+          "type_parameters" : [ ],
+          "params" : [ ],
+          "returns" : "String",
+          "throws" : [ ],
+          "annotations" : [ ],
+          "doc" : "",
+          "calls" : [ ]
+        }
+      ],
+      "enum_constants" : [
+        "RED",
+        "GREEN",
+        "BLUE"
+      ]
+    },
+    {
+      "fqn" : "com.example.Shape",
+      "package" : "com.example",
+      "name" : "Shape",
+      "kind" : "interface",
+      "modifiers" : [
+        "public",
+        "sealed"
+      ],
+      "type_parameters" : [ ],
+      "extends" : "",
+      "implements" : [ ],
+      "permits" : [
+        "Circle",
+        "Square"
+      ],
+      "source_file" : "com/example/Shape.java",
+      "doc" : "Sealed interface — exercises permits + interface declaration.",
+      "annotations" : [ ],
+      "fields" : [ ],
+      "methods" : [
+        {
+          "name" : "area",
+          "kind" : "method",
+          "modifiers" : [ ],
+          "type_parameters" : [ ],
+          "params" : [ ],
+          "returns" : "double",
+          "throws" : [ ],
+          "annotations" : [ ],
+          "doc" : "",
+          "calls" : [ ]
+        }
+      ],
+      "enum_constants" : [ ]
+    },
+    {
+      "fqn" : "com.example.Square",
+      "package" : "com.example",
+      "name" : "Square",
+      "kind" : "class",
+      "modifiers" : [
+        "public",
+        "final"
+      ],
+      "type_parameters" : [ ],
+      "extends" : "",
+      "implements" : [
+        "Shape"
+      ],
+      "permits" : [ ],
+      "source_file" : "com/example/Square.java",
+      "doc" : "",
+      "annotations" : [ ],
+      "fields" : [
+        {
+          "name" : "side",
+          "type" : "double",
+          "modifiers" : [
+            "private",
+            "final"
+          ],
+          "annotations" : [ ],
+          "doc" : ""
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "Square",
+          "kind" : "constructor",
+          "modifiers" : [
+            "public"
+          ],
+          "type_parameters" : [ ],
+          "params" : [
+            {
+              "name" : "side",
+              "type" : "double",
+              "varargs" : false,
+              "modifiers" : [ ],
+              "annotations" : [ ]
+            }
+          ],
+          "returns" : "void",
+          "throws" : [ ],
+          "annotations" : [ ],
+          "doc" : "",
+          "calls" : [ ]
+        },
+        {
+          "name" : "area",
+          "kind" : "method",
+          "modifiers" : [
+            "public"
+          ],
+          "type_parameters" : [ ],
+          "params" : [ ],
+          "returns" : "double",
+          "throws" : [ ],
+          "annotations" : [
+            {
+              "fqn" : "Override",
+              "args" : [ ]
+            }
+          ],
+          "doc" : "",
+          "calls" : [ ]
+        }
+      ],
+      "enum_constants" : [ ]
+    }
+  ],
+  "imports" : [ ],
+  "parse_warnings" : [ ]
+}

--- a/tools/archai-java-analyzer/src/test/resources/golden/sealed-and-enums/src/com/example/Circle.java
+++ b/tools/archai-java-analyzer/src/test/resources/golden/sealed-and-enums/src/com/example/Circle.java
@@ -1,0 +1,14 @@
+package com.example;
+
+public final class Circle implements Shape {
+    private final double radius;
+
+    public Circle(double radius) {
+        this.radius = radius;
+    }
+
+    @Override
+    public double area() {
+        return Math.PI * radius * radius;
+    }
+}

--- a/tools/archai-java-analyzer/src/test/resources/golden/sealed-and-enums/src/com/example/Color.java
+++ b/tools/archai-java-analyzer/src/test/resources/golden/sealed-and-enums/src/com/example/Color.java
@@ -1,0 +1,20 @@
+package com.example;
+
+/**
+ * Enum with explicit constructor — exercises enum kind + enum_constants.
+ */
+public enum Color {
+    RED("#ff0000"),
+    GREEN("#00ff00"),
+    BLUE("#0000ff");
+
+    private final String hex;
+
+    Color(String hex) {
+        this.hex = hex;
+    }
+
+    public String hex() {
+        return hex;
+    }
+}

--- a/tools/archai-java-analyzer/src/test/resources/golden/sealed-and-enums/src/com/example/Shape.java
+++ b/tools/archai-java-analyzer/src/test/resources/golden/sealed-and-enums/src/com/example/Shape.java
@@ -1,0 +1,8 @@
+package com.example;
+
+/**
+ * Sealed interface — exercises permits + interface declaration.
+ */
+public sealed interface Shape permits Circle, Square {
+    double area();
+}

--- a/tools/archai-java-analyzer/src/test/resources/golden/sealed-and-enums/src/com/example/Square.java
+++ b/tools/archai-java-analyzer/src/test/resources/golden/sealed-and-enums/src/com/example/Square.java
@@ -1,0 +1,14 @@
+package com.example;
+
+public final class Square implements Shape {
+    private final double side;
+
+    public Square(double side) {
+        this.side = side;
+    }
+
+    @Override
+    public double area() {
+        return side * side;
+    }
+}

--- a/tools/archai-java-analyzer/src/test/resources/golden/simple-class/expected.json
+++ b/tools/archai-java-analyzer/src/test/resources/golden/simple-class/expected.json
@@ -1,0 +1,101 @@
+{
+  "schema" : "javafacts/v1",
+  "src_roots" : [
+    "src"
+  ],
+  "packages" : [
+    "com.example"
+  ],
+  "classes" : [
+    {
+      "fqn" : "com.example.Greeter",
+      "package" : "com.example",
+      "name" : "Greeter",
+      "kind" : "class",
+      "modifiers" : [
+        "public"
+      ],
+      "type_parameters" : [ ],
+      "extends" : "",
+      "implements" : [ ],
+      "permits" : [ ],
+      "source_file" : "com/example/Greeter.java",
+      "doc" : "Simple greeter — single class, single field, single method.",
+      "annotations" : [ ],
+      "fields" : [
+        {
+          "name" : "prefix",
+          "type" : "String",
+          "modifiers" : [
+            "private",
+            "final"
+          ],
+          "annotations" : [ ],
+          "doc" : ""
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "Greeter",
+          "kind" : "constructor",
+          "modifiers" : [
+            "public"
+          ],
+          "type_parameters" : [ ],
+          "params" : [
+            {
+              "name" : "prefix",
+              "type" : "String",
+              "varargs" : false,
+              "modifiers" : [ ],
+              "annotations" : [ ]
+            }
+          ],
+          "returns" : "void",
+          "throws" : [ ],
+          "annotations" : [ ],
+          "doc" : "",
+          "calls" : [
+            {
+              "to_class" : "Objects",
+              "to_method" : "requireNonNull",
+              "static" : true,
+              "external" : false
+            }
+          ]
+        },
+        {
+          "name" : "greet",
+          "kind" : "method",
+          "modifiers" : [
+            "public"
+          ],
+          "type_parameters" : [ ],
+          "params" : [
+            {
+              "name" : "name",
+              "type" : "String",
+              "varargs" : false,
+              "modifiers" : [ ],
+              "annotations" : [ ]
+            }
+          ],
+          "returns" : "String",
+          "throws" : [ ],
+          "annotations" : [ ],
+          "doc" : "",
+          "calls" : [ ]
+        }
+      ],
+      "enum_constants" : [ ]
+    }
+  ],
+  "imports" : [
+    {
+      "from" : "com.example.Greeter",
+      "to_class" : "java.util.Objects",
+      "kind" : "class"
+    }
+  ],
+  "parse_warnings" : [ ]
+}

--- a/tools/archai-java-analyzer/src/test/resources/golden/simple-class/src/com/example/Greeter.java
+++ b/tools/archai-java-analyzer/src/test/resources/golden/simple-class/src/com/example/Greeter.java
@@ -1,0 +1,18 @@
+package com.example;
+
+import java.util.Objects;
+
+/**
+ * Simple greeter — single class, single field, single method.
+ */
+public class Greeter {
+    private final String prefix;
+
+    public Greeter(String prefix) {
+        this.prefix = Objects.requireNonNull(prefix);
+    }
+
+    public String greet(String name) {
+        return prefix + ", " + name + "!";
+    }
+}


### PR DESCRIPTION
Implements #101 — child 1 of the Java-support epic #100. Foundation for the
Go-side adapter (#102) and CLI dispatch (#103).

## Summary

Stand up a separate Maven sub-project at `tools/archai-java-analyzer/` that
walks Java source roots with JavaParser and emits a `JavaFacts` JSON
document on stdout. The analyzer is intentionally semantically dumb — it
dumps what the AST tells it, with no archai-domain concepts. All
schema interpretation (stereotypes, hexagonal mapping) lives downstream in
the Go translator (#102).

## What's in this PR

- **`tools/archai-java-analyzer/`** — Maven project, JVM 17+ baseline, fat
  JAR via `maven-shade-plugin`. Output binary lands at
  `target/archai-java-analyzer.jar`.
- **`Analyzer.java`** — JavaParser walk that produces a populated
  `JavaFacts`. Uses `SourceRoot.tryToParseParallelized` for throughput;
  unparseable single files surface as non-fatal `parse_warnings`. JavaParser
  level pinned to `JAVA_17`.
- **`Main.java`** — CLI entry. `--pretty`, `--include-private` /
  `--no-include-private`, `--version`, `--help`. Exit 0 on success, 1 on
  hard failure (missing/non-existent root, unknown flag, all-files-
  unparseable). JSON to stdout, errors to stderr.
- **`facts/`** — POJO data classes (`JavaFacts`, `JavaClass`, `JavaMethod`,
  `JavaField`, `JavaParam`, `JavaCall`, `JavaImport`, `JavaAnnotation`,
  `ParseWarning`). Field order pinned via Jackson `@JsonPropertyOrder`;
  empty arrays always serialise as `[]`.
- **`json/Writer.java`** — Jackson serializer. Compact (default) and pretty
  modes. `\n` line separator and trailing newline. AUTO_CLOSE_TARGET
  disabled so we own stream lifecycle.
- **`SCHEMA.md`** — JavaFacts v1 contract documented field-by-field.
- **`README.md`** — usage, build, test, layout.

## JavaFacts v1 schema (TL;DR)

```json
{
  "schema": "javafacts/v1",
  "src_roots": ["src"],
  "packages":  ["com.example"],
  "classes": [{
    "fqn": "com.example.Greeter",
    "package": "com.example", "name": "Greeter",
    "kind": "class|interface|enum|record|annotation",
    "modifiers": ["public", "final"],
    "type_parameters": [], "extends": "", "implements": [], "permits": [],
    "source_file": "com/example/Greeter.java", "doc": "...",
    "annotations": [{"fqn": "Override", "args": []}],
    "fields":  [{"name": "x", "type": "int", "modifiers": ["private","final"], ...}],
    "methods": [{
      "name": "greet", "kind": "method|constructor",
      "modifiers": ["public"], "type_parameters": [],
      "params": [{"name": "n", "type": "String", "varargs": false, ...}],
      "returns": "String", "throws": [], "annotations": [], "doc": "",
      "calls": [{"to_class":"Math","to_method":"sqrt","static":true,"external":false}]
    }],
    "enum_constants": []
  }],
  "imports": [{"from":"com.example.Greeter","to_class":"java.util.Objects","kind":"class"}],
  "parse_warnings": []
}
```

Determinism: classes sorted by FQN, imports sorted by `(from,to_class,kind)`,
packages sorted, members in source order, no timestamps. Goldens are
compared byte-for-byte. Forward-slash `source_file` regardless of host OS.

Documented design choices (in `SCHEMA.md`):

- Interface super-interfaces (Java's `interface A extends B`) populate
  `implements`, not `extends` — keeps a single edge collection downstream.
- Record components surface as `fields` with `private final` modifiers.
- Nested types emit as siblings with `Outer.Inner` in `name` and
  `pkg.Outer.Inner` in `fqn`.
- `JavaCall.external` is reserved for v2 — currently always `false`; the
  Go translator can flip it after applying the analyzed-package set.

## Golden fixture coverage

Five `(input.java, expected.json)` pairs under
`src/test/resources/golden/`, runnable as a JUnit `@TestFactory`:

| Fixture                  | Covers                                          |
|--------------------------|-------------------------------------------------|
| `simple-class`           | Single class, fields, methods, calls, imports   |
| `interface-with-default` | Interface modifiers + default method body       |
| `record`                 | Record kind, components-as-fields               |
| `sealed-and-enums`       | `sealed`, `permits`, enum constants             |
| `inheritance`            | `extends`, `implements`, multi-file package     |

Plus 7 unit tests in `MainTest` covering CLI exit codes, stdout/stderr
routing, and the contract that compact output is single-line.

## How to run

```sh
make java-analyzer            # build only
make java-analyzer-test       # mvn test
make build-all                # Go binary + JAR side-by-side

mvn -f tools/archai-java-analyzer/pom.xml -Darchai.update-golden=true test
                              # regenerate goldens after schema changes
```

Default `make build` stays Go-only — Go-only users don't need a JVM. The
JAR builds via `make build-all` for releases that bundle both artifacts.

## Test plan

- [x] `mvn -f tools/archai-java-analyzer/pom.xml test` → 12 / 12 green
  (5 golden fixtures + 7 CLI tests)
- [x] `make build` (Go-only) builds without invoking Maven
- [x] `make build-all` builds binary + JAR
- [x] Manual run: `java -jar target/archai-java-analyzer.jar
  src/test/resources/golden/record/src` produces sane JSON
- [x] `--version` → `archai-java-analyzer schema=javafacts/v1`
- [x] `go test ./...` in the Go tree still green (no regression)
- [x] Re-run of golden tests after `--update-golden` confirms determinism

## Out of scope (tracked for follow-ups)

- Static initialiser blocks
- Resolved annotation argument values (only textual)
- Cross-JAR type resolution
- Method-body facts beyond calls (no field reads, control flow, lambda targets)
- Generic type substitutions in parameter types
- TODO comment in `Analyzer.extractCalls` flags wiring the symbol solver
  for resolved `to_class` FQNs — deferred to #102 where the Go translator
  can use either resolved or textual receivers.

Refs #100. Does not touch Go code.