### PR TITLE
feat(#103): CLI Java dispatch + e2e — multi-language reader pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,29 @@ Output goes to `.arch/` folder in each package:
 - `pub.d2` - exported symbols only (public API)
 - `internal.d2` - all symbols (full implementation)
 
+### Java Sources (experimental)
+
+Archai can also analyse Java source code via a companion JAR
+(`archai-java-analyzer.jar`, see `tools/archai-java-analyzer/`). Java
+support is opt-in:
+
+- Requires JRE 21+ on `PATH`.
+- Requires the JAR. Build it from source with `make java-analyzer` (Maven 3.9+ required), then point archai at it via `--java-jar` or the `ARCHAI_JAVA_JAR` environment variable. `make build-all` copies the JAR next to `bin/archai`, which the CLI auto-discovers.
+
+```bash
+# Build the JAR (one-time)
+make java-analyzer
+
+# Generate diagrams for a Java project
+archai diagram generate ./mysrc --java-jar tools/archai-java-analyzer/target/archai-java-analyzer.jar
+```
+
+Polyglot trees work too — `archai diagram generate ./...` will run the
+Go reader on `*.go` subtrees and the Java reader on `*.java` subtrees
+in the same invocation. Pure-Go projects pay no cost: when neither the
+flag nor `ARCHAI_JAVA_JAR` is set and no JAR sits next to the binary,
+archai silently skips Java detection.
+
 ### Split Combined Diagrams
 
 Split a combined diagram into per-package specification files:

--- a/cmd/archai/java_wiring.go
+++ b/cmd/archai/java_wiring.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	javaAdapter "github.com/kgatilin/archai/internal/adapter/java"
+)
+
+// tryAssembleJavaReader returns a Java ModelReader if the toolchain is
+// usable: `java` resolves on PATH AND a JAR can be located via the
+// flag, env var, or sibling-of-binary lookup. Otherwise it returns nil
+// plus an optional one-line note for stderr explaining what's missing
+// (so users with pure-Go projects don't trip over the Java code path).
+//
+// jarFlag is the value of `--java-jar`. Empty means "auto-detect".
+func tryAssembleJavaReader(jarFlag string) (*javaAdapter.Reader, string) {
+	if _, err := exec.LookPath("java"); err != nil {
+		// `java` missing is a soft-disable: the user might just be
+		// working on a Go-only project.
+		return nil, ""
+	}
+
+	jarPath := jarFlag
+	if jarPath == "" {
+		jarPath = os.Getenv("ARCHAI_JAVA_JAR")
+	}
+	if jarPath == "" {
+		// Sibling-of-binary fallback. We mirror the resolution chain in
+		// adapter/java but pre-check it here so we can surface a clear
+		// "not bundled" note rather than failing later inside Read().
+		if exe, err := os.Executable(); err == nil {
+			candidate := filepath.Join(filepath.Dir(exe), "archai-java-analyzer.jar")
+			if _, statErr := os.Stat(candidate); statErr == nil {
+				jarPath = candidate
+			}
+		}
+	}
+	if jarPath == "" {
+		return nil, "Note: Java sources will be skipped (set --java-jar or ARCHAI_JAVA_JAR to enable)."
+	}
+
+	if _, err := os.Stat(jarPath); err != nil {
+		return nil, fmt.Sprintf("Note: Java sources will be skipped (jar at %q not readable: %v).", jarPath, err)
+	}
+
+	return javaAdapter.NewReader(jarPath), ""
+}

--- a/cmd/archai/main.go
+++ b/cmd/archai/main.go
@@ -92,6 +92,7 @@ Examples:
 	generateCmd.Flags().Bool("debug", false, "Print debug information about packages and dependencies")
 	generateCmd.Flags().String("overlay", "", "Path to archai.yaml overlay (default: auto-detect in current directory)")
 	generateCmd.Flags().String("mode", "public", "Combined-mode overview detail: 'public' (default) or 'full'")
+	generateCmd.Flags().String("java-jar", "", "Path to archai-java-analyzer.jar (defaults to ARCHAI_JAVA_JAR env or sibling-of-binary)")
 
 	diagramCmd.AddCommand(generateCmd)
 
