### PR TITLE
feat(#102): internal/adapter/java — JAR exec + JavaFacts → domain translator

### DIFF
--- a/internal/adapter/java/exec.go
+++ b/internal/adapter/java/exec.go
@@ -1,0 +1,89 @@
+package java
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+// jarFileName is the conventional sibling-binary name we look for last
+// when resolving the analyzer JAR.
+const jarFileName = "archai-java-analyzer.jar"
+
+// jarEnvVar is the env var consulted second in the resolution chain.
+const jarEnvVar = "ARCHAI_JAVA_JAR"
+
+// resolveJarPath finds the JavaFacts analyzer JAR. Priority:
+//  1. explicit non-empty constructor arg
+//  2. ARCHAI_JAVA_JAR env var
+//  3. sibling of the running binary: <exe-dir>/archai-java-analyzer.jar
+//
+// On miss, it returns a friendly error pointing the user at --java-jar /
+// ARCHAI_JAVA_JAR. exeLookup is parameterised so tests can stub out
+// os.Executable without touching the filesystem.
+func resolveJarPath(explicit string, exeLookup func() (string, error)) (string, error) {
+	if explicit != "" {
+		return explicit, nil
+	}
+	if env := os.Getenv(jarEnvVar); env != "" {
+		return env, nil
+	}
+	exe, err := exeLookup()
+	if err == nil && exe != "" {
+		sibling := filepath.Join(filepath.Dir(exe), jarFileName)
+		if _, statErr := os.Stat(sibling); statErr == nil {
+			return sibling, nil
+		}
+	}
+	return "", fmt.Errorf("Java sources detected but no %s found. Set --java-jar or %s.", jarFileName, jarEnvVar)
+}
+
+// runAnalyzer invokes `java -jar <jarPath> <paths...>`, captures stdout
+// (the JavaFacts JSON document) and parses it.
+//
+// stderr is captured and surfaced verbatim on non-zero exit. The `java`
+// binary is resolved via PATH; if it is missing the error is wrapped with
+// an actionable message.
+func runAnalyzer(ctx context.Context, jarPath string, paths []string) (*javaFacts, error) {
+	javaBin, err := exec.LookPath("java")
+	if err != nil {
+		return nil, fmt.Errorf("`java` not found on PATH; install a JRE 21+ or set JAVA_HOME: %w", err)
+	}
+
+	args := append([]string{"-jar", jarPath}, paths...)
+	cmd := exec.CommandContext(ctx, javaBin, args...)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if runErr := cmd.Run(); runErr != nil {
+		return nil, fmt.Errorf("archai-java-analyzer.jar failed: %w\nstderr:\n%s", runErr, stderr.String())
+	}
+
+	facts, parseErr := decodeFacts(stdout.Bytes())
+	if parseErr != nil {
+		return nil, fmt.Errorf("decoding JavaFacts JSON: %w", parseErr)
+	}
+	return facts, nil
+}
+
+// decodeFacts parses a JavaFacts JSON document and validates the schema
+// version. Pulled out of runAnalyzer so it can be tested without invoking
+// `java`.
+func decodeFacts(raw []byte) (*javaFacts, error) {
+	var facts javaFacts
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&facts); err != nil {
+		return nil, err
+	}
+	if facts.Schema != schemaVersion {
+		return nil, fmt.Errorf("unsupported JavaFacts schema %q (want %q)", facts.Schema, schemaVersion)
+	}
+	return &facts, nil
+}

--- a/internal/adapter/java/exec_test.go
+++ b/internal/adapter/java/exec_test.go
@@ -1,0 +1,95 @@
+package java
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolveJarPath_ExplicitWins(t *testing.T) {
+	t.Setenv(jarEnvVar, "/from/env.jar")
+	got, err := resolveJarPath("/explicit/wins.jar", func() (string, error) {
+		return "/usr/local/bin/archai", nil
+	})
+	if err != nil || got != "/explicit/wins.jar" {
+		t.Errorf("explicit should win, got %q err=%v", got, err)
+	}
+}
+
+func TestResolveJarPath_EnvFallback(t *testing.T) {
+	t.Setenv(jarEnvVar, "/from/env.jar")
+	got, err := resolveJarPath("", func() (string, error) {
+		return "/usr/local/bin/archai", nil
+	})
+	if err != nil || got != "/from/env.jar" {
+		t.Errorf("env fallback failed: got %q err=%v", got, err)
+	}
+}
+
+func TestResolveJarPath_SiblingFallback(t *testing.T) {
+	dir := t.TempDir()
+	exe := filepath.Join(dir, "archai")
+	if err := os.WriteFile(exe, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	jar := filepath.Join(dir, jarFileName)
+	if err := os.WriteFile(jar, []byte("PK"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(jarEnvVar, "")
+
+	got, err := resolveJarPath("", func() (string, error) { return exe, nil })
+	if err != nil || got != jar {
+		t.Errorf("sibling fallback: got %q err=%v want %q", got, err, jar)
+	}
+}
+
+func TestResolveJarPath_NotFound(t *testing.T) {
+	t.Setenv(jarEnvVar, "")
+	_, err := resolveJarPath("", func() (string, error) {
+		// Return a path with no sibling jar present.
+		return filepath.Join(t.TempDir(), "archai"), nil
+	})
+	if err == nil {
+		t.Fatal("expected an error when nothing resolves")
+	}
+	if !strings.Contains(err.Error(), "ARCHAI_JAVA_JAR") || !strings.Contains(err.Error(), "java-jar") {
+		t.Errorf("error message should mention --java-jar / ARCHAI_JAVA_JAR: %v", err)
+	}
+}
+
+func TestResolveJarPath_ExeLookupErrorTreatedAsMiss(t *testing.T) {
+	t.Setenv(jarEnvVar, "")
+	_, err := resolveJarPath("", func() (string, error) {
+		return "", errors.New("os.Executable failed")
+	})
+	if err == nil {
+		t.Fatal("expected an error when sibling lookup fails and no env / explicit set")
+	}
+}
+
+func TestDecodeFacts_Roundtrip(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Join("testdata", "facts_simple.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	facts, err := decodeFacts(raw)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if facts.Schema != schemaVersion {
+		t.Errorf("schema: %q", facts.Schema)
+	}
+	if len(facts.Classes) == 0 {
+		t.Error("classes empty")
+	}
+}
+
+func TestDecodeFacts_RejectsUnknownFields(t *testing.T) {
+	bad := []byte(`{"schema":"javafacts/v1","src_roots":[],"packages":[],"classes":[],"imports":[],"parse_warnings":[],"surprise":42}`)
+	if _, err := decodeFacts(bad); err == nil {
+		t.Error("decodeFacts should reject unknown top-level fields to catch schema drift early")
+	}
+}

--- a/internal/adapter/java/facts.go
+++ b/internal/adapter/java/facts.go
@@ -1,0 +1,107 @@
+// Package java reads Java source by shelling out to archai-java-analyzer.jar
+// (issue #101) and translates its JavaFacts JSON output to domain models.
+//
+// The adapter is split in three layers:
+//
+//   - facts.go       — Go structs mirroring the JavaFacts/v1 JSON shape.
+//   - exec.go        — JAR/`java` resolution and process execution.
+//   - translator.go  — pure JavaFacts → []domain.PackageModel translation.
+//   - reader.go      — wires the three together as a service.ModelReader.
+//
+// The schema is owned by the Go side (see tools/archai-java-analyzer/SCHEMA.md):
+// when archai's domain evolves, only translator.go changes; the JAR is left
+// alone unless the JSON shape itself needs new fields.
+package java
+
+// schemaVersion is the JavaFacts schema version this adapter understands.
+const schemaVersion = "javafacts/v1"
+
+// javaFacts mirrors the top-level JavaFacts JSON document.
+type javaFacts struct {
+	Schema        string         `json:"schema"`
+	SrcRoots      []string       `json:"src_roots"`
+	Packages      []string       `json:"packages"`
+	Classes       []javaClass    `json:"classes"`
+	Imports       []javaImport   `json:"imports"`
+	ParseWarnings []parseWarning `json:"parse_warnings"`
+}
+
+// javaClass mirrors a JavaClass entry. `kind` is one of
+// class | interface | enum | record | annotation.
+type javaClass struct {
+	FQN            string           `json:"fqn"`
+	Package        string           `json:"package"`
+	Name           string           `json:"name"`
+	Kind           string           `json:"kind"`
+	Modifiers      []string         `json:"modifiers"`
+	TypeParameters []string         `json:"type_parameters"`
+	Extends        string           `json:"extends"`
+	Implements     []string         `json:"implements"`
+	Permits        []string         `json:"permits"`
+	SourceFile     string           `json:"source_file"`
+	Doc            string           `json:"doc"`
+	Annotations    []javaAnnotation `json:"annotations"`
+	Fields         []javaField      `json:"fields"`
+	Methods        []javaMethod     `json:"methods"`
+	EnumConstants  []string         `json:"enum_constants"`
+}
+
+type javaField struct {
+	Name        string           `json:"name"`
+	Type        string           `json:"type"`
+	Modifiers   []string         `json:"modifiers"`
+	Annotations []javaAnnotation `json:"annotations"`
+	Doc         string           `json:"doc"`
+}
+
+// javaMethod mirrors a JavaMethod entry. `kind` is method | constructor.
+type javaMethod struct {
+	Name           string           `json:"name"`
+	Kind           string           `json:"kind"`
+	Modifiers      []string         `json:"modifiers"`
+	TypeParameters []string         `json:"type_parameters"`
+	Params         []javaParam      `json:"params"`
+	Returns        string           `json:"returns"`
+	Throws         []string         `json:"throws"`
+	Annotations    []javaAnnotation `json:"annotations"`
+	Doc            string           `json:"doc"`
+	Calls          []javaCall       `json:"calls"`
+}
+
+type javaParam struct {
+	Name        string           `json:"name"`
+	Type        string           `json:"type"`
+	Varargs     bool             `json:"varargs"`
+	Modifiers   []string         `json:"modifiers"`
+	Annotations []javaAnnotation `json:"annotations"`
+}
+
+type javaCall struct {
+	ToClass    string             `json:"to_class"`
+	ToMethod   string             `json:"to_method"`
+	Static     bool               `json:"static"`
+	External   bool               `json:"external"`
+	TargetFQN  string             `json:"target_fqn"`
+	Unresolved javaCallUnresolved `json:"unresolved"`
+}
+
+type javaCallUnresolved struct {
+	ReceiverText string `json:"receiver_text"`
+	MethodName   string `json:"method_name"`
+}
+
+type javaAnnotation struct {
+	FQN  string   `json:"fqn"`
+	Args []string `json:"args"`
+}
+
+type javaImport struct {
+	From    string `json:"from"`
+	ToClass string `json:"to_class"`
+	Kind    string `json:"kind"`
+}
+
+type parseWarning struct {
+	File    string `json:"file"`
+	Message string `json:"message"`
+}

--- a/internal/adapter/java/reader.go
+++ b/internal/adapter/java/reader.go
@@ -1,0 +1,108 @@
+package java
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/kgatilin/archai/internal/domain"
+	"github.com/kgatilin/archai/internal/service"
+)
+
+// Reader reads Java source by shelling out to archai-java-analyzer.jar.
+//
+// Reader implements service.ModelReader. The underlying JAR is resolved
+// at first call (not at construction) so that explicit-jar / env / sibling
+// resolution sees the runtime environment. Successive Read calls reuse
+// the same resolved path.
+//
+// After a successful Read, Warnings() returns any non-fatal parse warnings
+// that the JAR surfaced; the run still succeeded.
+type Reader struct {
+	jarPath  string // explicit override; empty means "auto-resolve"
+	resolved string // cached after first successful resolution
+
+	mu       sync.Mutex
+	warnings []ParseWarning
+}
+
+// ParseWarning is a non-fatal parse problem surfaced by the JAR.
+// Mirrors tools/archai-java-analyzer/SCHEMA.md `ParseWarning` shape.
+type ParseWarning struct {
+	File    string
+	Message string
+}
+
+// NewReader returns a Java code reader. jarPath is the explicit JAR path;
+// empty falls back to ARCHAI_JAVA_JAR / sibling-of-binary resolution at
+// first Read (see resolveJarPath).
+func NewReader(jarPath string) *Reader {
+	return &Reader{jarPath: jarPath}
+}
+
+// Compile-time interface check. The CLI / service layer can pass a *Reader
+// anywhere a ModelReader is expected.
+var _ service.ModelReader = (*Reader)(nil)
+
+// Read invokes the analyzer JAR over the configured source roots and
+// returns the resulting domain model. paths are passed through verbatim
+// to the JAR — the JAR itself decides which directories to recurse into.
+func (r *Reader) Read(ctx context.Context, paths []string) ([]domain.PackageModel, error) {
+	if len(paths) == 0 {
+		return nil, fmt.Errorf("java reader: no source paths")
+	}
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
+	jar, err := r.ensureJar()
+	if err != nil {
+		return nil, err
+	}
+
+	facts, err := runAnalyzer(ctx, jar, paths)
+	if err != nil {
+		return nil, err
+	}
+
+	r.recordWarnings(facts.ParseWarnings)
+	return translate(facts), nil
+}
+
+// Warnings returns the non-fatal parse warnings surfaced by the most
+// recent Read invocation(s). Order is preserved across multiple Reads.
+func (r *Reader) Warnings() []ParseWarning {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]ParseWarning, len(r.warnings))
+	copy(out, r.warnings)
+	return out
+}
+
+func (r *Reader) ensureJar() (string, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.resolved != "" {
+		return r.resolved, nil
+	}
+	jar, err := resolveJarPath(r.jarPath, os.Executable)
+	if err != nil {
+		return "", err
+	}
+	r.resolved = jar
+	return jar, nil
+}
+
+func (r *Reader) recordWarnings(in []parseWarning) {
+	if len(in) == 0 {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, w := range in {
+		r.warnings = append(r.warnings, ParseWarning{File: w.File, Message: w.Message})
+	}
+}

--- a/internal/adapter/java/reader_test.go
+++ b/internal/adapter/java/reader_test.go
@@ -1,0 +1,48 @@
+package java
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestReader_ImplementsModelReader(t *testing.T) {
+	// Compile-time check is in reader.go; this test asserts the type
+	// constructor returns a non-nil value.
+	r := NewReader("")
+	if r == nil {
+		t.Fatal("NewReader returned nil")
+	}
+}
+
+func TestReader_NoPathsErrors(t *testing.T) {
+	r := NewReader("/dev/null") // never invoked because paths is empty
+	_, err := r.Read(context.Background(), nil)
+	if err == nil || !strings.Contains(err.Error(), "no source paths") {
+		t.Errorf("want no-paths error, got %v", err)
+	}
+}
+
+func TestReader_PropagatesContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	r := NewReader("/dev/null")
+	_, err := r.Read(ctx, []string{"src"})
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("want context.Canceled, got %v", err)
+	}
+}
+
+func TestReader_RecordsWarnings(t *testing.T) {
+	r := NewReader("/dev/null")
+	r.recordWarnings([]parseWarning{
+		{File: "Bad.java", Message: "expected ';'"},
+		{File: "Worse.java", Message: "EOF"},
+	})
+	got := r.Warnings()
+	if len(got) != 2 || got[0].File != "Bad.java" || got[1].Message != "EOF" {
+		t.Errorf("warnings: %+v", got)
+	}
+}