@@ -1047,6 +1048,7 @@ func runGenerate(cmd *cobra.Command, args []string) error {
 	debug, _ := cmd.Flags().GetBool("debug")
 	overlayFlag, _ := cmd.Flags().GetString("overlay")
 	modeFlag, _ := cmd.Flags().GetString("mode")
+	javaJarFlag, _ := cmd.Flags().GetString("java-jar")
 
 	// Resolve overlay path: explicit flag wins; otherwise auto-detect
 	// archai.yaml in the current working directory.
@@ -1075,7 +1077,19 @@ func runGenerate(cmd *cobra.Command, args []string) error {
 
 	yamlReader := yamlAdapter.NewReader()
 	yamlWriter := yamlAdapter.NewWriter()
-	svc := service.NewService(goReader, d2Reader, writer, service.WithYAML(yamlReader, yamlWriter))
+
+	// Java support is opt-in by environment: only attach the Java reader
+	// when both `java` is on PATH AND a JAR can be resolved. Pure-Go
+	// users pay no cost (the Java reader's match predicate skips paths
+	// without .java files anyway, but we belt-and-brace by not even
+	// registering the reader when the toolchain is incomplete).
+	options := []service.Option{service.WithYAML(yamlReader, yamlWriter)}
+	if javaReader, note := tryAssembleJavaReader(javaJarFlag); javaReader != nil {
+		options = append(options, service.WithJavaReader(javaReader))
+	} else if note != "" {
+		fmt.Fprintln(os.Stderr, note)
+	}
+	svc := service.NewService(goReader, d2Reader, writer, options...)
 
 	// Validate flags
 	if pubOnly && internalOnly {
@@ -1113,7 +1127,9 @@ func runGenerate(cmd *cobra.Command, args []string) error {
 			if !ok {
 				return fmt.Errorf("writer does not support full-mode combined output (use --format=d2)")
 			}
-			packages, err := goReader.Read(ctx, args)
+			// Use the service so the Java/Go multi-language dispatch is
+			// honoured here too, not just on the per-package path.
+			packages, err := svc.ReadModels(ctx, args)
 			if err != nil {
 				return fmt.Errorf("generation failed: reading packages: %w", err)
 			}

--- a/docs/features/java-support.md
+++ b/docs/features/java-support.md
@@ -1,0 +1,61 @@
+# Java support
+
+Status: **experimental**, lands in archai 0.x via [#100](https://github.com/kgatilin/archai/issues/100) (children: #101, #102, #103).
+
+## Goal
+
+Generate the same `.arch/{pub,internal}.{d2,yaml}` outputs from Java source code as we already do from Go, with no archai-side schema changes and no extra ceremony for Go-only users.
+
+## Architecture
+
+```
+                       ┌────────────────────────────┐
+   archai (Go binary)  │  cmd/archai                │
+                       │  service.Service           │
+                       │   ├── adapter/golang       │
+                       │   ├── adapter/java ────────┼──── exec ─────► archai-java-analyzer.jar
+                       │   ├── adapter/d2           │                   (JavaParser + symbol-solver)
+                       │   └── adapter/yaml         │                   emits JavaFacts/v1 JSON on stdout
+                       └────────────────────────────┘
+```
+
+Two halves, talking through a versioned JSON contract:
+
+1. **`tools/archai-java-analyzer/`** (#101): a small Maven-built fat-jar. JavaParser walks Java source under the configured `src/` roots and emits a `JavaFacts/v1` document on stdout. The analyzer is intentionally **AST-shape, not archai-shape** — it emits what the AST says, no DDD vocabulary, no archai stereotypes. Fully documented in [`tools/archai-java-analyzer/SCHEMA.md`](../../tools/archai-java-analyzer/SCHEMA.md).
+2. **`internal/adapter/java/`** (#102): the Go side. Resolves the JAR (constructor arg → `ARCHAI_JAVA_JAR` → sibling-of-binary), shells out via `java -jar`, decodes the JSON, and runs a pure translator that produces `[]domain.PackageModel`.
+3. **`service.Service`** (#103): now accepts language-scoped readers via `WithJavaReader` / `WithLanguageReader`. The Go reader passed to `NewService` always runs first; additional readers are dispatched only on input paths whose subtree contains the language's source files. Polyglot directories work — both readers run, results are concatenated.
+
+## Why the schema lives in Go
+
+Archai's domain model evolves as we learn (new stereotype, new edge kind, richer `TypeRef`). Putting that semantics in Java would couple every domain change to a Maven release; instead the JAR speaks a fixed, dumb shape and the Go translator owns all interpretation. The JAR's schema string (`javafacts/v1`) is checked on every run — a future bump fails loudly instead of silently mis-mapping.
+
+## CLI surface
+
+```
+archai diagram generate <paths...> [--java-jar <path>]
+```
+
+- `--java-jar` is optional. Resolution order: `--java-jar` flag → `ARCHAI_JAVA_JAR` env → sibling of `bin/archai` → "skip Java" (with a one-line stderr note for the user).
+- Pure-Go users: when neither the flag, env, nor sibling JAR is present, archai silently registers no Java reader and the dispatch path is a no-op.
+- Polyglot dispatch: each input path is checked for `*.java` files in its subtree; the Java reader runs only on matching paths, the Go reader runs as before.
+
+## What's not in v1
+
+- **Cross-language edges** (Go ↔ Java in the same diagram). Each language renders its own packages.
+- **Build-system integration.** The JAR takes raw source-root paths; it doesn't read `pom.xml` or `build.gradle`.
+- **Annotation argument resolution.** Annotation values stay textual.
+- **Resolved `extends` / `implements` FQN.** Inheritance edges to types outside the analyzed source set stay textual; only same-source class names are resolved (for in-source classes the Go translator finds them by simple name as well).
+
+These are tracked as explicit follow-ups; anything that lands on the schema bumps `javafacts/v2`.
+
+## Testing
+
+- Unit tests for the JAR live in `tools/archai-java-analyzer/src/test/java/` (golden-JSON comparison).
+- Unit tests for the Go side live in `internal/adapter/java/` (translator + exec resolution + reader).
+- The end-to-end path is exercised by `tests/integration/java_e2e_test.go`, gated behind both the `e2e` build tag and the `RUN_E2E=1` env var:
+
+  ```
+  RUN_E2E=1 go test -tags e2e -run TestJavaEndToEnd ./tests/integration/...
+  ```
+
+  The fixture under `tests/integration/fixtures/java/` is a 3-package Java mini-project; the test asserts the analyzer + translator + service pipeline produces models for all three packages and round-trips through `adapter/yaml`.

--- a/internal/service/dispatch.go
+++ b/internal/service/dispatch.go
@@ -1,0 +1,147 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/kgatilin/archai/internal/domain"
+)
+
+// languageReader pairs a ModelReader with a path-matching predicate. A
+// reader is invoked only for the input paths whose subtree contains the
+// language's source files. The concrete type is unexported because
+// callers wire readers via the WithJavaReader / WithLanguageReader
+// options rather than constructing this struct directly.
+type languageReader struct {
+	name   string
+	reader ModelReader
+	// match returns true if the given input path's subtree contains
+	// source files this reader can analyse. When match is nil, the
+	// reader runs unconditionally (legacy behaviour for the Go reader
+	// passed to NewService).
+	match func(path string) bool
+}
+
+// ReadModels is the exported counterpart of readPackages. CLI callsites
+// that want to bypass the full Generate pipeline (e.g. combined-full
+// mode in cmd/archai) can use this to honour the multi-language
+// dispatch without re-implementing it.
+func (s *Service) ReadModels(ctx context.Context, paths []string) ([]domain.PackageModel, error) {
+	return s.readPackages(ctx, paths)
+}
+
+// readPackages dispatches the input paths to every registered language
+// reader whose match predicate accepts them, then concatenates the
+// resulting models. This is the single entry point used by both
+// generateInternal and generateCombined so the dispatch logic stays in
+// one place.
+//
+// Behaviour summary:
+//
+//   - The Go reader passed to NewService runs on every path (legacy
+//     behaviour) unless the caller registers a Go matcher via
+//     WithGoLanguageMatcher. This keeps existing tests green.
+//   - Additional language readers (e.g., Java via WithJavaReader) only
+//     run on paths whose match predicate returns true.
+//   - If no reader produces any output AND at least one was registered
+//     beyond Go, returns a "no supported sources" error so the user gets
+//     a clear signal instead of silent empty output.
+func (s *Service) readPackages(ctx context.Context, paths []string) ([]domain.PackageModel, error) {
+	// Backward-compat: callers that build a Service via struct literal
+	// (older internal tests) skip NewService's langReaders bootstrap.
+	// Fall back to the bare goReader so they keep working unchanged.
+	if len(s.langReaders) == 0 {
+		if s.goReader == nil {
+			return nil, fmt.Errorf("service has no language readers configured")
+		}
+		return s.goReader.Read(ctx, paths)
+	}
+
+	var all []domain.PackageModel
+	for _, lr := range s.langReaders {
+		matched := paths
+		if lr.match != nil {
+			matched = filterMatchingPaths(paths, lr.match)
+			if len(matched) == 0 {
+				continue
+			}
+		}
+		pkgs, err := lr.reader.Read(ctx, matched)
+		if err != nil {
+			return nil, fmt.Errorf("%s reader: %w", lr.name, err)
+		}
+		all = append(all, pkgs...)
+	}
+
+	if len(all) == 0 && len(s.langReaders) > 1 {
+		// Only error out for multi-reader setups: a single Go-reader
+		// service may legitimately yield zero packages (empty workspace),
+		// matching legacy behaviour.
+		return nil, fmt.Errorf("no supported sources at %v", paths)
+	}
+	return all, nil
+}
+
+func filterMatchingPaths(paths []string, match func(string) bool) []string {
+	out := make([]string, 0, len(paths))
+	for _, p := range paths {
+		if match(p) {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// matchSubtreeHasExt returns a path matcher that walks the path's
+// subtree and reports whether any file has the given suffix. Used as
+// the default matcher for language readers registered via
+// WithJavaReader / WithLanguageReader.
+//
+// "./..." style Go patterns are stripped before walking — the heuristic
+// reduces them to the leading directory.
+func matchSubtreeHasExt(ext string) func(string) bool {
+	return func(path string) bool {
+		root := stripGoPattern(path)
+		info, err := os.Stat(root)
+		if err != nil {
+			return false
+		}
+		if !info.IsDir() {
+			return strings.HasSuffix(root, ext)
+		}
+		var found bool
+		_ = filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return nil // skip unreadable subtrees rather than failing detection
+			}
+			if d.IsDir() {
+				if strings.HasPrefix(d.Name(), ".") || d.Name() == "node_modules" || d.Name() == "target" {
+					return fs.SkipDir
+				}
+				return nil
+			}
+			if strings.HasSuffix(d.Name(), ext) {
+				found = true
+				return fs.SkipAll
+			}
+			return nil
+		})
+		return found
+	}
+}
+
+// stripGoPattern reduces a `./...` style path to its directory root so
+// os.Stat / filepath.WalkDir can operate on it. "./internal/..." → "./internal".
+func stripGoPattern(path string) string {
+	if strings.HasSuffix(path, "/...") {
+		return strings.TrimSuffix(path, "/...")
+	}
+	if path == "..." {
+		return "."
+	}
+	return path
+}

--- a/internal/service/dispatch_test.go
+++ b/internal/service/dispatch_test.go
@@ -1,0 +1,153 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/kgatilin/archai/internal/domain"
+)
+
+// fakeReader is a minimal stub ModelReader that records what paths it
+// was asked to read and returns canned packages.
+type fakeReader struct {
+	name      string
+	calls     [][]string
+	pkgs      []domain.PackageModel
+	returnErr error
+}
+
+func (f *fakeReader) Read(_ context.Context, paths []string) ([]domain.PackageModel, error) {
+	f.calls = append(f.calls, append([]string(nil), paths...))
+	if f.returnErr != nil {
+		return nil, f.returnErr
+	}
+	return f.pkgs, nil
+}
+
+func newPkg(path string) domain.PackageModel {
+	return domain.PackageModel{Path: path, Name: path}
+}
+
+func TestReadPackages_GoOnly(t *testing.T) {
+	goR := &fakeReader{name: "go", pkgs: []domain.PackageModel{newPkg("a")}}
+	svc := NewService(goR, nil, nil)
+
+	got, err := svc.readPackages(context.Background(), []string{"./..."})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(got) != 1 || got[0].Path != "a" {
+		t.Errorf("got %+v", got)
+	}
+	if len(goR.calls) != 1 {
+		t.Errorf("go reader call count: %d", len(goR.calls))
+	}
+}
+
+func TestReadPackages_JavaOnly_GoSkipsWhenMatcher(t *testing.T) {
+	goR := &fakeReader{name: "go", pkgs: []domain.PackageModel{newPkg("go-pkg")}}
+	javaR := &fakeReader{name: "java", pkgs: []domain.PackageModel{newPkg("com.example")}}
+
+	tmp := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmp, "Hello.java"), []byte("class Hello {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	svc := NewService(goR, nil, nil,
+		// Override the Go matcher so Java-only inputs skip it: this
+		// mirrors the CLI wiring that lands in #103.
+		WithLanguageReader("java", javaR, matchSubtreeHasExt(".java")),
+	)
+	// Replace the default unconditional Go entry with a Go-file matcher
+	// so the test exercises pure-Java input.
+	for i := range svc.langReaders {
+		if svc.langReaders[i].name == "go" {
+			svc.langReaders[i].match = matchSubtreeHasExt(".go")
+		}
+	}
+
+	got, err := svc.readPackages(context.Background(), []string{tmp})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(got) != 1 || got[0].Path != "com.example" {
+		t.Errorf("got %+v", got)
+	}
+	if len(goR.calls) != 0 {
+		t.Errorf("go reader should be skipped on pure-Java input, got calls=%v", goR.calls)
+	}
+	if len(javaR.calls) != 1 {
+		t.Errorf("java reader should run once, got %d", len(javaR.calls))
+	}
+}
+
+func TestReadPackages_Polyglot(t *testing.T) {
+	goR := &fakeReader{name: "go", pkgs: []domain.PackageModel{newPkg("go-pkg")}}
+	javaR := &fakeReader{name: "java", pkgs: []domain.PackageModel{newPkg("com.example")}}
+
+	tmp := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmp, "Hello.java"), []byte("class Hello {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	svc := NewService(goR, nil, nil, WithJavaReader(javaR))
+
+	got, err := svc.readPackages(context.Background(), []string{tmp})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	paths := []string{}
+	for _, p := range got {
+		paths = append(paths, p.Path)
+	}
+	sort.Strings(paths)
+	if len(paths) != 2 || paths[0] != "com.example" || paths[1] != "go-pkg" {
+		t.Errorf("polyglot dispatch should yield both packages, got %v", paths)
+	}
+}
+
+func TestReadPackages_PropagatesReaderError(t *testing.T) {
+	javaR := &fakeReader{name: "java", returnErr: errors.New("boom")}
+	tmp := t.TempDir()
+	_ = os.WriteFile(filepath.Join(tmp, "Hello.java"), []byte("class Hello {}\n"), 0o644)
+
+	goR := &fakeReader{name: "go"}
+	svc := NewService(goR, nil, nil, WithJavaReader(javaR))
+
+	_, err := svc.readPackages(context.Background(), []string{tmp})
+	if err == nil || !strings.Contains(err.Error(), "java reader") {
+		t.Errorf("want wrapped java reader error, got %v", err)
+	}
+}
+
+func TestMatchSubtreeHasExt_DetectsJava(t *testing.T) {
+	tmp := t.TempDir()
+	nested := filepath.Join(tmp, "src", "main", "java", "com", "example")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(nested, "X.java"), []byte("class X {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !matchSubtreeHasExt(".java")(tmp) {
+		t.Errorf("should detect .java file in nested subtree")
+	}
+	if matchSubtreeHasExt(".java")(t.TempDir()) {
+		t.Errorf("empty tree should not match")
+	}
+}
+
+func TestMatchSubtreeHasExt_HonoursGoPattern(t *testing.T) {
+	tmp := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmp, "X.java"), []byte("class X {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !matchSubtreeHasExt(".java")(tmp + "/...") {
+		t.Errorf("`./...` patterns should be stripped before walking")
+	}
+}

--- a/internal/service/factory.go
+++ b/internal/service/factory.go
@@ -11,16 +11,51 @@ func WithYAML(reader ModelReader, writer ModelWriter) Option {
 	}
 }
 
+// WithJavaReader registers a Java reader. It is invoked only on input
+// paths whose subtree contains *.java files, so users with pure-Go
+// projects pay no cost when the option is wired in unconditionally.
+func WithJavaReader(reader ModelReader) Option {
+	return func(s *Service) {
+		s.langReaders = append(s.langReaders, languageReader{
+			name:   "java",
+			reader: reader,
+			match:  matchSubtreeHasExt(".java"),
+		})
+	}
+}
+
+// WithLanguageReader is the generic form of WithJavaReader. It registers
+// a reader scoped to paths for which match returns true. Pass nil for
+// match to run the reader unconditionally.
+//
+// Order is preserved: readers added earlier run earlier; the Go reader
+// passed to NewService always runs first.
+func WithLanguageReader(name string, reader ModelReader, match func(path string) bool) Option {
+	return func(s *Service) {
+		s.langReaders = append(s.langReaders, languageReader{
+			name: name, reader: reader, match: match,
+		})
+	}
+}
+
 // NewService creates a new diagram service with the given adapters.
 // Parameters:
-//   - goReader: reads package models from Go source code
+//   - goReader: reads package models from Go source code (always runs first;
+//     wrapped as the leading entry in the language-reader chain)
 //   - d2Reader: reads package models from D2 diagram files (for split operation)
 //   - d2Writer: writes package models as D2 diagram files
+//
+// Additional language readers (e.g. Java via WithJavaReader) are layered
+// on top through opts; they only run on paths whose subtree contains
+// the language's source files.
 func NewService(goReader, d2Reader ModelReader, d2Writer ModelWriter, opts ...Option) *Service {
 	s := &Service{
 		goReader: goReader,
 		d2Reader: d2Reader,
 		d2Writer: d2Writer,
+		langReaders: []languageReader{
+			{name: "go", reader: goReader, match: nil},
+		},
 	}
 	for _, opt := range opts {
 		opt(s)

--- a/internal/service/generate.go
+++ b/internal/service/generate.go
@@ -94,8 +94,9 @@ func (s *Service) generateInternal(ctx context.Context, opts GenerateOptions) ([
 		}
 	}
 
-	// Read all packages from Go source code
-	packages, err := s.goReader.Read(ctx, opts.Paths)
+	// Read all packages from configured language readers (Go always; Java
+	// and friends only when their match predicate accepts a path).
+	packages, err := s.readPackages(ctx, opts.Paths)
 	if err != nil {
 		return nil, nil, fmt.Errorf("reading packages: %w", err)
 	}

--- a/internal/service/generate_combined.go
+++ b/internal/service/generate_combined.go
@@ -51,8 +51,9 @@ func (s *Service) GenerateCombined(ctx context.Context, opts GenerateCombinedOpt
 		}
 	}
 
-	// Read all packages from Go source code
-	packages, err := s.goReader.Read(ctx, opts.Paths)
+	// Read all packages from configured language readers (Go always; Java
+	// and friends only when their match predicate accepts a path).
+	packages, err := s.readPackages(ctx, opts.Paths)
 	if err != nil {
 		return nil, fmt.Errorf("reading packages: %w", err)
 	}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -5,7 +5,16 @@ package service
 // and write to various destinations (D2 files, YAML files, stdout).
 type Service struct {
 	// goReader reads package models from Go source code.
+	// Retained for the rare callsite that needs direct access (e.g. the
+	// combined full-mode path in cmd/archai). Prefer s.readPackages for
+	// new code so the multi-language dispatch path is exercised.
 	goReader ModelReader
+
+	// langReaders is the ordered list of language readers consulted by
+	// readPackages. The Go reader is always entry [0]; additional
+	// readers (Java today, more in future) are appended via With*Reader
+	// options at construction time.
+	langReaders []languageReader
 
 	// d2Reader reads package models from D2 diagram files.
 	d2Reader ModelReader

--- a/tests/integration/fixtures/java/README.md
+++ b/tests/integration/fixtures/java/README.md
@@ -1,0 +1,16 @@
+# Java e2e fixture
+
+Three-package Java mini-project used by the gated end-to-end test in
+`java_e2e_test.go`. Kept tiny on purpose so the test stays fast and
+self-contained:
+
+| Package | Class | Role |
+|---|---|---|
+| `com.example.app` | `App` | Wires the other two together |
+| `com.example.service` | `Greeter` | Pure formatter |
+| `com.example.repo` | `Storage` | In-memory key-value map |
+
+The test runs the analyzer JAR over `src/`, asks the CLI to emit per-package
+`.arch/pub.d2` + `pub.yaml`, and round-trips the YAML back through
+`adapter/yaml`. It is gated behind both the `e2e` build tag and the
+`RUN_E2E=1` env var so default `go test ./...` doesn't require a JVM.

--- a/tests/integration/fixtures/java/src/com/example/app/App.java
+++ b/tests/integration/fixtures/java/src/com/example/app/App.java
@@ -1,0 +1,20 @@
+package com.example.app;
+
+import com.example.service.Greeter;
+import com.example.repo.Storage;
+
+public class App {
+    private final Greeter greeter;
+    private final Storage storage;
+
+    public App(Greeter greeter, Storage storage) {
+        this.greeter = greeter;
+        this.storage = storage;
+    }
+
+    public String run(String name) {
+        String greeting = greeter.greet(name);
+        storage.save(name, greeting);
+        return greeting;
+    }
+}

--- a/tests/integration/fixtures/java/src/com/example/repo/Storage.java
+++ b/tests/integration/fixtures/java/src/com/example/repo/Storage.java
@@ -1,0 +1,16 @@
+package com.example.repo;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class Storage {
+    private final Map<String, String> store = new HashMap<>();
+
+    public void save(String key, String value) {
+        store.put(key, value);
+    }
+
+    public String load(String key) {
+        return store.get(key);
+    }
+}

--- a/tests/integration/fixtures/java/src/com/example/service/Greeter.java
+++ b/tests/integration/fixtures/java/src/com/example/service/Greeter.java
@@ -1,0 +1,13 @@
+package com.example.service;
+
+public class Greeter {
+    private final String prefix;
+
+    public Greeter(String prefix) {
+        this.prefix = prefix;
+    }
+
+    public String greet(String name) {
+        return prefix + ", " + name + "!";
+    }
+}

--- a/tests/integration/java_e2e_test.go
+++ b/tests/integration/java_e2e_test.go
@@ -1,0 +1,128 @@
+//go:build e2e
+
+package integration
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/kgatilin/archai/internal/adapter/d2"
+	"github.com/kgatilin/archai/internal/adapter/golang"
+	javaAdapter "github.com/kgatilin/archai/internal/adapter/java"
+	yamlAdapter "github.com/kgatilin/archai/internal/adapter/yaml"
+	"github.com/kgatilin/archai/internal/domain"
+	"github.com/kgatilin/archai/internal/service"
+)
+
+// TestJavaEndToEnd runs the analyzer JAR over the in-tree 3-package
+// fixture and asserts the generate pipeline produces models for all
+// three packages, then round-trips each through adapter/yaml.
+//
+// Gated behind both the e2e build tag and RUN_E2E=1 so the default `go
+// test ./...` run on machines without a JVM stays unaffected. To run:
+//
+//	RUN_E2E=1 go test -tags e2e -run TestJavaEndToEnd ./tests/integration/...
+func TestJavaEndToEnd(t *testing.T) {
+	if os.Getenv("RUN_E2E") != "1" {
+		t.Skip("set RUN_E2E=1 to enable the Java end-to-end smoke test")
+	}
+	if _, err := exec.LookPath("java"); err != nil {
+		t.Skip("`java` not on PATH; install JRE 21+ to run this test")
+	}
+
+	repoRoot := repoRootDir(t)
+	jar := ensureAnalyzerJar(t, repoRoot)
+
+	fixtureSrc := filepath.Join(repoRoot, "tests", "integration", "fixtures", "java", "src")
+	output := t.TempDir()
+	t.Logf("running analyzer over %s; output → %s", fixtureSrc, output)
+
+	// Wiring matches what runGenerate in cmd/archai sets up for
+	// --format=d2; we exercise the service directly so the test stays
+	// hermetic (no need to `make build` first).
+	svc := service.NewService(
+		golang.NewReader(),
+		d2.NewReader(),
+		d2.NewWriter(),
+		service.WithYAML(yamlAdapter.NewReader(), yamlAdapter.NewWriter()),
+		service.WithJavaReader(javaAdapter.NewReader(jar)),
+	)
+
+	models, err := svc.ReadModels(context.Background(), []string{fixtureSrc})
+	if err != nil {
+		t.Fatalf("ReadModels: %v", err)
+	}
+	if len(models) < 3 {
+		t.Fatalf("want ≥3 packages from 3-package fixture, got %d (%v)", len(models), packagePaths(models))
+	}
+
+	// Round-trip every model through adapter/yaml. Catches schema drift
+	// between the in-memory model produced by the translator and what
+	// the YAML reader expects on disk.
+	yw := yamlAdapter.NewWriter()
+	yr := yamlAdapter.NewReader()
+	for _, m := range models {
+		dir := filepath.Join(output, m.Path, ".arch")
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		yamlPath := filepath.Join(dir, "pub.yaml")
+		if err := yw.Write(context.Background(), m, domain.WriteOptions{
+			OutputPath: yamlPath,
+			PublicOnly: true,
+		}); err != nil {
+			t.Fatalf("yaml write %s: %v", m.Path, err)
+		}
+		got, err := yr.Read(context.Background(), []string{yamlPath})
+		if err != nil {
+			t.Fatalf("yaml read-back %s: %v", m.Path, err)
+		}
+		if len(got) == 0 {
+			t.Fatalf("yaml round-trip yielded zero packages for %s", m.Path)
+		}
+	}
+}
+
+func ensureAnalyzerJar(t *testing.T, repoRoot string) string {
+	t.Helper()
+	jar := filepath.Join(repoRoot, "tools", "archai-java-analyzer", "target", "archai-java-analyzer.jar")
+	if _, err := os.Stat(jar); err == nil {
+		return jar
+	}
+	if _, err := exec.LookPath("mvn"); err != nil {
+		t.Skip("analyzer JAR missing and `mvn` not on PATH; run `make java-analyzer` to bootstrap")
+	}
+	cmd := exec.Command("make", "java-analyzer-build")
+	cmd.Dir = repoRoot
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("`make java-analyzer-build` failed: %v\n%s", err, out)
+	}
+	if _, err := os.Stat(jar); err != nil {
+		t.Fatalf("expected JAR at %s after build, got %v", jar, err)
+	}
+	return jar
+}
+
+func repoRootDir(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	// thisFile = .../tests/integration/java_e2e_test.go → repo root is
+	// two levels up.
+	return filepath.Dir(filepath.Dir(filepath.Dir(thisFile)))
+}
+
+func packagePaths(ms []domain.PackageModel) []string {
+	out := make([]string, 0, len(ms))
+	for _, m := range ms {
+		out = append(out, m.Path)
+	}
+	return out
+}


### PR DESCRIPTION
Closes #103. **Stacks on #106** (#102) — please merge that one first.

The diff in this PR includes #106's commits as a base. Once #106 lands, this branch reduces to the +696 / -7 of #103-only changes.

## Summary
- Service grows a multi-language reader dispatcher. \`WithJavaReader\` / \`WithLanguageReader\` register readers that only run on paths whose subtree matches their language; the Go reader passed to \`NewService\` is unchanged for legacy callers.
- \`archai diagram generate ./mysrc --java-jar <path>\` now reads Java. Auto-detect chain: \`--java-jar\` flag → \`ARCHAI_JAVA_JAR\` → sibling-of-binary → silently skip. Pure-Go users pay no cost.
- E2E test on an in-tree 3-package Java fixture, gated behind \`e2e\` build tag and \`RUN_E2E=1\` env so default \`go test ./...\` stays JVM-free.

## What you can do after this lands
\`\`\`bash
make java-analyzer                                  # one-time, builds JAR
archai diagram generate ./mysrc \\
  --java-jar tools/archai-java-analyzer/target/archai-java-analyzer.jar
\`\`\`
or set \`ARCHAI_JAVA_JAR\` once and drop the flag. \`make build-all\` puts the JAR next to \`bin/archai\` and the CLI auto-discovers it.

## Service-layer change
- New file \`internal/service/dispatch.go\`: \`languageReader\`, \`readPackages\`, \`ReadModels\`, \`matchSubtreeHasExt\`.
- \`NewService\` bootstraps a single \`languageReader{name: \"go\", reader: goReader, match: nil}\` so behaviour is identical for existing callers. Additional readers are appended via Option.
- \`generate.go\` and \`generate_combined.go\` now go through \`s.readPackages\` instead of \`s.goReader.Read\` directly. The combined-full path in \`cmd/archai\` goes through the new \`svc.ReadModels\`.

Tests cover go-only, java-only (with Go matcher swapped), polyglot, error propagation, subtree detection, and \`./...\`-pattern stripping.

## What's intentionally **not** here (vs. #103 spec)
- \`--lang go,java\` override flag — auto-detect covers the cases I had time to ship; explicit override can land as a follow-up if anyone hits a directory the heuristic fools.
- \`archai version\` reading the JAR's manifest — version reporting stays Go-only for now.
- CLAUDE.md updates — left for the next ecosystem-docs sweep so I don't churn the file Konstantin maintains.

These are explicit follow-ups, not silent gaps.

## Test plan
- [x] \`go test ./...\` (full repo, no regressions)
- [x] \`go vet ./...\` clean
- [x] \`go build -tags e2e ./tests/integration/...\` clean
- [ ] \`RUN_E2E=1 make java-analyzer && go test -tags e2e -run TestJavaEndToEnd ./tests/integration/...\` — needs JVM + Maven; please re-run in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)