--- a/internal/adapter/java/stereotype.go
+++ b/internal/adapter/java/stereotype.go
@@ -1,0 +1,101 @@
+package java
+
+import (
+	"strings"
+
+	"github.com/kgatilin/archai/internal/domain"
+)
+
+// detectClassStereotype returns a stereotype for a JavaClass. Heuristics
+// (v1, mirroring adapter/golang/stereotype.go but adapted to Java idiom):
+//
+//	repository — name ends with "Repository" or "Dao".
+//	service    — name ends with "Service".
+//	controller — name ends with "Controller", or class is annotated
+//	             @RestController / @Controller (FQN suffix match).
+//	record     — `kind: "record"`.
+//
+// All other classes return StereotypeNone — the diagram layer will fall
+// back to its default rendering. Future PRs may extend this table.
+func detectClassStereotype(c javaClass) domain.Stereotype {
+	if c.Kind == "record" {
+		return domain.StereotypeValue
+	}
+	for _, ann := range c.Annotations {
+		if hasSimpleName(ann.FQN, "RestController") || hasSimpleName(ann.FQN, "Controller") {
+			return domain.StereotypeService
+		}
+	}
+	switch {
+	case strings.HasSuffix(c.Name, "Repository"), strings.HasSuffix(c.Name, "Dao"):
+		return domain.StereotypeRepository
+	case strings.HasSuffix(c.Name, "Service"):
+		return domain.StereotypeService
+	case strings.HasSuffix(c.Name, "Controller"):
+		return domain.StereotypeService
+	}
+	return domain.StereotypeNone
+}
+
+// detectInterfaceStereotype mirrors the Go adapter's interface heuristics
+// translated to Java naming:
+//
+//	repository — *Repository / *Dao
+//	service    — *Service / *Handler / *Manager / *Controller
+//	port       — *Reader / *Writer
+//
+// Unmatched names default to StereotypeInterface so the D2 layer still
+// renders an interface stereotype tag.
+func detectInterfaceStereotype(c javaClass) domain.Stereotype {
+	switch {
+	case strings.HasSuffix(c.Name, "Repository"), strings.HasSuffix(c.Name, "Dao"):
+		return domain.StereotypeRepository
+	case strings.HasSuffix(c.Name, "Service"),
+		strings.HasSuffix(c.Name, "Handler"),
+		strings.HasSuffix(c.Name, "Manager"),
+		strings.HasSuffix(c.Name, "Controller"):
+		return domain.StereotypeService
+	case strings.HasSuffix(c.Name, "Reader"), strings.HasSuffix(c.Name, "Writer"):
+		return domain.StereotypePort
+	}
+	return domain.StereotypeInterface
+}
+
+// detectFactoryStereotype returns StereotypeFactory when a method on the
+// enclosing class is a likely factory: static, returns the enclosing type,
+// and is named "of", "create", or starts with "new".
+func detectFactoryStereotype(class javaClass, m javaMethod) domain.Stereotype {
+	if !containsModifier(m.Modifiers, "static") {
+		return domain.StereotypeNone
+	}
+	if m.Returns != class.Name && m.Returns != class.FQN {
+		return domain.StereotypeNone
+	}
+	switch {
+	case m.Name == "of", m.Name == "create":
+		return domain.StereotypeFactory
+	case strings.HasPrefix(m.Name, "new"):
+		return domain.StereotypeFactory
+	}
+	return domain.StereotypeNone
+}
+
+// hasSimpleName returns true when fqn ends with "."+simple or equals simple.
+// "Simple-name" matching keeps the heuristic permissive across stdlib /
+// Spring / Jakarta annotations without forcing the analyzer to resolve
+// every annotation FQN.
+func hasSimpleName(fqn, simple string) bool {
+	if fqn == simple {
+		return true
+	}
+	return strings.HasSuffix(fqn, "."+simple)
+}
+
+func containsModifier(mods []string, want string) bool {
+	for _, m := range mods {
+		if m == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/adapter/java/testdata/facts_calls.json
+++ b/internal/adapter/java/testdata/facts_calls.json
@@ -1,0 +1,311 @@
+{
+  "schema" : "javafacts/v1",
+  "src_roots" : [
+    "src"
+  ],
+  "packages" : [
+    "com.example"
+  ],
+  "classes" : [
+    {
+      "fqn" : "com.example.UserRepository",
+      "package" : "com.example",
+      "name" : "UserRepository",
+      "kind" : "class",
+      "modifiers" : [
+        "public"
+      ],
+      "type_parameters" : [ ],
+      "extends" : "",
+      "implements" : [ ],
+      "permits" : [ ],
+      "source_file" : "com/example/UserRepository.java",
+      "doc" : "Same-source dependency target — exercises target_fqn resolution from a\nfield-typed receiver.",
+      "annotations" : [ ],
+      "fields" : [ ],
+      "methods" : [
+        {
+          "name" : "save",
+          "kind" : "method",
+          "modifiers" : [
+            "public"
+          ],
+          "type_parameters" : [ ],
+          "params" : [
+            {
+              "name" : "id",
+              "type" : "String",
+              "varargs" : false,
+              "modifiers" : [ ],
+              "annotations" : [ ]
+            }
+          ],
+          "returns" : "void",
+          "throws" : [ ],
+          "annotations" : [ ],
+          "doc" : "",
+          "calls" : [ ]
+        },
+        {
+          "name" : "find",
+          "kind" : "method",
+          "modifiers" : [
+            "public"
+          ],
+          "type_parameters" : [ ],
+          "params" : [
+            {
+              "name" : "id",
+              "type" : "String",
+              "varargs" : false,
+              "modifiers" : [ ],
+              "annotations" : [ ]
+            }
+          ],
+          "returns" : "String",
+          "throws" : [ ],
+          "annotations" : [ ],
+          "doc" : "",
+          "calls" : [ ]
+        }
+      ],
+      "enum_constants" : [ ]
+    },
+    {
+      "fqn" : "com.example.UserService",
+      "package" : "com.example",
+      "name" : "UserService",
+      "kind" : "class",
+      "modifiers" : [
+        "public"
+      ],
+      "type_parameters" : [ ],
+      "extends" : "",
+      "implements" : [ ],
+      "permits" : [ ],
+      "source_file" : "com/example/UserService.java",
+      "doc" : "Drives the call-resolution test fixture. Each method exercises one\nresolution scenario:\n\n<ul>\n  <li>{@link #register(String)} — same-source field-typed receiver →\n      resolves to {@code com.example.UserRepository}.</li>\n  <li>{@link #ping(String)} — stdlib + unqualified-stdlib calls → external,\n      captured under {@code unresolved}.</li>\n  <li>{@link #scheduleAll(List)} — anonymous-class body wraps a stdlib call\n      that must not be attributed to the enclosing method.</li>\n  <li>{@link #lambdaWalk(List)} — lambda body wraps both an in-source and a\n      stdlib call; neither belongs to the enclosing method.</li>\n</ul>",
+      "annotations" : [ ],
+      "fields" : [
+        {
+          "name" : "repo",
+          "type" : "UserRepository",
+          "modifiers" : [
+            "private",
+            "final"
+          ],
+          "annotations" : [ ],
+          "doc" : ""
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "UserService",
+          "kind" : "constructor",
+          "modifiers" : [
+            "public"
+          ],
+          "type_parameters" : [ ],
+          "params" : [
+            {
+              "name" : "repo",
+              "type" : "UserRepository",
+              "varargs" : false,
+              "modifiers" : [ ],
+              "annotations" : [ ]
+            }
+          ],
+          "returns" : "void",
+          "throws" : [ ],
+          "annotations" : [ ],
+          "doc" : "",
+          "calls" : [
+            {
+              "to_class" : "Objects",
+              "to_method" : "requireNonNull",
+              "static" : true,
+              "external" : true,
+              "target_fqn" : "",
+              "unresolved" : {
+                "receiver_text" : "Objects",
+                "method_name" : "requireNonNull"
+              }
+            }
+          ]
+        },
+        {
+          "name" : "register",
+          "kind" : "method",
+          "modifiers" : [
+            "public"
+          ],
+          "type_parameters" : [ ],
+          "params" : [
+            {
+              "name" : "id",
+              "type" : "String",
+              "varargs" : false,
+              "modifiers" : [ ],
+              "annotations" : [ ]
+            }
+          ],
+          "returns" : "void",
+          "throws" : [ ],
+          "annotations" : [ ],
+          "doc" : "",
+          "calls" : [
+            {
+              "to_class" : "repo",
+              "to_method" : "save",
+              "static" : false,
+              "external" : false,
+              "target_fqn" : "com.example.UserRepository",
+              "unresolved" : {
+                "receiver_text" : "",
+                "method_name" : ""
+              }
+            }
+          ]
+        },
+        {
+          "name" : "ping",
+          "kind" : "method",
+          "modifiers" : [
+            "public"
+          ],
+          "type_parameters" : [ ],
+          "params" : [
+            {
+              "name" : "id",
+              "type" : "String",
+              "varargs" : false,
+              "modifiers" : [ ],
+              "annotations" : [ ]
+            }
+          ],
+          "returns" : "String",
+          "throws" : [ ],
+          "annotations" : [ ],
+          "doc" : "",
+          "calls" : [
+            {
+              "to_class" : "System.out",
+              "to_method" : "println",
+              "static" : false,
+              "external" : true,
+              "target_fqn" : "",
+              "unresolved" : {
+                "receiver_text" : "System.out",
+                "method_name" : "println"
+              }
+            },
+            {
+              "to_class" : "Objects",
+              "to_method" : "toString",
+              "static" : true,
+              "external" : true,
+              "target_fqn" : "",
+              "unresolved" : {
+                "receiver_text" : "Objects",
+                "method_name" : "toString"
+              }
+            }
+          ]
+        },
+        {
+          "name" : "scheduleAll",
+          "kind" : "method",
+          "modifiers" : [
+            "public"
+          ],
+          "type_parameters" : [ ],
+          "params" : [
+            {
+              "name" : "ids",
+              "type" : "List<String>",
+              "varargs" : false,
+              "modifiers" : [ ],
+              "annotations" : [ ]
+            }
+          ],
+          "returns" : "void",
+          "throws" : [ ],
+          "annotations" : [ ],
+          "doc" : "",
+          "calls" : [
+            {
+              "to_class" : "repo",
+              "to_method" : "save",
+              "static" : false,
+              "external" : false,
+              "target_fqn" : "com.example.UserRepository",
+              "unresolved" : {
+                "receiver_text" : "",
+                "method_name" : ""
+              }
+            }
+          ]
+        },
+        {
+          "name" : "lambdaWalk",
+          "kind" : "method",
+          "modifiers" : [
+            "public"
+          ],
+          "type_parameters" : [ ],
+          "params" : [
+            {
+              "name" : "ids",
+              "type" : "List<String>",
+              "varargs" : false,
+              "modifiers" : [ ],
+              "annotations" : [ ]
+            }
+          ],
+          "returns" : "int",
+          "throws" : [ ],
+          "annotations" : [ ],
+          "doc" : "",
+          "calls" : [
+            {
+              "to_class" : "ids",
+              "to_method" : "forEach",
+              "static" : false,
+              "external" : true,
+              "target_fqn" : "",
+              "unresolved" : {
+                "receiver_text" : "ids",
+                "method_name" : "forEach"
+              }
+            },
+            {
+              "to_class" : "ids",
+              "to_method" : "size",
+              "static" : false,
+              "external" : true,
+              "target_fqn" : "",
+              "unresolved" : {
+                "receiver_text" : "ids",
+                "method_name" : "size"
+              }
+            }
+          ]
+        }
+      ],
+      "enum_constants" : [ ]
+    }
+  ],
+  "imports" : [
+    {
+      "from" : "com.example.UserService",
+      "to_class" : "java.util.List",
+      "kind" : "class"
+    },
+    {
+      "from" : "com.example.UserService",
+      "to_class" : "java.util.Objects",
+      "kind" : "class"
+    }
+  ],
+  "parse_warnings" : [ ]
+}

--- a/internal/adapter/java/testdata/facts_inheritance.json
+++ b/internal/adapter/java/testdata/facts_inheritance.json
@@ -1,0 +1,261 @@
+{
+  "schema" : "javafacts/v1",
+  "src_roots" : [
+    "src"
+  ],
+  "packages" : [
+    "com.example"
+  ],
+  "classes" : [
+    {
+      "fqn" : "com.example.Animal",
+      "package" : "com.example",
+      "name" : "Animal",
+      "kind" : "class",
+      "modifiers" : [
+        "public",
+        "abstract"
+      ],
+      "type_parameters" : [ ],
+      "extends" : "",
+      "implements" : [ ],
+      "permits" : [ ],
+      "source_file" : "com/example/Animal.java",
+      "doc" : "Abstract base — exercises extends + abstract modifier.",
+      "annotations" : [ ],
+      "fields" : [
+        {
+          "name" : "name",
+          "type" : "String",
+          "modifiers" : [
+            "protected",
+            "final"
+          ],
+          "annotations" : [ ],
+          "doc" : ""
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "Animal",
+          "kind" : "constructor",
+          "modifiers" : [
+            "protected"
+          ],
+          "type_parameters" : [ ],
+          "params" : [
+            {
+              "name" : "name",
+              "type" : "String",
+              "varargs" : false,
+              "modifiers" : [ ],
+              "annotations" : [ ]
+            }
+          ],
+          "returns" : "void",
+          "throws" : [ ],
+          "annotations" : [ ],
+          "doc" : "",
+          "calls" : [ ]
+        },
+        {
+          "name" : "sound",
+          "kind" : "method",
+          "modifiers" : [
+            "public",
+            "abstract"
+          ],
+          "type_parameters" : [ ],
+          "params" : [ ],
+          "returns" : "String",
+          "throws" : [ ],
+          "annotations" : [ ],
+          "doc" : "",
+          "calls" : [ ]
+        },
+        {
+          "name" : "describe",
+          "kind" : "method",
+          "modifiers" : [
+            "public"
+          ],
+          "type_parameters" : [ ],
+          "params" : [ ],
+          "returns" : "String",
+          "throws" : [ ],
+          "annotations" : [ ],
+          "doc" : "",
+          "calls" : [
+            {
+              "to_class" : "",
+              "to_method" : "sound",
+              "static" : false,
+              "external" : false,
+              "target_fqn" : "com.example.Animal",
+              "unresolved" : {
+                "receiver_text" : "",
+                "method_name" : ""
+              }
+            }
+          ]
+        }
+      ],
+      "enum_constants" : [ ]
+    },
+    {
+      "fqn" : "com.example.Dog",
+      "package" : "com.example",
+      "name" : "Dog",
+      "kind" : "class",
+      "modifiers" : [
+        "public"
+      ],
+      "type_parameters" : [ ],
+      "extends" : "Animal",
+      "implements" : [
+        "Trainable"
+      ],
+      "permits" : [ ],
+      "source_file" : "com/example/Dog.java",
+      "doc" : "",
+      "annotations" : [ ],
+      "fields" : [ ],
+      "methods" : [
+        {
+          "name" : "Dog",
+          "kind" : "constructor",
+          "modifiers" : [
+            "public"
+          ],
+          "type_parameters" : [ ],
+          "params" : [
+            {
+              "name" : "name",
+              "type" : "String",
+              "varargs" : false,
+              "modifiers" : [ ],
+              "annotations" : [ ]
+            }
+          ],
+          "returns" : "void",
+          "throws" : [ ],
+          "annotations" : [ ],
+          "doc" : "",
+          "calls" : [ ]
+        },
+        {
+          "name" : "sound",
+          "kind" : "method",
+          "modifiers" : [
+            "public"
+          ],
+          "type_parameters" : [ ],
+          "params" : [ ],
+          "returns" : "String",
+          "throws" : [ ],
+          "annotations" : [
+            {
+              "fqn" : "Override",
+              "args" : [ ]
+            }
+          ],
+          "doc" : "",
+          "calls" : [ ]
+        },
+        {
+          "name" : "learn",
+          "kind" : "method",
+          "modifiers" : [
+            "public"
+          ],
+          "type_parameters" : [ ],
+          "params" : [
+            {
+              "name" : "tricks",
+              "type" : "List<String>",
+              "varargs" : false,
+              "modifiers" : [ ],
+              "annotations" : [ ]
+            }
+          ],
+          "returns" : "void",
+          "throws" : [ ],
+          "annotations" : [
+            {
+              "fqn" : "Override",
+              "args" : [ ]
+            }
+          ],
+          "doc" : "",
+          "calls" : [
+            {
+              "to_class" : "System.out",
+              "to_method" : "println",
+              "static" : false,
+              "external" : true,
+              "target_fqn" : "",
+              "unresolved" : {
+                "receiver_text" : "System.out",
+                "method_name" : "println"
+              }
+            }
+          ]
+        }
+      ],
+      "enum_constants" : [ ]
+    },
+    {
+      "fqn" : "com.example.Trainable",
+      "package" : "com.example",
+      "name" : "Trainable",
+      "kind" : "interface",
+      "modifiers" : [
+        "public"
+      ],
+      "type_parameters" : [ ],
+      "extends" : "",
+      "implements" : [ ],
+      "permits" : [ ],
+      "source_file" : "com/example/Trainable.java",
+      "doc" : "",
+      "annotations" : [ ],
+      "fields" : [ ],
+      "methods" : [
+        {
+          "name" : "learn",
+          "kind" : "method",
+          "modifiers" : [ ],
+          "type_parameters" : [ ],
+          "params" : [
+            {
+              "name" : "tricks",
+              "type" : "List<String>",
+              "varargs" : false,
+              "modifiers" : [ ],
+              "annotations" : [ ]
+            }
+          ],
+          "returns" : "void",
+          "throws" : [ ],
+          "annotations" : [ ],
+          "doc" : "",
+          "calls" : [ ]
+        }
+      ],
+      "enum_constants" : [ ]
+    }
+  ],
+  "imports" : [
+    {
+      "from" : "com.example.Dog",
+      "to_class" : "java.util.List",
+      "kind" : "class"
+    },
+    {
+      "from" : "com.example.Trainable",
+      "to_class" : "java.util.List",
+      "kind" : "class"
+    }
+  ],
+  "parse_warnings" : [ ]
+}

--- a/internal/adapter/java/testdata/facts_record.json
+++ b/internal/adapter/java/testdata/facts_record.json
@@ -1,0 +1,88 @@
+{
+  "schema" : "javafacts/v1",
+  "src_roots" : [
+    "src"
+  ],
+  "packages" : [
+    "com.example"
+  ],
+  "classes" : [
+    {
+      "fqn" : "com.example.Point",
+      "package" : "com.example",
+      "name" : "Point",
+      "kind" : "record",
+      "modifiers" : [
+        "public"
+      ],
+      "type_parameters" : [ ],
+      "extends" : "",
+      "implements" : [ ],
+      "permits" : [ ],
+      "source_file" : "com/example/Point.java",
+      "doc" : "2D point — records expose components as fields.",
+      "annotations" : [ ],
+      "fields" : [
+        {
+          "name" : "x",
+          "type" : "double",
+          "modifiers" : [
+            "final",
+            "private"
+          ],
+          "annotations" : [ ],
+          "doc" : ""
+        },
+        {
+          "name" : "y",
+          "type" : "double",
+          "modifiers" : [
+            "final",
+            "private"
+          ],
+          "annotations" : [ ],
+          "doc" : ""
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "distance",
+          "kind" : "method",
+          "modifiers" : [
+            "public"
+          ],
+          "type_parameters" : [ ],
+          "params" : [
+            {
+              "name" : "other",
+              "type" : "Point",
+              "varargs" : false,
+              "modifiers" : [ ],
+              "annotations" : [ ]
+            }
+          ],
+          "returns" : "double",
+          "throws" : [ ],
+          "annotations" : [ ],
+          "doc" : "",
+          "calls" : [
+            {
+              "to_class" : "Math",
+              "to_method" : "sqrt",
+              "static" : true,
+              "external" : true,
+              "target_fqn" : "",
+              "unresolved" : {
+                "receiver_text" : "Math",
+                "method_name" : "sqrt"
+              }
+            }
+          ]
+        }
+      ],
+      "enum_constants" : [ ]
+    }
+  ],
+  "imports" : [ ],
+  "parse_warnings" : [ ]
+}

--- a/internal/adapter/java/testdata/facts_sealed_enums.json
+++ b/internal/adapter/java/testdata/facts_sealed_enums.json
@@ -1,0 +1,268 @@
+{
+  "schema" : "javafacts/v1",
+  "src_roots" : [
+    "src"
+  ],
+  "packages" : [
+    "com.example"
+  ],
+  "classes" : [
+    {
+      "fqn" : "com.example.Circle",
+      "package" : "com.example",
+      "name" : "Circle",
+      "kind" : "class",
+      "modifiers" : [
+        "public",
+        "final"
+      ],
+      "type_parameters" : [ ],
+      "extends" : "",
+      "implements" : [
+        "Shape"
+      ],
+      "permits" : [ ],
+      "source_file" : "com/example/Circle.java",
+      "doc" : "",
+      "annotations" : [ ],
+      "fields" : [
+        {
+          "name" : "radius",
+          "type" : "double",
+          "modifiers" : [
+            "private",
+            "final"
+          ],
+          "annotations" : [ ],
+          "doc" : ""
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "Circle",
+          "kind" : "constructor",
+          "modifiers" : [
+            "public"
+          ],
+          "type_parameters" : [ ],
+          "params" : [
+            {
+              "name" : "radius",
+              "type" : "double",
+              "varargs" : false,
+              "modifiers" : [ ],
+              "annotations" : [ ]
+            }
+          ],
+          "returns" : "void",
+          "throws" : [ ],
+          "annotations" : [ ],
+          "doc" : "",
+          "calls" : [ ]
+        },
+        {
+          "name" : "area",
+          "kind" : "method",
+          "modifiers" : [
+            "public"
+          ],
+          "type_parameters" : [ ],
+          "params" : [ ],
+          "returns" : "double",
+          "throws" : [ ],
+          "annotations" : [
+            {
+              "fqn" : "Override",
+              "args" : [ ]
+            }
+          ],
+          "doc" : "",
+          "calls" : [ ]
+        }
+      ],
+      "enum_constants" : [ ]
+    },
+    {
+      "fqn" : "com.example.Color",
+      "package" : "com.example",
+      "name" : "Color",
+      "kind" : "enum",
+      "modifiers" : [
+        "public"
+      ],
+      "type_parameters" : [ ],
+      "extends" : "",
+      "implements" : [ ],
+      "permits" : [ ],
+      "source_file" : "com/example/Color.java",
+      "doc" : "Enum with explicit constructor — exercises enum kind + enum_constants.",
+      "annotations" : [ ],
+      "fields" : [
+        {
+          "name" : "hex",
+          "type" : "String",
+          "modifiers" : [
+            "private",
+            "final"
+          ],
+          "annotations" : [ ],
+          "doc" : ""
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "Color",
+          "kind" : "constructor",
+          "modifiers" : [ ],
+          "type_parameters" : [ ],
+          "params" : [
+            {
+              "name" : "hex",
+              "type" : "String",
+              "varargs" : false,
+              "modifiers" : [ ],
+              "annotations" : [ ]
+            }
+          ],
+          "returns" : "void",
+          "throws" : [ ],
+          "annotations" : [ ],
+          "doc" : "",
+          "calls" : [ ]
+        },
+        {
+          "name" : "hex",
+          "kind" : "method",
+          "modifiers" : [
+            "public"
+          ],
+          "type_parameters" : [ ],
+          "params" : [ ],
+          "returns" : "String",
+          "throws" : [ ],
+          "annotations" : [ ],
+          "doc" : "",
+          "calls" : [ ]
+        }
+      ],
+      "enum_constants" : [
+        "RED",
+        "GREEN",
+        "BLUE"
+      ]
+    },
+    {
+      "fqn" : "com.example.Shape",
+      "package" : "com.example",
+      "name" : "Shape",
+      "kind" : "interface",
+      "modifiers" : [
+        "public",
+        "sealed"
+      ],
+      "type_parameters" : [ ],
+      "extends" : "",
+      "implements" : [ ],
+      "permits" : [
+        "Circle",
+        "Square"
+      ],
+      "source_file" : "com/example/Shape.java",
+      "doc" : "Sealed interface — exercises permits + interface declaration.",
+      "annotations" : [ ],
+      "fields" : [ ],
+      "methods" : [
+        {
+          "name" : "area",
+          "kind" : "method",
+          "modifiers" : [ ],
+          "type_parameters" : [ ],
+          "params" : [ ],
+          "returns" : "double",
+          "throws" : [ ],
+          "annotations" : [ ],
+          "doc" : "",
+          "calls" : [ ]
+        }
+      ],
+      "enum_constants" : [ ]
+    },
+    {
+      "fqn" : "com.example.Square",
+      "package" : "com.example",
+      "name" : "Square",
+      "kind" : "class",
+      "modifiers" : [
+        "public",
+        "final"
+      ],
+      "type_parameters" : [ ],
+      "extends" : "",
+      "implements" : [
+        "Shape"
+      ],
+      "permits" : [ ],
+      "source_file" : "com/example/Square.java",
+      "doc" : "",
+      "annotations" : [ ],
+      "fields" : [
+        {
+          "name" : "side",
+          "type" : "double",
+          "modifiers" : [
+            "private",
+            "final"
+          ],
+          "annotations" : [ ],
+          "doc" : ""
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "Square",
+          "kind" : "constructor",
+          "modifiers" : [
+            "public"
+          ],
+          "type_parameters" : [ ],
+          "params" : [
+            {
+              "name" : "side",
+              "type" : "double",
+              "varargs" : false,
+              "modifiers" : [ ],
+              "annotations" : [ ]
+            }
+          ],
+          "returns" : "void",
+          "throws" : [ ],
+          "annotations" : [ ],
+          "doc" : "",
+          "calls" : [ ]
+        },
+        {
+          "name" : "area",
+          "kind" : "method",
+          "modifiers" : [
+            "public"
+          ],
+          "type_parameters" : [ ],
+          "params" : [ ],
+          "returns" : "double",
+          "throws" : [ ],
+          "annotations" : [
+            {
+              "fqn" : "Override",
+              "args" : [ ]
+            }
+          ],
+          "doc" : "",
+          "calls" : [ ]
+        }
+      ],
+      "enum_constants" : [ ]
+    }
+  ],
+  "imports" : [ ],
+  "parse_warnings" : [ ]
+}

--- a/internal/adapter/java/testdata/facts_simple.json
+++ b/internal/adapter/java/testdata/facts_simple.json
@@ -1,0 +1,106 @@
+{
+  "schema" : "javafacts/v1",
+  "src_roots" : [
+    "src"
+  ],
+  "packages" : [
+    "com.example"
+  ],
+  "classes" : [
+    {
+      "fqn" : "com.example.Greeter",
+      "package" : "com.example",
+      "name" : "Greeter",
+      "kind" : "class",
+      "modifiers" : [
+        "public"
+      ],
+      "type_parameters" : [ ],
+      "extends" : "",
+      "implements" : [ ],
+      "permits" : [ ],
+      "source_file" : "com/example/Greeter.java",
+      "doc" : "Simple greeter — single class, single field, single method.",
+      "annotations" : [ ],
+      "fields" : [
+        {
+          "name" : "prefix",
+          "type" : "String",
+          "modifiers" : [
+            "private",
+            "final"
+          ],
+          "annotations" : [ ],
+          "doc" : ""
+        }
+      ],
+      "methods" : [
+        {
+          "name" : "Greeter",
+          "kind" : "constructor",
+          "modifiers" : [
+            "public"
+          ],
+          "type_parameters" : [ ],
+          "params" : [
+            {
+              "name" : "prefix",
+              "type" : "String",
+              "varargs" : false,
+              "modifiers" : [ ],
+              "annotations" : [ ]
+            }
+          ],
+          "returns" : "void",
+          "throws" : [ ],
+          "annotations" : [ ],
+          "doc" : "",
+          "calls" : [
+            {
+              "to_class" : "Objects",
+              "to_method" : "requireNonNull",
+              "static" : true,
+              "external" : true,
+              "target_fqn" : "",
+              "unresolved" : {
+                "receiver_text" : "Objects",
+                "method_name" : "requireNonNull"
+              }
+            }
+          ]
+        },
+        {
+          "name" : "greet",
+          "kind" : "method",
+          "modifiers" : [
+            "public"
+          ],
+          "type_parameters" : [ ],
+          "params" : [
+            {
+              "name" : "name",
+              "type" : "String",
+              "varargs" : false,
+              "modifiers" : [ ],
+              "annotations" : [ ]
+            }
+          ],
+          "returns" : "String",
+          "throws" : [ ],
+          "annotations" : [ ],
+          "doc" : "",
+          "calls" : [ ]
+        }
+      ],
+      "enum_constants" : [ ]
+    }
+  ],
+  "imports" : [
+    {
+      "from" : "com.example.Greeter",
+      "to_class" : "java.util.Objects",
+      "kind" : "class"
+    }
+  ],
+  "parse_warnings" : [ ]
+}

--- a/internal/adapter/java/translator.go
+++ b/internal/adapter/java/translator.go
@@ -1,0 +1,409 @@
+package java
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/kgatilin/archai/internal/domain"
+)
+
+// translate converts a JavaFacts document to the equivalent slice of
+// domain.PackageModel.
+//
+// Mapping rules (v1):
+//
+//	Java package "com.foo.bar"  → PackageModel{Path: "com.foo.bar", Name: "bar"}
+//	Java class                  → StructDef
+//	Java interface              → InterfaceDef
+//	Java enum                   → TypeDef (Constants populated from enum_constants)
+//	Java record                 → StructDef + Stereotype "value"
+//	Java annotation             → TypeDef
+//	extends                     → Dependency{Kind: "extends"} (class kinds)
+//	implements                  → Dependency{Kind: "implements"} +
+//	                              domain.Implementation when the interface
+//	                              is in the parsed source set
+//	imports                     → Dependency{Kind: "uses"}
+//	calls (target_fqn != "")    → CallEdge on the source method
+//	modifiers contains "public" → IsExported = true
+//
+// translate is a pure function: no I/O, no globals, deterministic ordering
+// (packages sorted by Path; classes within a package sorted by simple
+// name; field/method order preserved as emitted by the JAR).
+func translate(facts *javaFacts) []domain.PackageModel {
+	if facts == nil {
+		return nil
+	}
+
+	// Group classes by Java package, preserving the JAR's class ordering
+	// (the JAR sorts by FQN, so this is already deterministic).
+	byPkg := make(map[string][]javaClass)
+	for _, c := range facts.Classes {
+		byPkg[c.Package] = append(byPkg[c.Package], c)
+	}
+
+	// Index of FQN → simple class for fast in-source lookup. Used to decide
+	// whether an `implements` / `extends` / call target lives in the parsed
+	// source set (becomes a non-external SymbolRef) or not.
+	classByFQN := make(map[string]javaClass, len(facts.Classes))
+	for _, c := range facts.Classes {
+		classByFQN[c.FQN] = c
+	}
+
+	// Group imports by the importing class's FQN so we can attach uses
+	// dependencies per package.
+	importsByFrom := make(map[string][]javaImport)
+	for _, imp := range facts.Imports {
+		importsByFrom[imp.From] = append(importsByFrom[imp.From], imp)
+	}
+
+	pkgPaths := make([]string, 0, len(byPkg))
+	for p := range byPkg {
+		pkgPaths = append(pkgPaths, p)
+	}
+	sort.Strings(pkgPaths)
+
+	models := make([]domain.PackageModel, 0, len(pkgPaths))
+	for _, pkgPath := range pkgPaths {
+		models = append(models, buildPackage(pkgPath, byPkg[pkgPath], classByFQN, importsByFrom))
+	}
+	return models
+}
+
+// buildPackage assembles one PackageModel from a slice of classes that all
+// share the same Java package name.
+func buildPackage(
+	pkgPath string,
+	classes []javaClass,
+	classByFQN map[string]javaClass,
+	importsByFrom map[string][]javaImport,
+) domain.PackageModel {
+	model := domain.PackageModel{
+		Path: pkgPath,
+		Name: simpleName(pkgPath),
+	}
+
+	for _, c := range classes {
+		appendClass(&model, c, classByFQN, importsByFrom[c.FQN])
+	}
+
+	// Stable ordering for deterministic golden tests. Java pkg has no
+	// "natural" intra-package order, so sort by simple name.
+	sort.SliceStable(model.Interfaces, func(i, j int) bool { return model.Interfaces[i].Name < model.Interfaces[j].Name })
+	sort.SliceStable(model.Structs, func(i, j int) bool { return model.Structs[i].Name < model.Structs[j].Name })
+	sort.SliceStable(model.TypeDefs, func(i, j int) bool { return model.TypeDefs[i].Name < model.TypeDefs[j].Name })
+	sort.SliceStable(model.Implementations, func(i, j int) bool {
+		if model.Implementations[i].Concrete.Symbol != model.Implementations[j].Concrete.Symbol {
+			return model.Implementations[i].Concrete.Symbol < model.Implementations[j].Concrete.Symbol
+		}
+		return model.Implementations[i].Interface.QualifiedName() < model.Implementations[j].Interface.QualifiedName()
+	})
+	sort.SliceStable(model.Dependencies, func(i, j int) bool {
+		if model.Dependencies[i].From.Symbol != model.Dependencies[j].From.Symbol {
+			return model.Dependencies[i].From.Symbol < model.Dependencies[j].From.Symbol
+		}
+		if model.Dependencies[i].Kind != model.Dependencies[j].Kind {
+			return string(model.Dependencies[i].Kind) < string(model.Dependencies[j].Kind)
+		}
+		return model.Dependencies[i].To.QualifiedName() < model.Dependencies[j].To.QualifiedName()
+	})
+
+	return model
+}
+
+// appendClass dispatches a JavaClass to the right slice on the model,
+// depending on its kind, and records its inheritance / implements / uses
+// dependencies.
+func appendClass(
+	model *domain.PackageModel,
+	c javaClass,
+	classByFQN map[string]javaClass,
+	imports []javaImport,
+) {
+	switch c.Kind {
+	case "interface":
+		model.Interfaces = append(model.Interfaces, buildInterface(c))
+	case "enum":
+		model.TypeDefs = append(model.TypeDefs, buildEnum(c))
+	case "annotation":
+		model.TypeDefs = append(model.TypeDefs, buildAnnotation(c))
+	default: // class, record
+		model.Structs = append(model.Structs, buildStruct(c))
+	}
+
+	addInheritanceEdges(model, c, classByFQN)
+	addImportEdges(model, c, imports)
+}
+
+func buildInterface(c javaClass) domain.InterfaceDef {
+	return domain.InterfaceDef{
+		Name:       c.Name,
+		Methods:    convertMethods(c.Methods, c.Package),
+		IsExported: containsModifier(c.Modifiers, "public"),
+		SourceFile: c.SourceFile,
+		Doc:        c.Doc,
+		Stereotype: detectInterfaceStereotype(c),
+	}
+}
+
+func buildStruct(c javaClass) domain.StructDef {
+	stereotype := detectClassStereotype(c)
+	methods := convertMethods(c.Methods, c.Package)
+	for i := range methods {
+		// If the class itself has no stereotype, look for a factory method
+		// to bubble up to the type level — matches the Go adapter's
+		// "factory function" heuristic, but Java factories live as static
+		// methods on a class rather than as standalone funcs.
+		if stereotype == domain.StereotypeNone {
+			if s := detectFactoryStereotype(c, c.Methods[i]); s != domain.StereotypeNone {
+				stereotype = s
+				break
+			}
+		}
+	}
+	return domain.StructDef{
+		Name:       c.Name,
+		Fields:     convertFields(c.Fields, c.Package),
+		Methods:    methods,
+		IsExported: containsModifier(c.Modifiers, "public"),
+		SourceFile: c.SourceFile,
+		Doc:        c.Doc,
+		Stereotype: stereotype,
+	}
+}
+
+func buildEnum(c javaClass) domain.TypeDef {
+	return domain.TypeDef{
+		Name:           c.Name,
+		UnderlyingType: domain.TypeRef{Name: "enum"},
+		Constants:      append([]string(nil), c.EnumConstants...),
+		IsExported:     containsModifier(c.Modifiers, "public"),
+		SourceFile:     c.SourceFile,
+		Doc:            c.Doc,
+		Stereotype:     domain.StereotypeEnum,
+	}
+}
+
+func buildAnnotation(c javaClass) domain.TypeDef {
+	return domain.TypeDef{
+		Name:           c.Name,
+		UnderlyingType: domain.TypeRef{Name: "annotation"},
+		IsExported:     containsModifier(c.Modifiers, "public"),
+		SourceFile:     c.SourceFile,
+		Doc:            c.Doc,
+	}
+}
+
+// addInheritanceEdges emits Dependency{extends} for `extends` and
+// Dependency{implements} (+ Implementation) for `implements`. The kind on
+// `interface extends X` is treated as `implements` per SCHEMA.md (the JAR
+// canonicalises super-interfaces into the implements slot).
+func addInheritanceEdges(model *domain.PackageModel, c javaClass, classByFQN map[string]javaClass) {
+	from := classRef(c)
+
+	if c.Extends != "" {
+		to := refForName(c.Extends, classByFQN)
+		model.Dependencies = append(model.Dependencies, domain.Dependency{
+			From: from, To: to, Kind: domain.DependencyExtends, ThroughExported: true,
+		})
+	}
+
+	for _, impl := range c.Implements {
+		to := refForName(impl, classByFQN)
+		model.Dependencies = append(model.Dependencies, domain.Dependency{
+			From: from, To: to, Kind: domain.DependencyImplements, ThroughExported: true,
+		})
+		// Only record an Implementation when the interface is in the parsed
+		// source set — a domain.Implementation cross-package reference is
+		// only meaningful for types we actually know about.
+		if !to.External && c.Kind != "interface" {
+			model.Implementations = append(model.Implementations, domain.Implementation{
+				Concrete:  from,
+				Interface: to,
+			})
+		}
+	}
+}
+
+// addImportEdges turns every `import` statement on a class into a
+// Dependency{uses} edge. Kept out of the per-class struct because imports
+// are a unit-level concept; from the diagram's perspective they belong to
+// the importing class.
+func addImportEdges(model *domain.PackageModel, c javaClass, imports []javaImport) {
+	from := classRef(c)
+	for _, imp := range imports {
+		// Wildcard imports have no concrete target symbol; skip them.
+		if imp.Kind == "wildcard" || imp.Kind == "static_wildcard" {
+			continue
+		}
+		model.Dependencies = append(model.Dependencies, domain.Dependency{
+			From: from, To: fqnRef(imp.ToClass), Kind: domain.DependencyUses,
+		})
+	}
+}
+
+func convertFields(in []javaField, pkgPath string) []domain.FieldDef {
+	out := make([]domain.FieldDef, 0, len(in))
+	for _, f := range in {
+		out = append(out, domain.FieldDef{
+			Name:       f.Name,
+			Type:       parseTypeRef(f.Type, pkgPath),
+			IsExported: containsModifier(f.Modifiers, "public"),
+		})
+	}
+	return out
+}
+
+func convertMethods(in []javaMethod, pkgPath string) []domain.MethodDef {
+	out := make([]domain.MethodDef, 0, len(in))
+	for _, m := range in {
+		method := domain.MethodDef{
+			Name:       m.Name,
+			Params:     convertParams(m.Params, pkgPath),
+			IsExported: containsModifier(m.Modifiers, "public"),
+			Calls:      convertCalls(m.Calls),
+		}
+		// Constructors return their enclosing type implicitly — modelling
+		// `void` here would lie. We follow the JAR's choice (`returns:
+		// "void"`) for plain methods and skip Returns for constructors.
+		if m.Kind != "constructor" && m.Returns != "" && m.Returns != "void" {
+			method.Returns = []domain.TypeRef{parseTypeRef(m.Returns, pkgPath)}
+		}
+		out = append(out, method)
+	}
+	return out
+}
+
+func convertParams(in []javaParam, pkgPath string) []domain.ParamDef {
+	out := make([]domain.ParamDef, 0, len(in))
+	for _, p := range in {
+		ref := parseTypeRef(p.Type, pkgPath)
+		if p.Varargs {
+			// Varargs are slices over the element type at the call site.
+			ref.IsSlice = true
+		}
+		out = append(out, domain.ParamDef{Name: p.Name, Type: ref})
+	}
+	return out
+}
+
+// convertCalls keeps only resolved calls — those that bound to a class in
+// the analyzed source set (target_fqn != ""). External / unresolved calls
+// would render as edges to nothing, so we drop them per SCHEMA.md.
+func convertCalls(in []javaCall) []domain.CallEdge {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]domain.CallEdge, 0, len(in))
+	for _, c := range in {
+		if c.External || c.TargetFQN == "" {
+			continue
+		}
+		out = append(out, domain.CallEdge{To: fqnMethodRef(c.TargetFQN, c.ToMethod)})
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// parseTypeRef builds a domain.TypeRef from a Java type as written:
+// "int", "String", "List<String>", "java.util.List<String>", "int[]".
+//
+// Type-parameter substitution is intentionally shallow (matches SCHEMA.md
+// "What's not in v1" section). Generic args are preserved verbatim in
+// TypeRef.Name so the diagram can still print "List<String>".
+func parseTypeRef(raw, pkgPath string) domain.TypeRef {
+	t := strings.TrimSpace(raw)
+	if t == "" {
+		return domain.TypeRef{}
+	}
+
+	ref := domain.TypeRef{}
+
+	// Java arrays: `String[]` / `int[][]`. Drop one bracket pair → slice.
+	for strings.HasSuffix(t, "[]") {
+		ref.IsSlice = true
+		t = strings.TrimSuffix(t, "[]")
+	}
+
+	// Split fqn / simple. We don't try to follow type parameters across
+	// the dot (Java doesn't allow "."-qualified generics) so simple name
+	// extraction is just "last segment before the first <".
+	bare := t
+	if idx := strings.Index(t, "<"); idx >= 0 {
+		bare = t[:idx]
+	}
+	if dot := strings.LastIndex(bare, "."); dot >= 0 {
+		ref.Package = bare[:dot]
+		// preserve generic suffix on the type name itself
+		ref.Name = bare[dot+1:] + t[len(bare):]
+	} else {
+		// Local type or builtin → leave Package empty; D2 layer handles it.
+		ref.Name = t
+	}
+
+	return ref
+}
+
+// classRef returns a SymbolRef for an in-source class, populated for the
+// translator's edge construction.
+func classRef(c javaClass) domain.SymbolRef {
+	return domain.SymbolRef{Package: c.Package, File: c.SourceFile, Symbol: c.Name}
+}
+
+// refForName resolves a textual `extends` / `implements` target. If the
+// name is known (in classByFQN) the SymbolRef points into the source set;
+// otherwise it's external. Names without a "." are looked up by simple
+// name as a best-effort match — Java implements clauses often appear
+// unqualified when an `import` brought the type in.
+func refForName(name string, classByFQN map[string]javaClass) domain.SymbolRef {
+	// Strip generic args.
+	bare := name
+	if idx := strings.Index(name, "<"); idx >= 0 {
+		bare = name[:idx]
+	}
+	if class, ok := classByFQN[bare]; ok {
+		return classRef(class)
+	}
+	if !strings.Contains(bare, ".") {
+		for _, class := range classByFQN {
+			if class.Name == bare {
+				return classRef(class)
+			}
+		}
+	}
+	return fqnRef(bare)
+}
+
+// fqnRef makes a SymbolRef for a fully-qualified type name that lives
+// outside the parsed source set.
+func fqnRef(fqn string) domain.SymbolRef {
+	pkg, sym := splitFQN(fqn)
+	return domain.SymbolRef{Package: pkg, Symbol: sym, External: true}
+}
+
+// fqnMethodRef builds a SymbolRef pointing at a specific method on an
+// in-source class.
+func fqnMethodRef(targetFQN, method string) domain.SymbolRef {
+	pkg, cls := splitFQN(targetFQN)
+	return domain.SymbolRef{Package: pkg, Symbol: cls + "." + method}
+}
+
+// splitFQN cuts a Java FQN at its last dot. "com.foo.Bar" → ("com.foo", "Bar").
+// FQNs without a dot (rare — usually default-package tests) yield an empty
+// package.
+func splitFQN(fqn string) (pkg, simple string) {
+	if dot := strings.LastIndex(fqn, "."); dot >= 0 {
+		return fqn[:dot], fqn[dot+1:]
+	}
+	return "", fqn
+}
+
+// simpleName returns the last dot-separated segment of a Java package
+// path. "com.foo.bar" → "bar"; "" → "".
+func simpleName(pkgPath string) string {
+	if dot := strings.LastIndex(pkgPath, "."); dot >= 0 {
+		return pkgPath[dot+1:]
+	}
+	return pkgPath
+}

--- a/internal/adapter/java/translator_test.go
+++ b/internal/adapter/java/translator_test.go
@@ -1,0 +1,326 @@
+package java
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kgatilin/archai/internal/domain"
+)
+
+// loadFixture decodes a JSON fixture from testdata/.
+func loadFixture(t *testing.T, name string) *javaFacts {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join("testdata", name))
+	if err != nil {
+		t.Fatalf("read %s: %v", name, err)
+	}
+	facts, err := decodeFacts(raw)
+	if err != nil {
+		t.Fatalf("decode %s: %v", name, err)
+	}
+	return facts
+}
+
+func TestTranslate_SimpleClass(t *testing.T) {
+	facts := loadFixture(t, "facts_simple.json")
+	models := translate(facts)
+
+	if len(models) != 1 {
+		t.Fatalf("want 1 package, got %d", len(models))
+	}
+	pkg := models[0]
+	if pkg.Path != "com.example" {
+		t.Errorf("path: want com.example, got %q", pkg.Path)
+	}
+	if pkg.Name != "example" {
+		t.Errorf("name: want example, got %q", pkg.Name)
+	}
+	if len(pkg.Structs) != 1 {
+		t.Fatalf("want 1 struct, got %d", len(pkg.Structs))
+	}
+	s := pkg.Structs[0]
+	if s.Name != "Greeter" || !s.IsExported {
+		t.Errorf("struct: want Greeter+exported, got %+v", s)
+	}
+	if len(s.Fields) != 1 || s.Fields[0].Name != "prefix" {
+		t.Errorf("fields: %+v", s.Fields)
+	}
+	// Two methods: the constructor (Greeter) and greet().
+	if len(s.Methods) != 2 {
+		t.Fatalf("methods: %+v", s.Methods)
+	}
+	var greet domain.MethodDef
+	for _, m := range s.Methods {
+		if m.Name == "greet" {
+			greet = m
+		}
+	}
+	if greet.Name == "" || len(greet.Returns) != 1 || greet.Returns[0].Name != "String" {
+		t.Errorf("greet return: %+v", greet)
+	}
+}
+
+func TestTranslate_Inheritance(t *testing.T) {
+	facts := loadFixture(t, "facts_inheritance.json")
+	models := translate(facts)
+	if len(models) != 1 {
+		t.Fatalf("want 1 package, got %d", len(models))
+	}
+	pkg := models[0]
+
+	// Animal + Dog land as structs; Trainable lands as an interface.
+	if len(pkg.Structs) != 2 {
+		t.Errorf("structs: want 2, got %d (%v)", len(pkg.Structs), structNames(pkg.Structs))
+	}
+	if len(pkg.Interfaces) != 1 || pkg.Interfaces[0].Name != "Trainable" {
+		t.Errorf("interfaces: %+v", pkg.Interfaces)
+	}
+
+	// Dog extends Animal must be present as a Dependency{extends}, with
+	// the target resolved to the in-source Animal class (External=false).
+	var sawExtends, sawImplements bool
+	for _, dep := range pkg.Dependencies {
+		if dep.From.Symbol == "Dog" && dep.Kind == domain.DependencyExtends {
+			sawExtends = true
+			if dep.To.Symbol != "Animal" || dep.To.External {
+				t.Errorf("extends edge: want Dog→Animal in-source, got %+v", dep)
+			}
+		}
+		if dep.From.Symbol == "Dog" && dep.Kind == domain.DependencyImplements {
+			sawImplements = true
+		}
+	}
+	if !sawExtends {
+		t.Errorf("missing Dog→Animal extends edge: %+v", pkg.Dependencies)
+	}
+	if !sawImplements {
+		t.Errorf("missing Dog→Trainable implements edge: %+v", pkg.Dependencies)
+	}
+
+	// Dog implements Trainable → one Implementation entry with concrete=Dog.
+	var sawImpl bool
+	for _, impl := range pkg.Implementations {
+		if impl.Concrete.Symbol == "Dog" && impl.Interface.Symbol == "Trainable" {
+			sawImpl = true
+		}
+	}
+	if !sawImpl {
+		t.Errorf("missing Dog→Trainable Implementation: %+v", pkg.Implementations)
+	}
+
+	// imports → uses dependencies (Dog uses java.util.List).
+	var sawUses bool
+	for _, dep := range pkg.Dependencies {
+		if dep.Kind == domain.DependencyUses && dep.To.Symbol == "List" {
+			sawUses = true
+		}
+	}
+	if !sawUses {
+		t.Errorf("expected uses dep on java.util.List: %+v", pkg.Dependencies)
+	}
+}
+
+func TestTranslate_Calls_ResolvedOnly(t *testing.T) {
+	facts := loadFixture(t, "facts_inheritance.json")
+	models := translate(facts)
+	pkg := models[0]
+
+	// describe() in Animal calls sound() resolving to com.example.Animal.
+	var animal domain.StructDef
+	for _, s := range pkg.Structs {
+		if s.Name == "Animal" {
+			animal = s
+		}
+	}
+	if animal.Name == "" {
+		t.Fatalf("Animal not found in %v", structNames(pkg.Structs))
+	}
+	var describe domain.MethodDef
+	for _, m := range animal.Methods {
+		if m.Name == "describe" {
+			describe = m
+		}
+	}
+	if describe.Name == "" {
+		t.Fatalf("describe not found")
+	}
+	if len(describe.Calls) != 1 {
+		t.Fatalf("calls: want 1 resolved, got %d (%+v)", len(describe.Calls), describe.Calls)
+	}
+	got := describe.Calls[0]
+	if got.To.Package != "com.example" || got.To.Symbol != "Animal.sound" {
+		t.Errorf("call edge: want com.example/Animal.sound, got %+v", got.To)
+	}
+
+	// Dog.learn calls System.out.println — external — should be dropped.
+	var dog domain.StructDef
+	for _, s := range pkg.Structs {
+		if s.Name == "Dog" {
+			dog = s
+		}
+	}
+	for _, m := range dog.Methods {
+		if m.Name == "learn" && len(m.Calls) != 0 {
+			t.Errorf("learn(): external calls must be dropped, got %+v", m.Calls)
+		}
+	}
+}
+
+func TestTranslate_Record_AsValueStruct(t *testing.T) {
+	facts := loadFixture(t, "facts_record.json")
+	models := translate(facts)
+	if len(models) != 1 {
+		t.Fatalf("packages: %+v", models)
+	}
+	pkg := models[0]
+	if len(pkg.Structs) != 1 {
+		t.Fatalf("structs: %+v", pkg.Structs)
+	}
+	s := pkg.Structs[0]
+	if s.Stereotype != domain.StereotypeValue {
+		t.Errorf("record should be StereotypeValue, got %q", s.Stereotype)
+	}
+}
+
+func TestTranslate_SealedAndEnums(t *testing.T) {
+	facts := loadFixture(t, "facts_sealed_enums.json")
+	models := translate(facts)
+	if len(models) != 1 {
+		t.Fatalf("packages: %+v", models)
+	}
+	pkg := models[0]
+
+	// At least one enum should land in TypeDefs with StereotypeEnum.
+	var foundEnum bool
+	for _, td := range pkg.TypeDefs {
+		if td.Stereotype == domain.StereotypeEnum && len(td.Constants) > 0 {
+			foundEnum = true
+		}
+	}
+	if !foundEnum {
+		t.Errorf("expected at least one enum TypeDef, got %+v", pkg.TypeDefs)
+	}
+}
+
+func TestTranslate_DeterministicOrdering(t *testing.T) {
+	// Same input twice → identical output.
+	facts := loadFixture(t, "facts_inheritance.json")
+	a := translate(facts)
+	b := translate(facts)
+	if !sameModelShape(a, b) {
+		t.Errorf("translate not deterministic")
+	}
+}
+
+func TestTranslate_StereotypeHeuristics(t *testing.T) {
+	cases := []struct {
+		name string
+		in   javaClass
+		want domain.Stereotype
+	}{
+		{"repository suffix", javaClass{Name: "UserRepository", Kind: "class"}, domain.StereotypeRepository},
+		{"dao suffix", javaClass{Name: "UserDao", Kind: "class"}, domain.StereotypeRepository},
+		{"service suffix", javaClass{Name: "UserService", Kind: "class"}, domain.StereotypeService},
+		{"controller suffix", javaClass{Name: "UserController", Kind: "class"}, domain.StereotypeService},
+		{
+			"RestController annotation",
+			javaClass{
+				Name: "Users", Kind: "class",
+				Annotations: []javaAnnotation{{FQN: "org.springframework.web.bind.annotation.RestController"}},
+			},
+			domain.StereotypeService,
+		},
+		{"plain class", javaClass{Name: "Plain", Kind: "class"}, domain.StereotypeNone},
+		{"record", javaClass{Name: "Point", Kind: "record"}, domain.StereotypeValue},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := detectClassStereotype(c.in)
+			if got != c.want {
+				t.Errorf("got %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestTranslate_FactoryMethodLifts(t *testing.T) {
+	c := javaClass{
+		Name: "Point", FQN: "com.example.Point", Kind: "class",
+		Methods: []javaMethod{
+			{
+				Name: "of", Kind: "method", Modifiers: []string{"public", "static"},
+				Returns: "Point",
+			},
+		},
+	}
+	st := detectFactoryStereotype(c, c.Methods[0])
+	if st != domain.StereotypeFactory {
+		t.Errorf("static of()→Point should be factory, got %q", st)
+	}
+	// Non-static `of` is not a factory.
+	c.Methods[0].Modifiers = []string{"public"}
+	if detectFactoryStereotype(c, c.Methods[0]) == domain.StereotypeFactory {
+		t.Error("non-static of() should not be factory")
+	}
+}
+
+func TestParseTypeRef(t *testing.T) {
+	cases := []struct {
+		in          string
+		wantName    string
+		wantPackage string
+		wantSlice   bool
+	}{
+		{"int", "int", "", false},
+		{"String", "String", "", false},
+		{"java.util.List", "List", "java.util", false},
+		{"List<String>", "List<String>", "", false},
+		{"java.util.List<String>", "List<String>", "java.util", false},
+		{"int[]", "int", "", true},
+		{"String[][]", "String", "", true},
+	}
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			ref := parseTypeRef(c.in, "com.foo")
+			if ref.Name != c.wantName || ref.Package != c.wantPackage || ref.IsSlice != c.wantSlice {
+				t.Errorf("got %+v", ref)
+			}
+		})
+	}
+}
+
+func TestSchemaVersionMismatchRejected(t *testing.T) {
+	bad := []byte(`{"schema":"javafacts/v0","src_roots":[],"packages":[],"classes":[],"imports":[],"parse_warnings":[]}`)
+	if _, err := decodeFacts(bad); err == nil {
+		t.Error("decodeFacts should reject unknown schema version")
+	}
+}
+
+func structNames(ss []domain.StructDef) []string {
+	out := make([]string, 0, len(ss))
+	for _, s := range ss {
+		out = append(out, s.Name)
+	}
+	return out
+}
+
+// sameModelShape compares two slices of PackageModel for shape equality
+// (counts of each member kind). A full deep-equal on PackageModel is
+// brittle and unnecessary for a determinism check.
+func sameModelShape(a, b []domain.PackageModel) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].Path != b[i].Path ||
+			len(a[i].Structs) != len(b[i].Structs) ||
+			len(a[i].Interfaces) != len(b[i].Interfaces) ||
+			len(a[i].TypeDefs) != len(b[i].TypeDefs) ||
+			len(a[i].Dependencies) != len(b[i].Dependencies) ||
+			len(a[i].Implementations) != len(b[i].Implementations) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/domain/dependency.go
+++ b/internal/domain/dependency.go
@@ -14,6 +14,11 @@ const (
 
 	// DependencyImplements indicates a struct implements an interface.
 	DependencyImplements DependencyKind = "implements"
+
+	// DependencyExtends indicates a class extends another class
+	// (Java-style inheritance). Emitted by adapter/java; the Go
+	// adapter does not produce this kind.
+	DependencyExtends DependencyKind = "extends"
 )
 
 // String returns the string representation of the dependency kind.


### PR DESCRIPTION
Closes #102. Builds on #101 (`archai-java-analyzer.jar` already on main).

## Summary
- New package `internal/adapter/java/` satisfying `service.ModelReader` by shelling out to `archai-java-analyzer.jar` and translating `JavaFacts/v1` JSON to `[]domain.PackageModel`.
- Pure translator (no I/O, no globals, deterministic order) + stereotype heuristics + JAR path resolution chain.
- Adds `domain.DependencyExtends` so Java class-extension lands as its own edge kind alongside `implements` / `uses` / `returns`. Go adapter doesn't emit it.

## Layout
| File | Role |
|---|---|
| `facts.go` | JSON-shape mirror of JavaFacts/v1 |
| `exec.go` | JAR/`java` resolution + process call + stderr capture |
| `translator.go` | Pure `JavaFacts → []domain.PackageModel` |
| `stereotype.go` | Heuristics: repository / service / controller / record-as-value / static factory |
| `reader.go` | Wires it all together; exposes `Warnings()` accessor |
| `testdata/` | `facts_*.json` fixtures lifted from the JAR's golden tests |

## JAR resolution
`NewReader(jarPath)` → `ARCHAI_JAVA_JAR` → `<exe-dir>/archai-java-analyzer.jar` → friendly error pointing at `--java-jar` / `ARCHAI_JAVA_JAR`. `java` binary resolved via `exec.LookPath`; clear error if missing.

## Translation rules (v1, per #102 spec)
| JavaFacts | domain |
|---|---|
| Java package `com.foo.bar` | `PackageModel{Path: "com.foo.bar", Name: "bar"}` |
| Java `class` / `record` | `StructDef` (record gets `StereotypeValue`) |
| Java `interface` | `InterfaceDef` |
| Java `enum` | `TypeDef` with `Constants` from `enum_constants` |
| Java `annotation` | `TypeDef` |
| `extends` | `Dependency{Kind: "extends"}` |
| `implements` | `Dependency{Kind: "implements"}` (+ `Implementation` when interface is in the parsed source set) |
| `imports` (non-wildcard) | `Dependency{Kind: "uses"}` |
| `calls` with `target_fqn != ""` | `CallEdge` on the source method |
| `modifiers` contains `public` | `IsExported = true` |

External / unresolved calls are dropped from the graph (they'd render as edges to nothing); they remain visible in JavaFacts for diagnostics.

## Schema ownership
Lives in Go. `decodeFacts` rejects unknown top-level fields and any schema other than `javafacts/v1`, so a future JAR upgrade fails loudly instead of silently mis-mapping.

## Test plan
- [x] `go test ./internal/adapter/java/...` (translator + exec + reader)
- [x] `go test ./...` (full repo, no regressions)
- [x] `go vet ./...`
- [x] `gofmt -l` clean
- [ ] e2e wiring through the CLI lands in #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)