### PR TITLE
feat(#97): graph-backed architecture model as a projection-source read model

### DIFF
--- a/internal/domain/archgraph/build.go
+++ b/internal/domain/archgraph/build.go
@@ -1,0 +1,750 @@
+package archgraph
+
+import (
+	"sort"
+
+	"github.com/kgatilin/archai/internal/domain"
+)
+
+// BuildGraph constructs an architecture graph from a slice of
+// domain.PackageModel and an optional domain.Module. The module
+// argument may be nil; when non-nil, a single module node is added
+// and every package node is connected to it with a contains edge.
+//
+// BuildGraph is a pure function: same input → byte-identical Graph.
+// It does no I/O and never mutates its inputs.
+func BuildGraph(models []domain.PackageModel, mod *domain.Module) (*Graph, error) {
+	b := newBuilder()
+
+	if mod != nil {
+		b.addModule(mod.Path)
+	}
+
+	// Snapshot package paths in sorted order so the outer loop is
+	// deterministic regardless of caller ordering.
+	pkgByPath := make(map[string]*domain.PackageModel, len(models))
+	paths := make([]string, 0, len(models))
+	for i := range models {
+		p := &models[i]
+		pkgByPath[p.Path] = p
+		paths = append(paths, p.Path)
+	}
+	sort.Strings(paths)
+
+	// Pass 1: package nodes, file nodes, symbol nodes, containment.
+	for _, path := range paths {
+		b.addPackageWithContents(pkgByPath[path])
+	}
+
+	// Pass 2: implements relationships (interface-side declarations).
+	for _, path := range paths {
+		b.addImplementations(pkgByPath[path])
+	}
+
+	// Pass 3: symbol-level dependency edges (uses/returns/extends/...).
+	for _, path := range paths {
+		b.addDependencies(pkgByPath[path])
+	}
+
+	// Pass 4: call edges from function / method bodies.
+	for _, path := range paths {
+		b.addCallEdges(pkgByPath[path])
+	}
+
+	return b.finalize(), nil
+}
+
+// builder accumulates nodes/edges with dedup so callers can emit
+// the same id more than once safely (first write wins for payload).
+//
+// implPayloads / depPayloads / callPayloads are side tables keyed by
+// edge id. They retain the original domain values so projection can
+// reconstruct the input Dependencies / Implementations / Calls slices
+// without re-deriving fields from edge Attrs. They are not exposed
+// outside the package.
+type builder struct {
+	moduleID     string
+	nodes        map[string]Node
+	edges        map[string]Edge
+	implPayloads map[string]domain.Implementation
+	depPayloads  map[string]domain.Dependency
+	callPayloads map[string]callPayload
+}
+
+func newBuilder() *builder {
+	return &builder{
+		nodes:        make(map[string]Node),
+		edges:        make(map[string]Edge),
+		implPayloads: make(map[string]domain.Implementation),
+		depPayloads:  make(map[string]domain.Dependency),
+		callPayloads: make(map[string]callPayload),
+	}
+}
+
+func (b *builder) addNode(n Node) {
+	if _, ok := b.nodes[n.ID]; ok {
+		return
+	}
+	b.nodes[n.ID] = n
+}
+
+func (b *builder) addEdge(e Edge) {
+	if _, ok := b.edges[e.ID]; ok {
+		return
+	}
+	b.edges[e.ID] = e
+}
+
+func (b *builder) addModule(path string) {
+	id := ModuleID(path)
+	b.moduleID = id
+	b.addNode(Node{
+		ID:   id,
+		Kind: NodeKindModule,
+		Name: path,
+		Attrs: map[string]string{
+			"path": path,
+		},
+	})
+}
+
+func (b *builder) addPackageWithContents(p *domain.PackageModel) {
+	pkgID := PackageID(p.Path)
+	attrs := map[string]string{
+		"path": p.Path,
+		"name": p.Name,
+	}
+	if p.Layer != "" {
+		attrs["layer"] = p.Layer
+	}
+	if p.Aggregate != "" {
+		attrs["aggregate"] = p.Aggregate
+	}
+	b.addNode(Node{
+		ID:      pkgID,
+		Kind:    NodeKindPackage,
+		Name:    p.Name,
+		Package: p.Path,
+		Attrs:   attrs,
+	})
+
+	if b.moduleID != "" {
+		b.addEdge(Edge{
+			ID:   edgeID(EdgeKindContains, b.moduleID, pkgID),
+			Kind: EdgeKindContains,
+			From: b.moduleID,
+			To:   pkgID,
+		})
+	}
+
+	// Overlay annotation edges. Edges (not node attrs) per the
+	// ticket vocabulary; node attrs are kept too for quick lookup.
+	if p.Layer != "" {
+		// We don't materialize layer nodes; the layer is a string
+		// label. The edge target is a synthetic id so consumers
+		// that want a node-based view can add it later without
+		// changing this code.
+		layerID := "layer:" + p.Layer
+		b.addNode(Node{
+			ID:   layerID,
+			Kind: NodeKindExternal,
+			Name: p.Layer,
+			Attrs: map[string]string{
+				"kind": "layer",
+				"name": p.Layer,
+			},
+		})
+		b.addEdge(Edge{
+			ID:   edgeID(EdgeKindBelongsToLayer, pkgID, layerID),
+			Kind: EdgeKindBelongsToLayer,
+			From: pkgID,
+			To:   layerID,
+		})
+	}
+	if p.Aggregate != "" {
+		aggID := "domain:" + p.Aggregate
+		b.addNode(Node{
+			ID:   aggID,
+			Kind: NodeKindExternal,
+			Name: p.Aggregate,
+			Attrs: map[string]string{
+				"kind": "aggregate",
+				"name": p.Aggregate,
+			},
+		})
+		b.addEdge(Edge{
+			ID:   edgeID(EdgeKindBelongsToDomain, pkgID, aggID),
+			Kind: EdgeKindBelongsToDomain,
+			From: pkgID,
+			To:   aggID,
+		})
+	}
+
+	// File nodes — one per distinct source file. They get a
+	// contains edge from the package and a contains edge to each
+	// symbol declared in that file.
+	for _, file := range p.SourceFiles() {
+		fid := FileID(p.Path, file)
+		b.addNode(Node{
+			ID:      fid,
+			Kind:    NodeKindFile,
+			Name:    file,
+			Package: p.Path,
+			File:    file,
+			Attrs: map[string]string{
+				"path": p.Path,
+				"file": file,
+			},
+		})
+		b.addEdge(Edge{
+			ID:   edgeID(EdgeKindContains, pkgID, fid),
+			Kind: EdgeKindContains,
+			From: pkgID,
+			To:   fid,
+		})
+	}
+
+	// Interfaces. The payload stripped of method-level Calls so the
+	// dedicated call-edge pass owns the calls-roundtrip; otherwise
+	// projection would emit each call twice (once from payload,
+	// once from edge).
+	for _, iface := range p.Interfaces {
+		tid := TypeID(p.Path, iface.Name)
+		b.addNode(Node{
+			ID:      tid,
+			Kind:    NodeKindInterface,
+			Name:    iface.Name,
+			Package: p.Path,
+			File:    iface.SourceFile,
+			Attrs:   typeAttrs(iface.IsExported, iface.Stereotype, iface.SourceFile, iface.Doc),
+			Payload: stripInterfaceCalls(iface),
+		})
+		b.addContainsFromFileAndPackage(p.Path, iface.SourceFile, tid)
+		b.addRoleEdge(tid, iface.Stereotype)
+		for _, m := range iface.Methods {
+			mid := MethodID(p.Path, iface.Name, m.Name)
+			b.addNode(Node{
+				ID:      mid,
+				Kind:    NodeKindMethod,
+				Name:    m.Name,
+				Package: p.Path,
+				File:    iface.SourceFile,
+				Attrs: map[string]string{
+					"receiver": iface.Name,
+					"exported": boolStr(m.IsExported),
+				},
+				Payload: m,
+			})
+			b.addEdge(Edge{
+				ID:   edgeID(EdgeKindContains, tid, mid),
+				Kind: EdgeKindContains,
+				From: tid,
+				To:   mid,
+			})
+		}
+	}
+
+	// Structs. Method-level Calls are stripped from the payload —
+	// see Interfaces comment.
+	for _, s := range p.Structs {
+		tid := TypeID(p.Path, s.Name)
+		b.addNode(Node{
+			ID:      tid,
+			Kind:    NodeKindStruct,
+			Name:    s.Name,
+			Package: p.Path,
+			File:    s.SourceFile,
+			Attrs:   typeAttrs(s.IsExported, s.Stereotype, s.SourceFile, s.Doc),
+			Payload: stripStructCalls(s),
+		})
+		b.addContainsFromFileAndPackage(p.Path, s.SourceFile, tid)
+		b.addRoleEdge(tid, s.Stereotype)
+		for _, f := range s.Fields {
+			fid := FieldID(p.Path, s.Name, f.Name)
+			b.addNode(Node{
+				ID:      fid,
+				Kind:    NodeKindField,
+				Name:    f.Name,
+				Package: p.Path,
+				File:    s.SourceFile,
+				Attrs: map[string]string{
+					"struct":   s.Name,
+					"type":     f.Type.String(),
+					"exported": boolStr(f.IsExported),
+					"tag":      f.Tag,
+				},
+				Payload: f,
+			})
+			b.addEdge(Edge{
+				ID:   edgeID(EdgeKindContains, tid, fid),
+				Kind: EdgeKindContains,
+				From: tid,
+				To:   fid,
+			})
+		}
+		for _, m := range s.Methods {
+			mid := MethodID(p.Path, s.Name, m.Name)
+			b.addNode(Node{
+				ID:      mid,
+				Kind:    NodeKindMethod,
+				Name:    m.Name,
+				Package: p.Path,
+				File:    s.SourceFile,
+				Attrs: map[string]string{
+					"receiver": s.Name,
+					"exported": boolStr(m.IsExported),
+				},
+				Payload: m,
+			})
+			b.addEdge(Edge{
+				ID:   edgeID(EdgeKindContains, tid, mid),
+				Kind: EdgeKindContains,
+				From: tid,
+				To:   mid,
+			})
+		}
+	}
+
+	// TypeDefs (treated as type nodes with kind=typedef).
+	for _, td := range p.TypeDefs {
+		tid := TypeID(p.Path, td.Name)
+		b.addNode(Node{
+			ID:      tid,
+			Kind:    NodeKindTypeDef,
+			Name:    td.Name,
+			Package: p.Path,
+			File:    td.SourceFile,
+			Attrs: map[string]string{
+				"underlying": td.UnderlyingType.String(),
+				"exported":   boolStr(td.IsExported),
+				"stereotype": td.Stereotype.String(),
+				"source":     td.SourceFile,
+			},
+			Payload: td,
+		})
+		b.addContainsFromFileAndPackage(p.Path, td.SourceFile, tid)
+		b.addRoleEdge(tid, td.Stereotype)
+	}
+
+	// Package-level functions.
+	for _, fn := range p.Functions {
+		fid := FunctionID(p.Path, fn.Name)
+		b.addNode(Node{
+			ID:      fid,
+			Kind:    NodeKindFunction,
+			Name:    fn.Name,
+			Package: p.Path,
+			File:    fn.SourceFile,
+			Attrs: map[string]string{
+				"exported":   boolStr(fn.IsExported),
+				"stereotype": fn.Stereotype.String(),
+				"source":     fn.SourceFile,
+			},
+			Payload: stripFunctionCalls(fn),
+		})
+		b.addContainsFromFileAndPackage(p.Path, fn.SourceFile, fid)
+		b.addRoleEdge(fid, fn.Stereotype)
+	}
+
+	// Constants.
+	for _, c := range p.Constants {
+		cid := ConstID(p.Path, c.Name)
+		b.addNode(Node{
+			ID:      cid,
+			Kind:    NodeKindConst,
+			Name:    c.Name,
+			Package: p.Path,
+			File:    c.SourceFile,
+			Attrs: map[string]string{
+				"type":     c.Type.String(),
+				"value":    c.Value,
+				"exported": boolStr(c.IsExported),
+			},
+			Payload: c,
+		})
+		b.addContainsFromFileAndPackage(p.Path, c.SourceFile, cid)
+	}
+
+	// Variables.
+	for _, v := range p.Variables {
+		vid := VarID(p.Path, v.Name)
+		b.addNode(Node{
+			ID:      vid,
+			Kind:    NodeKindVar,
+			Name:    v.Name,
+			Package: p.Path,
+			File:    v.SourceFile,
+			Attrs: map[string]string{
+				"type":     v.Type.String(),
+				"exported": boolStr(v.IsExported),
+			},
+			Payload: v,
+		})
+		b.addContainsFromFileAndPackage(p.Path, v.SourceFile, vid)
+	}
+
+	// Errors.
+	for _, e := range p.Errors {
+		eid := ErrorID(p.Path, e.Name)
+		b.addNode(Node{
+			ID:      eid,
+			Kind:    NodeKindError,
+			Name:    e.Name,
+			Package: p.Path,
+			File:    e.SourceFile,
+			Attrs: map[string]string{
+				"message":  e.Message,
+				"exported": boolStr(e.IsExported),
+			},
+			Payload: e,
+		})
+		b.addContainsFromFileAndPackage(p.Path, e.SourceFile, eid)
+	}
+}
+
+// addContainsFromFileAndPackage emits package→symbol and (if a
+// source file is known) file→symbol contains edges.
+func (b *builder) addContainsFromFileAndPackage(pkgPath, file, symbolID string) {
+	pkgID := PackageID(pkgPath)
+	b.addEdge(Edge{
+		ID:   edgeID(EdgeKindContains, pkgID, symbolID),
+		Kind: EdgeKindContains,
+		From: pkgID,
+		To:   symbolID,
+	})
+	if file == "" {
+		return
+	}
+	fid := FileID(pkgPath, file)
+	b.addEdge(Edge{
+		ID:   edgeID(EdgeKindContains, fid, symbolID),
+		Kind: EdgeKindContains,
+		From: fid,
+		To:   symbolID,
+	})
+}
+
+// addRoleEdge attaches a has_role annotation edge to a synthetic role
+// node when the stereotype is non-empty.
+func (b *builder) addRoleEdge(symbolID string, s domain.Stereotype) {
+	if s.IsEmpty() {
+		return
+	}
+	roleID := "role:" + s.String()
+	b.addNode(Node{
+		ID:   roleID,
+		Kind: NodeKindExternal,
+		Name: s.String(),
+		Attrs: map[string]string{
+			"kind": "role",
+			"name": s.String(),
+		},
+	})
+	b.addEdge(Edge{
+		ID:   edgeID(EdgeKindHasRole, symbolID, roleID),
+		Kind: EdgeKindHasRole,
+		From: symbolID,
+		To:   roleID,
+	})
+}
+
+// addImplementations emits implements edges declared on this
+// package's Implementations slice. Both endpoints become nodes:
+// the interface (already added by addPackageWithContents above)
+// and the concrete (added here as an external if not loaded).
+func (b *builder) addImplementations(p *domain.PackageModel) {
+	for _, impl := range p.Implementations {
+		ifaceID := symbolRefToNodeID(impl.Interface, NodeKindInterface)
+		concID := symbolRefToNodeID(impl.Concrete, NodeKindStruct)
+		// Ensure concrete node exists even when it lives in a
+		// package we did not load (or when the concrete is in a
+		// different package and Pass 1 hasn't reached it — both
+		// orderings are fine because of dedup).
+		if _, ok := b.nodes[concID]; !ok {
+			b.addNode(Node{
+				ID:      concID,
+				Kind:    classifyExternal(impl.Concrete),
+				Name:    impl.Concrete.Symbol,
+				Package: impl.Concrete.Package,
+				Attrs: map[string]string{
+					"external": boolStr(impl.Concrete.External),
+				},
+			})
+		}
+		if _, ok := b.nodes[ifaceID]; !ok {
+			b.addNode(Node{
+				ID:      ifaceID,
+				Kind:    classifyExternal(impl.Interface),
+				Name:    impl.Interface.Symbol,
+				Package: impl.Interface.Package,
+				Attrs: map[string]string{
+					"external": boolStr(impl.Interface.External),
+				},
+			})
+		}
+		e := Edge{
+			ID:   edgeID(EdgeKindImplements, concID, ifaceID),
+			Kind: EdgeKindImplements,
+			From: concID,
+			To:   ifaceID,
+			Attrs: map[string]string{
+				"is_pointer":     boolStr(impl.IsPointer),
+				"iface_package":  impl.Interface.Package,
+				"iface_file":     impl.Interface.File,
+				"iface_external": boolStr(impl.Interface.External),
+				"conc_package":   impl.Concrete.Package,
+				"conc_file":      impl.Concrete.File,
+				"conc_external":  boolStr(impl.Concrete.External),
+			},
+		}
+		// Stash the original on the edge so projection is exact.
+		b.edges[e.ID] = e
+		b.implPayloads[e.ID] = impl
+	}
+}
+
+// addDependencies emits one edge per Dependency. The kind maps 1:1
+// to EdgeKind. Implements dependencies are also recorded so projection
+// can rebuild the full Dependencies slice; the structural Implements
+// pass above is the canonical implementation-relationship source for
+// graph consumers, but PackageModel.Dependencies may also carry the
+// edge separately and we round-trip both.
+func (b *builder) addDependencies(p *domain.PackageModel) {
+	for _, d := range p.Dependencies {
+		kind := dependencyKindToEdgeKind(d.Kind)
+		fromID := symbolRefToNodeID(d.From, "")
+		toID := symbolRefToNodeID(d.To, "")
+		// Ensure endpoint nodes exist (external dependencies often
+		// don't have nodes from the contents pass).
+		if _, ok := b.nodes[fromID]; !ok {
+			b.addNode(Node{
+				ID:      fromID,
+				Kind:    classifyExternal(d.From),
+				Name:    d.From.Symbol,
+				Package: d.From.Package,
+				File:    d.From.File,
+				Attrs: map[string]string{
+					"external": boolStr(d.From.External),
+				},
+			})
+		}
+		if _, ok := b.nodes[toID]; !ok {
+			b.addNode(Node{
+				ID:      toID,
+				Kind:    classifyExternal(d.To),
+				Name:    d.To.Symbol,
+				Package: d.To.Package,
+				File:    d.To.File,
+				Attrs: map[string]string{
+					"external": boolStr(d.To.External),
+				},
+			})
+		}
+		e := Edge{
+			ID:   edgeID(kind, fromID, toID),
+			Kind: kind,
+			From: fromID,
+			To:   toID,
+			Attrs: map[string]string{
+				"through_exported": boolStr(d.ThroughExported),
+				"from_package":     d.From.Package,
+				"from_file":        d.From.File,
+				"from_external":    boolStr(d.From.External),
+				"to_package":       d.To.Package,
+				"to_file":          d.To.File,
+				"to_external":      boolStr(d.To.External),
+			},
+		}
+		b.edges[e.ID] = e
+		b.depPayloads[e.ID] = d
+	}
+}
+
+// addCallEdges emits one edge per CallEdge on every function/method
+// in the package. The call payload is stashed for exact round-trip
+// because the same (from,to) edge id collapses Via variants, while
+// PackageModel preserves them as separate slice entries.
+func (b *builder) addCallEdges(p *domain.PackageModel) {
+	emit := func(fromID string, calls []domain.CallEdge) {
+		for _, c := range calls {
+			toID := symbolRefToNodeID(c.To, "")
+			if _, ok := b.nodes[toID]; !ok {
+				b.addNode(Node{
+					ID:      toID,
+					Kind:    classifyExternal(c.To),
+					Name:    c.To.Symbol,
+					Package: c.To.Package,
+					File:    c.To.File,
+					Attrs: map[string]string{
+						"external": boolStr(c.To.External),
+					},
+				})
+			}
+			// Edge id includes Via so interface-dispatched fanout
+			// keeps each variant as its own edge.
+			id := edgeID(EdgeKindCalls, fromID, toID)
+			if c.Via != "" {
+				id = id + "|via=" + c.Via
+			}
+			e := Edge{
+				ID:   id,
+				Kind: EdgeKindCalls,
+				From: fromID,
+				To:   toID,
+				Attrs: map[string]string{
+					"via":         c.Via,
+					"to_package":  c.To.Package,
+					"to_file":     c.To.File,
+					"to_external": boolStr(c.To.External),
+				},
+			}
+			b.edges[e.ID] = e
+			b.callPayloads[e.ID] = callPayload{
+				fromID: fromID,
+				edge:   c,
+			}
+		}
+	}
+
+	for _, fn := range p.Functions {
+		emit(FunctionID(p.Path, fn.Name), fn.Calls)
+	}
+	for _, s := range p.Structs {
+		for _, m := range s.Methods {
+			emit(MethodID(p.Path, s.Name, m.Name), m.Calls)
+		}
+	}
+	for _, iface := range p.Interfaces {
+		for _, m := range iface.Methods {
+			emit(MethodID(p.Path, iface.Name, m.Name), m.Calls)
+		}
+	}
+}
+
+// finalize sorts everything by id and returns the graph.
+func (b *builder) finalize() *Graph {
+	nodes := make([]Node, 0, len(b.nodes))
+	for _, n := range b.nodes {
+		nodes = append(nodes, n)
+	}
+	sort.Slice(nodes, func(i, j int) bool { return nodes[i].ID < nodes[j].ID })
+
+	edges := make([]Edge, 0, len(b.edges))
+	for _, e := range b.edges {
+		edges = append(edges, e)
+	}
+	sort.Slice(edges, func(i, j int) bool { return edges[i].ID < edges[j].ID })
+
+	return &Graph{
+		ModuleID:     b.moduleID,
+		Nodes:        nodes,
+		Edges:        edges,
+		implPayloads: b.implPayloads,
+		depPayloads:  b.depPayloads,
+		callPayloads: b.callPayloads,
+	}
+}
+
+// typeAttrs builds the common attribute set for interface/struct
+// nodes.
+func typeAttrs(isExported bool, s domain.Stereotype, source, doc string) map[string]string {
+	return map[string]string{
+		"exported":   boolStr(isExported),
+		"stereotype": s.String(),
+		"source":     source,
+		"doc":        doc,
+	}
+}
+
+func boolStr(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
+}
+
+// dependencyKindToEdgeKind maps domain.DependencyKind onto EdgeKind.
+func dependencyKindToEdgeKind(k domain.DependencyKind) EdgeKind {
+	switch k {
+	case domain.DependencyUses:
+		return EdgeKindUses
+	case domain.DependencyReturns:
+		return EdgeKindReturns
+	case domain.DependencyImplements:
+		return EdgeKindImplements
+	case domain.DependencyExtends:
+		return EdgeKindExtends
+	case domain.DependencyNestedIn:
+		return EdgeKindNestedIn
+	default:
+		return EdgeKindUses
+	}
+}
+
+// classifyExternal returns the node kind for a SymbolRef that does
+// not already have a typed node. External refs become NodeKindExternal;
+// otherwise we conservatively return NodeKindStruct (the most common
+// concrete-type kind). This is only used to backfill placeholder
+// nodes; real classification is done in the contents pass.
+func classifyExternal(r domain.SymbolRef) NodeKind {
+	if r.External {
+		return NodeKindExternal
+	}
+	return NodeKindStruct
+}
+
+// symbolRefToNodeID converts a SymbolRef to the node id used in the
+// graph. For external refs we always use ExternalID; for module
+// internal refs we use TypeID by default but allow callers to hint.
+func symbolRefToNodeID(r domain.SymbolRef, hint NodeKind) string {
+	if r.External {
+		return ExternalID(r.Package, r.Symbol)
+	}
+	// Inside the loaded module, the symbol kind isn't recorded on
+	// SymbolRef so we use the same TypeID prefix as interfaces and
+	// structs. This is fine because all symbols sharing a package
+	// name space already share the type: namespace in our id scheme.
+	_ = hint
+	return TypeID(r.Package, r.Symbol)
+}
+
+// stripInterfaceCalls returns a shallow copy of iface with the
+// per-method Calls slices nil. The call edges are stored separately
+// (see addCallEdges) and re-attached on projection; keeping them on
+// the payload too would double them after round-trip.
+func stripInterfaceCalls(iface domain.InterfaceDef) domain.InterfaceDef {
+	out := iface
+	out.Methods = make([]domain.MethodDef, len(iface.Methods))
+	for i, m := range iface.Methods {
+		m.Calls = nil
+		out.Methods[i] = m
+	}
+	return out
+}
+
+// stripStructCalls returns a shallow copy of s with the per-method
+// Calls slices nil.
+func stripStructCalls(s domain.StructDef) domain.StructDef {
+	out := s
+	out.Methods = make([]domain.MethodDef, len(s.Methods))
+	for i, m := range s.Methods {
+		m.Calls = nil
+		out.Methods[i] = m
+	}
+	return out
+}
+
+// stripFunctionCalls returns a shallow copy of fn with Calls nil.
+func stripFunctionCalls(fn domain.FunctionDef) domain.FunctionDef {
+	out := fn
+	out.Calls = nil
+	return out
+}
+
+// callPayload retains the original CallEdge plus the from-side
+// caller id so projection can place the edge on the right
+// function/method when rebuilding Calls slices.
+type callPayload struct {
+	fromID string
+	edge   domain.CallEdge
+}

--- a/internal/domain/archgraph/doc.go
+++ b/internal/domain/archgraph/doc.go
@@ -1,0 +1,53 @@
+// Package archgraph defines a graph-shaped read model of an
+// archai-analyzed codebase. It is the internal counterpart to the
+// existing package-centric domain.PackageModel: every node and edge
+// is a first-class data point with a stable, human-readable id, so
+// downstream surfaces (browser, diagrams, MCP) can consume the
+// architecture as a graph instead of as a denormalized aggregate.
+//
+// Issue: kgatilin/archai#97. This package is additive and is not
+// wired into any reader, writer, or service path in this change;
+// follow-ups #98 and #99 will migrate callers onto graph projections.
+//
+// # Dependency direction
+//
+// archgraph imports domain. domain does NOT import archgraph. The
+// graph is a derived view; the original PackageModel slice remains
+// authoritative input. Projection back to PackageModel exists to
+// prove the graph carries every field of the input model.
+//
+// # Stable IDs
+//
+// IDs are derived purely from package path + symbol name so the
+// same input always produces byte-identical id sets. The scheme
+// mirrors the one used by internal/adapter/archmotif so a single
+// vocabulary covers both internal projections and the external
+// archmotif export.
+//
+//	module     mod:<module-path>
+//	package    pkg:<package-path>
+//	file       file:<package-path>/<base>
+//	interface  type:<package-path>.<Name>
+//	struct     type:<package-path>.<Name>
+//	typedef    type:<package-path>.<Name>
+//	function   fn:<package-path>.<Name>
+//	method     method:<package-path>.<Recv>.<Name>
+//	field      field:<package-path>.<Struct>.<Field>
+//	const      const:<package-path>.<Name>
+//	var        var:<package-path>.<Name>
+//	error      err:<package-path>.<Name>
+//	external   ext:<package>.<Symbol>
+//
+// Edge ids are derived from kind + endpoint ids:
+//
+//	<kind>:<from>-><to>
+//
+// # Round-trip
+//
+// BuildGraph(models, mod) produces a Graph that, when fed to
+// Graph.ProjectPackages(), reconstructs the input []PackageModel
+// modulo deterministic sort order. The graph achieves this by
+// retaining typed payloads on symbol-kind nodes; later changes
+// may shrink payloads to attribute maps as graph-native consumers
+// arrive in #98 / #99.
+package archgraph

--- a/internal/domain/archgraph/graph.go
+++ b/internal/domain/archgraph/graph.go
@@ -1,0 +1,233 @@
+package archgraph
+
+import (
+	"sort"
+
+	"github.com/kgatilin/archai/internal/domain"
+)
+
+// NodeKind classifies a Node in the architecture graph.
+type NodeKind string
+
+const (
+	NodeKindModule    NodeKind = "module"
+	NodeKindPackage   NodeKind = "package"
+	NodeKindFile      NodeKind = "file"
+	NodeKindInterface NodeKind = "interface"
+	NodeKindStruct    NodeKind = "struct"
+	NodeKindTypeDef   NodeKind = "typedef"
+	NodeKindFunction  NodeKind = "function"
+	NodeKindMethod    NodeKind = "method"
+	NodeKindField     NodeKind = "field"
+	NodeKindConst     NodeKind = "const"
+	NodeKindVar       NodeKind = "var"
+	NodeKindError     NodeKind = "error"
+	NodeKindExternal  NodeKind = "external"
+)
+
+// EdgeKind classifies an Edge in the architecture graph.
+type EdgeKind string
+
+const (
+	// Structural containment.
+	EdgeKindContains EdgeKind = "contains"
+
+	// Module-level import (package -> package import set).
+	EdgeKindImports EdgeKind = "imports"
+
+	// Symbol-level dependency edges. These mirror domain.DependencyKind
+	// 1:1 so projection back to []Dependency is lossless.
+	EdgeKindUses       EdgeKind = "uses"
+	EdgeKindReturns    EdgeKind = "returns"
+	EdgeKindImplements EdgeKind = "implements"
+	EdgeKindExtends    EdgeKind = "extends"
+	EdgeKindNestedIn   EdgeKind = "nested-in"
+
+	// Behavioral / annotation edges.
+	EdgeKindCalls           EdgeKind = "calls"
+	EdgeKindBelongsToLayer  EdgeKind = "belongs_to_layer"
+	EdgeKindBelongsToDomain EdgeKind = "belongs_to_domain"
+	EdgeKindHasRole         EdgeKind = "has_role"
+)
+
+// Node is a vertex in the architecture graph.
+type Node struct {
+	// ID is the stable, content-derived identifier (see doc.go).
+	ID string
+
+	// Kind classifies what this node represents.
+	Kind NodeKind
+
+	// Name is the human-readable label (e.g., the package or symbol
+	// name). Not necessarily unique; ID is.
+	Name string
+
+	// Package is the owning package path for symbol-kind nodes,
+	// empty for module / package / external nodes.
+	Package string
+
+	// File is the owning file basename for symbol-kind nodes when
+	// known, empty otherwise.
+	File string
+
+	// Attrs carries scalar metadata that is also derivable from
+	// Payload but kept here for graph-only consumers (browser /
+	// diagram code that wants attribute access without a type
+	// switch on Payload).
+	Attrs map[string]string
+
+	// Payload retains the original domain.* value (InterfaceDef,
+	// StructDef, FunctionDef, ...) for symbol-kind nodes so that
+	// ProjectPackages can reconstruct the input without fanning out
+	// every field into Attrs. For module/package/file/external
+	// nodes Payload is nil.
+	Payload any
+}
+
+// Edge is a directed relationship between two nodes.
+type Edge struct {
+	// ID is the stable, content-derived identifier (see doc.go).
+	ID string
+
+	// Kind classifies the relationship.
+	Kind EdgeKind
+
+	// From is the source node id.
+	From string
+
+	// To is the target node id.
+	To string
+
+	// Attrs carries scalar metadata (e.g., "through_exported": "true"
+	// for symbol dependencies, "via": "<interface>" for interface
+	// dispatched calls).
+	Attrs map[string]string
+}
+
+// Graph is the bag of nodes and edges produced by BuildGraph. It is
+// immutable by convention (callers may inspect but not mutate). Two
+// Graphs are equal iff their node id set, edge id set, and per-node /
+// per-edge attribute sets match.
+type Graph struct {
+	// ModuleID is the id of the single module node, or "" if no
+	// module context was supplied to BuildGraph.
+	ModuleID string
+
+	// Nodes are sorted by ID for deterministic iteration.
+	Nodes []Node
+
+	// Edges are sorted by ID for deterministic iteration.
+	Edges []Edge
+
+	// implPayloads / depPayloads / callPayloads are unexported side
+	// tables that let ProjectPackages reconstruct the input slices
+	// exactly. Graph-native consumers (browser, diagrams, MCP) do
+	// not need them; they exist solely to prove the graph carries
+	// every field of the input PackageModel. As follow-ups #98 / #99
+	// migrate callers, these may shrink or disappear.
+	implPayloads map[string]domain.Implementation
+	depPayloads  map[string]domain.Dependency
+	callPayloads map[string]callPayload
+}
+
+// NodeByID returns the node with the given id and a found flag.
+// O(log n) over the sorted Nodes slice.
+func (g *Graph) NodeByID(id string) (Node, bool) {
+	i := sort.Search(len(g.Nodes), func(i int) bool {
+		return g.Nodes[i].ID >= id
+	})
+	if i < len(g.Nodes) && g.Nodes[i].ID == id {
+		return g.Nodes[i], true
+	}
+	return Node{}, false
+}
+
+// NodesByKind returns all nodes of the given kind in stable id order.
+func (g *Graph) NodesByKind(kind NodeKind) []Node {
+	var out []Node
+	for _, n := range g.Nodes {
+		if n.Kind == kind {
+			out = append(out, n)
+		}
+	}
+	return out
+}
+
+// EdgesFrom returns all edges originating at the given node id, in
+// stable id order.
+func (g *Graph) EdgesFrom(id string) []Edge {
+	var out []Edge
+	for _, e := range g.Edges {
+		if e.From == id {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// EdgesByKind returns all edges of the given kind in stable id order.
+func (g *Graph) EdgesByKind(kind EdgeKind) []Edge {
+	var out []Edge
+	for _, e := range g.Edges {
+		if e.Kind == kind {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// payloadInterface extracts an InterfaceDef payload from a node.
+func payloadInterface(n Node) (domain.InterfaceDef, bool) {
+	if v, ok := n.Payload.(domain.InterfaceDef); ok {
+		return v, true
+	}
+	return domain.InterfaceDef{}, false
+}
+
+// payloadStruct extracts a StructDef payload from a node.
+func payloadStruct(n Node) (domain.StructDef, bool) {
+	if v, ok := n.Payload.(domain.StructDef); ok {
+		return v, true
+	}
+	return domain.StructDef{}, false
+}
+
+// payloadFunction extracts a FunctionDef payload from a node.
+func payloadFunction(n Node) (domain.FunctionDef, bool) {
+	if v, ok := n.Payload.(domain.FunctionDef); ok {
+		return v, true
+	}
+	return domain.FunctionDef{}, false
+}
+
+// payloadTypeDef extracts a TypeDef payload from a node.
+func payloadTypeDef(n Node) (domain.TypeDef, bool) {
+	if v, ok := n.Payload.(domain.TypeDef); ok {
+		return v, true
+	}
+	return domain.TypeDef{}, false
+}
+
+// payloadConst extracts a ConstDef payload from a node.
+func payloadConst(n Node) (domain.ConstDef, bool) {
+	if v, ok := n.Payload.(domain.ConstDef); ok {
+		return v, true
+	}
+	return domain.ConstDef{}, false
+}
+
+// payloadVar extracts a VarDef payload from a node.
+func payloadVar(n Node) (domain.VarDef, bool) {
+	if v, ok := n.Payload.(domain.VarDef); ok {
+		return v, true
+	}
+	return domain.VarDef{}, false
+}
+
+// payloadError extracts an ErrorDef payload from a node.
+func payloadError(n Node) (domain.ErrorDef, bool) {
+	if v, ok := n.Payload.(domain.ErrorDef); ok {
+		return v, true
+	}
+	return domain.ErrorDef{}, false
+}

--- a/internal/domain/archgraph/graph_test.go
+++ b/internal/domain/archgraph/graph_test.go
@@ -1,0 +1,344 @@
+package archgraph_test
+
+import (
+	"context"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"testing"
+
+	"github.com/kgatilin/archai/internal/adapter/golang"
+	"github.com/kgatilin/archai/internal/domain"
+	"github.com/kgatilin/archai/internal/domain/archgraph"
+)
+
+// synthModule returns a small handwritten []domain.PackageModel that
+// exercises every field projection has to round-trip: packages with
+// interfaces, structs (fields + methods), functions (with calls),
+// type defs, constants, variables, errors, dependencies, and
+// implementations. Avoids the Go reader so the test isn't coupled
+// to live source.
+func synthModule() []domain.PackageModel {
+	pkgA := "example.com/m/internal/svc"
+	pkgB := "example.com/m/internal/repo"
+
+	contextRef := domain.TypeRef{Name: "Context", Package: "context"}
+	userRef := domain.TypeRef{Name: "User", Package: pkgA, IsPointer: true}
+	errRef := domain.TypeRef{Name: "error"}
+
+	userStruct := domain.StructDef{
+		Name:       "User",
+		IsExported: true,
+		SourceFile: "user.go",
+		Doc:        "User is the aggregate root.",
+		Stereotype: domain.StereotypeAggregate,
+		Fields: []domain.FieldDef{
+			{Name: "ID", Type: domain.TypeRef{Name: "string"}, IsExported: true, Tag: `json:"id"`},
+			{Name: "name", Type: domain.TypeRef{Name: "string"}},
+		},
+		Methods: []domain.MethodDef{
+			{
+				Name:       "Rename",
+				IsExported: true,
+				Params:     []domain.ParamDef{{Name: "n", Type: domain.TypeRef{Name: "string"}}},
+				Returns:    []domain.TypeRef{errRef},
+			},
+		},
+	}
+
+	userService := domain.InterfaceDef{
+		Name:       "UserService",
+		IsExported: true,
+		SourceFile: "service.go",
+		Doc:        "UserService manages users.",
+		Stereotype: domain.StereotypeService,
+		Methods: []domain.MethodDef{
+			{
+				Name:       "Get",
+				IsExported: true,
+				Params: []domain.ParamDef{
+					{Name: "ctx", Type: contextRef},
+					{Name: "id", Type: domain.TypeRef{Name: "string"}},
+				},
+				Returns: []domain.TypeRef{userRef, errRef},
+				Calls: []domain.CallEdge{
+					{To: domain.SymbolRef{Package: pkgB, Symbol: "Repository.Find"}},
+				},
+			},
+		},
+	}
+
+	newUserService := domain.FunctionDef{
+		Name:       "NewUserService",
+		IsExported: true,
+		SourceFile: "factory.go",
+		Doc:        "NewUserService is a constructor.",
+		Stereotype: domain.StereotypeFactory,
+		Params:     []domain.ParamDef{{Name: "r", Type: domain.TypeRef{Name: "Repository", Package: pkgB}}},
+		Returns:    []domain.TypeRef{{Name: "UserService", Package: pkgA}},
+		Calls: []domain.CallEdge{
+			{To: domain.SymbolRef{Package: pkgA, Symbol: "userServiceImpl.init"}},
+		},
+	}
+
+	status := domain.TypeDef{
+		Name:           "Status",
+		UnderlyingType: domain.TypeRef{Name: "string"},
+		Constants:      []string{"StatusActive", "StatusInactive"},
+		IsExported:     true,
+		SourceFile:     "status.go",
+		Stereotype:     domain.StereotypeEnum,
+	}
+
+	pkgAModel := domain.PackageModel{
+		Path:       pkgA,
+		Name:       "svc",
+		Layer:      "application",
+		Aggregate:  "User",
+		Structs:    []domain.StructDef{userStruct},
+		Interfaces: []domain.InterfaceDef{userService},
+		Functions:  []domain.FunctionDef{newUserService},
+		TypeDefs:   []domain.TypeDef{status},
+		Constants: []domain.ConstDef{
+			{Name: "DefaultPageSize", Type: domain.TypeRef{Name: "int"}, Value: "20", IsExported: true, SourceFile: "config.go"},
+		},
+		Variables: []domain.VarDef{
+			{Name: "DefaultTimeout", Type: domain.TypeRef{Name: "Duration", Package: "time"}, IsExported: true, SourceFile: "config.go"},
+		},
+		Errors: []domain.ErrorDef{
+			{Name: "ErrNotFound", Message: "user not found", IsExported: true, SourceFile: "errors.go"},
+		},
+		Dependencies: []domain.Dependency{
+			{
+				From:            domain.SymbolRef{Package: pkgA, File: "service.go", Symbol: "UserService"},
+				To:              domain.SymbolRef{Package: pkgB, File: "repository.go", Symbol: "Repository"},
+				Kind:            domain.DependencyUses,
+				ThroughExported: true,
+			},
+		},
+		Implementations: []domain.Implementation{
+			{
+				Concrete:  domain.SymbolRef{Package: pkgA, File: "service.go", Symbol: "userServiceImpl"},
+				Interface: domain.SymbolRef{Package: pkgA, File: "service.go", Symbol: "UserService"},
+				IsPointer: true,
+			},
+		},
+	}
+
+	pkgBModel := domain.PackageModel{
+		Path:  pkgB,
+		Name:  "repo",
+		Layer: "adapter",
+		Interfaces: []domain.InterfaceDef{
+			{
+				Name:       "Repository",
+				IsExported: true,
+				SourceFile: "repository.go",
+				Stereotype: domain.StereotypeRepository,
+				Methods: []domain.MethodDef{
+					{
+						Name:       "Find",
+						IsExported: true,
+						Params: []domain.ParamDef{
+							{Name: "ctx", Type: contextRef},
+							{Name: "id", Type: domain.TypeRef{Name: "string"}},
+						},
+						Returns: []domain.TypeRef{userRef, errRef},
+					},
+				},
+			},
+		},
+	}
+
+	return []domain.PackageModel{pkgAModel, pkgBModel}
+}
+
+// TestBuildGraph_FromFixture builds a graph from the live archai
+// codebase via the Go reader and asserts non-zero counts for every
+// major node kind. This is the closest thing to a "from a small Go
+// module" fixture without inventing a new testdata tree.
+func TestBuildGraph_FromFixture(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration-style read of archai sources skipped in -short")
+	}
+	repoRoot := repoRootFromTest(t)
+	reader := golang.NewReader()
+	models, err := reader.Read(context.Background(), []string{filepath.Join(repoRoot, "internal", "domain", "...")})
+	if err != nil {
+		t.Fatalf("reader.Read: %v", err)
+	}
+	if len(models) == 0 {
+		t.Fatalf("reader returned no packages")
+	}
+
+	g, err := archgraph.BuildGraph(models, &domain.Module{Path: "github.com/kgatilin/archai"})
+	if err != nil {
+		t.Fatalf("BuildGraph: %v", err)
+	}
+
+	counts := map[archgraph.NodeKind]int{}
+	for _, n := range g.Nodes {
+		counts[n.Kind]++
+	}
+
+	for _, kind := range []archgraph.NodeKind{
+		archgraph.NodeKindPackage,
+		archgraph.NodeKindStruct,
+		archgraph.NodeKindFunction,
+		archgraph.NodeKindFile,
+	} {
+		if counts[kind] == 0 {
+			t.Errorf("expected non-zero nodes of kind %s, got 0", kind)
+		}
+	}
+	if g.ModuleID == "" {
+		t.Errorf("expected module node id to be set when Module was passed")
+	}
+	if len(g.Edges) == 0 {
+		t.Fatalf("expected edges, got 0")
+	}
+}
+
+// TestProjectPackages_RoundTrip — BuildGraph then ProjectPackages
+// reconstructs the input modulo deterministic sort order.
+func TestProjectPackages_RoundTrip(t *testing.T) {
+	in := synthModule()
+	g, err := archgraph.BuildGraph(in, &domain.Module{Path: "example.com/m"})
+	if err != nil {
+		t.Fatalf("BuildGraph: %v", err)
+	}
+	out := g.ProjectPackages()
+	want := archgraph.NormalizePackages(in)
+
+	if !reflect.DeepEqual(out, want) {
+		t.Fatalf("round-trip mismatch.\nwant: %#v\ngot:  %#v", want, out)
+	}
+}
+
+// TestGraphIDs_AreStable — building the same graph twice on the same
+// input yields identical id sets and edge sets.
+func TestGraphIDs_AreStable(t *testing.T) {
+	in := synthModule()
+	g1, err := archgraph.BuildGraph(in, &domain.Module{Path: "example.com/m"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	g2, err := archgraph.BuildGraph(in, &domain.Module{Path: "example.com/m"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(g1.Nodes) != len(g2.Nodes) {
+		t.Fatalf("node count drift: %d vs %d", len(g1.Nodes), len(g2.Nodes))
+	}
+	for i := range g1.Nodes {
+		if g1.Nodes[i].ID != g2.Nodes[i].ID {
+			t.Fatalf("node id drift at %d: %q vs %q", i, g1.Nodes[i].ID, g2.Nodes[i].ID)
+		}
+		if g1.Nodes[i].Kind != g2.Nodes[i].Kind {
+			t.Fatalf("node kind drift at %s: %s vs %s", g1.Nodes[i].ID, g1.Nodes[i].Kind, g2.Nodes[i].Kind)
+		}
+	}
+	if len(g1.Edges) != len(g2.Edges) {
+		t.Fatalf("edge count drift: %d vs %d", len(g1.Edges), len(g2.Edges))
+	}
+	for i := range g1.Edges {
+		if g1.Edges[i].ID != g2.Edges[i].ID {
+			t.Fatalf("edge id drift at %d: %q vs %q", i, g1.Edges[i].ID, g2.Edges[i].ID)
+		}
+	}
+}
+
+// TestContainmentEdges — package contains files; file contains
+// types/functions; type contains methods/fields.
+func TestContainmentEdges(t *testing.T) {
+	in := synthModule()
+	g, err := archgraph.BuildGraph(in, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pkgID := archgraph.PackageID("example.com/m/internal/svc")
+	fileID := archgraph.FileID("example.com/m/internal/svc", "user.go")
+	structID := archgraph.TypeID("example.com/m/internal/svc", "User")
+	methodID := archgraph.MethodID("example.com/m/internal/svc", "User", "Rename")
+	fieldID := archgraph.FieldID("example.com/m/internal/svc", "User", "ID")
+
+	if !hasEdge(g, pkgID, fileID, archgraph.EdgeKindContains) {
+		t.Errorf("expected package->file contains edge")
+	}
+	if !hasEdge(g, fileID, structID, archgraph.EdgeKindContains) {
+		t.Errorf("expected file->struct contains edge")
+	}
+	if !hasEdge(g, pkgID, structID, archgraph.EdgeKindContains) {
+		t.Errorf("expected package->struct contains edge")
+	}
+	if !hasEdge(g, structID, methodID, archgraph.EdgeKindContains) {
+		t.Errorf("expected struct->method contains edge")
+	}
+	if !hasEdge(g, structID, fieldID, archgraph.EdgeKindContains) {
+		t.Errorf("expected struct->field contains edge")
+	}
+}
+
+// TestDependencyEdges — verify uses, implements, and calls edges
+// land in the graph as expected.
+func TestDependencyEdges(t *testing.T) {
+	in := synthModule()
+	g, err := archgraph.BuildGraph(in, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Implements: userServiceImpl => UserService
+	implFrom := archgraph.TypeID("example.com/m/internal/svc", "userServiceImpl")
+	implTo := archgraph.TypeID("example.com/m/internal/svc", "UserService")
+	if !hasEdge(g, implFrom, implTo, archgraph.EdgeKindImplements) {
+		t.Errorf("expected implements edge userServiceImpl=>UserService")
+	}
+
+	// Uses: UserService -> Repository
+	usesFrom := archgraph.TypeID("example.com/m/internal/svc", "UserService")
+	usesTo := archgraph.TypeID("example.com/m/internal/repo", "Repository")
+	if !hasEdge(g, usesFrom, usesTo, archgraph.EdgeKindUses) {
+		t.Errorf("expected uses edge UserService->Repository")
+	}
+
+	// Calls: NewUserService -> userServiceImpl.init
+	callFrom := archgraph.FunctionID("example.com/m/internal/svc", "NewUserService")
+	hasCall := false
+	for _, e := range g.EdgesFrom(callFrom) {
+		if e.Kind == archgraph.EdgeKindCalls {
+			hasCall = true
+			break
+		}
+	}
+	if !hasCall {
+		t.Errorf("expected at least one calls edge from NewUserService")
+	}
+}
+
+func hasEdge(g *archgraph.Graph, from, to string, kind archgraph.EdgeKind) bool {
+	for _, e := range g.Edges {
+		if e.From == from && e.To == to && e.Kind == kind {
+			return true
+		}
+	}
+	return false
+}
+
+// repoRootFromTest walks up from the test file location to find the
+// archai repo root (containing go.mod). Returns the absolute path.
+func repoRootFromTest(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatalf("runtime.Caller failed")
+	}
+	// file is .../internal/domain/archgraph/graph_test.go;
+	// repo root is three dirs up.
+	dir := filepath.Dir(file)
+	for i := 0; i < 3; i++ {
+		dir = filepath.Dir(dir)
+	}
+	return dir
+}

--- a/internal/domain/archgraph/ids.go
+++ b/internal/domain/archgraph/ids.go
@@ -1,0 +1,73 @@
+package archgraph
+
+import (
+	"fmt"
+)
+
+// ModuleID returns the stable id for a module node.
+func ModuleID(modulePath string) string {
+	return "mod:" + modulePath
+}
+
+// PackageID returns the stable id for a package node.
+func PackageID(pkgPath string) string {
+	return "pkg:" + pkgPath
+}
+
+// FileID returns the stable id for a file node.
+func FileID(pkgPath, base string) string {
+	return "file:" + pkgPath + "/" + base
+}
+
+// TypeID returns the stable id for an interface / struct / typedef
+// node. The scheme is shared across all three because they live in
+// the same package-level type namespace.
+func TypeID(pkgPath, name string) string {
+	return "type:" + pkgPath + "." + name
+}
+
+// FunctionID returns the stable id for a package-level function.
+func FunctionID(pkgPath, name string) string {
+	return "fn:" + pkgPath + "." + name
+}
+
+// MethodID returns the stable id for a method on a struct or
+// interface.
+func MethodID(pkgPath, recv, name string) string {
+	return "method:" + pkgPath + "." + recv + "." + name
+}
+
+// FieldID returns the stable id for a field on a struct.
+func FieldID(pkgPath, structName, fieldName string) string {
+	return "field:" + pkgPath + "." + structName + "." + fieldName
+}
+
+// ConstID returns the stable id for a package-level constant.
+func ConstID(pkgPath, name string) string {
+	return "const:" + pkgPath + "." + name
+}
+
+// VarID returns the stable id for a package-level variable.
+func VarID(pkgPath, name string) string {
+	return "var:" + pkgPath + "." + name
+}
+
+// ErrorID returns the stable id for a sentinel error.
+func ErrorID(pkgPath, name string) string {
+	return "err:" + pkgPath + "." + name
+}
+
+// ExternalID returns the stable id for a symbol outside the loaded
+// module set.
+func ExternalID(pkg, name string) string {
+	if pkg == "" {
+		return "ext:" + name
+	}
+	return "ext:" + pkg + "." + name
+}
+
+// edgeID composes an edge id from kind and endpoints. Keeping this
+// helper internal so all edge ids are formatted identically.
+func edgeID(kind EdgeKind, from, to string) string {
+	return fmt.Sprintf("%s:%s->%s", string(kind), from, to)
+}

--- a/internal/domain/archgraph/project.go
+++ b/internal/domain/archgraph/project.go
@@ -1,0 +1,285 @@
+package archgraph
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/kgatilin/archai/internal/domain"
+)
+
+// ProjectPackages reconstructs a []domain.PackageModel slice from
+// the graph. Round-trip property: for any models input, BuildGraph
+// followed by ProjectPackages returns an equivalent slice modulo
+// the deterministic sort order applied below.
+//
+// Equivalence is defined by domain field equality on every field
+// of PackageModel — projection consumes the typed Payload on each
+// symbol-kind node and the side-table payloads stashed on the Graph
+// for Dependencies / Implementations / Calls.
+func (g *Graph) ProjectPackages() []domain.PackageModel {
+	// Index nodes by package path.
+	pkgs := make(map[string]*domain.PackageModel)
+	pkgOrder := make([]string, 0)
+
+	for _, n := range g.Nodes {
+		if n.Kind != NodeKindPackage {
+			continue
+		}
+		p := &domain.PackageModel{
+			Path:      n.Package,
+			Name:      n.Name,
+			Layer:     n.Attrs["layer"],
+			Aggregate: n.Attrs["aggregate"],
+		}
+		pkgs[n.Package] = p
+		pkgOrder = append(pkgOrder, n.Package)
+	}
+
+	// Walk symbol-kind nodes and append to their owning package's
+	// slice. We pre-bucket interface/struct method+field payloads
+	// because those live on the containing type, not as standalone
+	// slice entries on PackageModel.
+	for _, n := range g.Nodes {
+		p, ok := pkgs[n.Package]
+		if !ok {
+			continue
+		}
+		switch n.Kind {
+		case NodeKindInterface:
+			if v, ok := payloadInterface(n); ok {
+				p.Interfaces = append(p.Interfaces, v)
+			}
+		case NodeKindStruct:
+			if v, ok := payloadStruct(n); ok {
+				p.Structs = append(p.Structs, v)
+			}
+		case NodeKindTypeDef:
+			if v, ok := payloadTypeDef(n); ok {
+				p.TypeDefs = append(p.TypeDefs, v)
+			}
+		case NodeKindFunction:
+			if v, ok := payloadFunction(n); ok {
+				p.Functions = append(p.Functions, v)
+			}
+		case NodeKindConst:
+			if v, ok := payloadConst(n); ok {
+				p.Constants = append(p.Constants, v)
+			}
+		case NodeKindVar:
+			if v, ok := payloadVar(n); ok {
+				p.Variables = append(p.Variables, v)
+			}
+		case NodeKindError:
+			if v, ok := payloadError(n); ok {
+				p.Errors = append(p.Errors, v)
+			}
+		}
+	}
+
+	// Restore Dependencies on each owning package from the side
+	// table. Side-table keys carry the original "from" package id
+	// implicitly via the edge.From node id — we re-parse the package
+	// out of From.
+	for _, d := range g.depPayloads {
+		p, ok := pkgs[d.From.Package]
+		if !ok {
+			// Dependencies whose owning package wasn't a loaded
+			// package can't be projected; this matches the
+			// expectation that PackageModel.Dependencies only
+			// contains edges owned by that package.
+			continue
+		}
+		p.Dependencies = append(p.Dependencies, d)
+	}
+
+	// Restore Implementations on each interface-side package.
+	for _, impl := range g.implPayloads {
+		p, ok := pkgs[impl.Interface.Package]
+		if !ok {
+			continue
+		}
+		p.Implementations = append(p.Implementations, impl)
+	}
+
+	// Restore Calls on functions / methods inside packages.
+	for _, cp := range g.callPayloads {
+		owner, name, recv := parseCallerID(cp.fromID)
+		p, ok := pkgs[owner]
+		if !ok {
+			continue
+		}
+		if recv == "" {
+			// package-level function
+			for i := range p.Functions {
+				if p.Functions[i].Name == name {
+					p.Functions[i].Calls = append(p.Functions[i].Calls, cp.edge)
+					break
+				}
+			}
+			continue
+		}
+		// method on struct or interface
+		matched := false
+		for i := range p.Structs {
+			if p.Structs[i].Name != recv {
+				continue
+			}
+			for j := range p.Structs[i].Methods {
+				if p.Structs[i].Methods[j].Name == name {
+					p.Structs[i].Methods[j].Calls = append(p.Structs[i].Methods[j].Calls, cp.edge)
+					matched = true
+					break
+				}
+			}
+			if matched {
+				break
+			}
+		}
+		if matched {
+			continue
+		}
+		for i := range p.Interfaces {
+			if p.Interfaces[i].Name != recv {
+				continue
+			}
+			for j := range p.Interfaces[i].Methods {
+				if p.Interfaces[i].Methods[j].Name == name {
+					p.Interfaces[i].Methods[j].Calls = append(p.Interfaces[i].Methods[j].Calls, cp.edge)
+					break
+				}
+			}
+			break
+		}
+	}
+
+	// Final deterministic ordering.
+	sort.Strings(pkgOrder)
+	out := make([]domain.PackageModel, 0, len(pkgOrder))
+	for _, path := range pkgOrder {
+		p := pkgs[path]
+		normalizePackage(p)
+		out = append(out, *p)
+	}
+	return out
+}
+
+// parseCallerID splits a function or method id into (package, name,
+// receiver). For a function id "fn:pkg.X" it returns (pkg, X, "").
+// For a method id "method:pkg.Recv.M" it returns (pkg, M, Recv).
+// Unknown ids return zero values.
+func parseCallerID(id string) (pkg, name, recv string) {
+	switch {
+	case strings.HasPrefix(id, "fn:"):
+		rest := strings.TrimPrefix(id, "fn:")
+		// rest is "<pkg>.<name>", split on the LAST dot because
+		// package paths may contain dots (rare but allowed).
+		idx := strings.LastIndex(rest, ".")
+		if idx <= 0 {
+			return "", rest, ""
+		}
+		return rest[:idx], rest[idx+1:], ""
+	case strings.HasPrefix(id, "method:"):
+		rest := strings.TrimPrefix(id, "method:")
+		// rest is "<pkg>.<recv>.<name>". Split off the last two
+		// dotted segments. The package can contain dots, so we walk
+		// from the right.
+		idxName := strings.LastIndex(rest, ".")
+		if idxName <= 0 {
+			return "", "", ""
+		}
+		head := rest[:idxName]
+		name = rest[idxName+1:]
+		idxRecv := strings.LastIndex(head, ".")
+		if idxRecv <= 0 {
+			return "", name, head
+		}
+		return head[:idxRecv], name, head[idxRecv+1:]
+	}
+	return "", "", ""
+}
+
+// normalizePackage sorts each slice on a PackageModel in a stable,
+// content-derived order. This is what makes round-trip work: the
+// same package projected twice yields the same field values in the
+// same order.
+func normalizePackage(p *domain.PackageModel) {
+	sort.SliceStable(p.Interfaces, func(i, j int) bool {
+		return p.Interfaces[i].Name < p.Interfaces[j].Name
+	})
+	for i := range p.Interfaces {
+		sortMethods(p.Interfaces[i].Methods)
+	}
+	sort.SliceStable(p.Structs, func(i, j int) bool {
+		return p.Structs[i].Name < p.Structs[j].Name
+	})
+	for i := range p.Structs {
+		sort.SliceStable(p.Structs[i].Fields, func(a, b int) bool {
+			return p.Structs[i].Fields[a].Name < p.Structs[i].Fields[b].Name
+		})
+		sortMethods(p.Structs[i].Methods)
+	}
+	sort.SliceStable(p.Functions, func(i, j int) bool {
+		return p.Functions[i].Name < p.Functions[j].Name
+	})
+	for i := range p.Functions {
+		sortCalls(p.Functions[i].Calls)
+	}
+	sort.SliceStable(p.TypeDefs, func(i, j int) bool {
+		return p.TypeDefs[i].Name < p.TypeDefs[j].Name
+	})
+	sort.SliceStable(p.Constants, func(i, j int) bool {
+		return p.Constants[i].Name < p.Constants[j].Name
+	})
+	sort.SliceStable(p.Variables, func(i, j int) bool {
+		return p.Variables[i].Name < p.Variables[j].Name
+	})
+	sort.SliceStable(p.Errors, func(i, j int) bool {
+		return p.Errors[i].Name < p.Errors[j].Name
+	})
+	sort.SliceStable(p.Dependencies, func(i, j int) bool {
+		return depKey(p.Dependencies[i]) < depKey(p.Dependencies[j])
+	})
+	sort.SliceStable(p.Implementations, func(i, j int) bool {
+		return implKey(p.Implementations[i]) < implKey(p.Implementations[j])
+	})
+}
+
+func sortMethods(ms []domain.MethodDef) {
+	sort.SliceStable(ms, func(i, j int) bool {
+		return ms[i].Name < ms[j].Name
+	})
+	for i := range ms {
+		sortCalls(ms[i].Calls)
+	}
+}
+
+func sortCalls(cs []domain.CallEdge) {
+	sort.SliceStable(cs, func(i, j int) bool {
+		ki := cs[i].To.QualifiedName() + "|" + cs[i].Via
+		kj := cs[j].To.QualifiedName() + "|" + cs[j].Via
+		return ki < kj
+	})
+}
+
+func depKey(d domain.Dependency) string {
+	return d.From.QualifiedName() + "->" + d.To.QualifiedName() + ":" + string(d.Kind)
+}
+
+func implKey(i domain.Implementation) string {
+	return i.Concrete.QualifiedName() + "=>" + i.Interface.QualifiedName()
+}
+
+// NormalizePackages applies the same deterministic ordering used
+// internally by ProjectPackages to an input slice, so callers can
+// compare BuildGraph round-trips against the original input.
+func NormalizePackages(models []domain.PackageModel) []domain.PackageModel {
+	out := make([]domain.PackageModel, len(models))
+	copy(out, models)
+	sort.SliceStable(out, func(i, j int) bool {
+		return out[i].Path < out[j].Path
+	})
+	for i := range out {
+		normalizePackage(&out[i])
+	}
+	return out
+}


### PR DESCRIPTION
## Summary

Introduces `internal/domain/archgraph`, a new graph-shaped read model for archai's analyzed codebase. Nodes cover modules, packages, files, interfaces, structs, type defs, functions, methods, fields, constants, variables, errors, externals, and synthetic role / layer / domain annotation targets. Edges cover containment, the five dependency kinds (uses / returns / implements / extends / nested-in), calls, and overlay annotations (`belongs_to_layer`, `belongs_to_domain`, `has_role`). IDs are stable, content-derived strings sharing the prefix vocabulary used by `internal/adapter/archmotif` (`pkg:`, `type:`, `fn:`, `method:`, `field:`, ...) so a single id namespace covers both internal projections and the existing external archmotif export.

## Scope

Additive only — no callers wired yet (#98 / #99 follow-ups). The new package is exercised purely by tests in this PR; no existing reader, writer, service, or browser code is changed. `domain` does not import `archgraph` — the one-way dependency is enforced.

## Round-trip

`BuildGraph(models, mod)` followed by `Graph.ProjectPackages()` matches the original `[]domain.PackageModel` modulo deterministic ordering (`reflect.DeepEqual` against `archgraph.NormalizePackages(input)`). See `TestProjectPackages_RoundTrip`. Symbol-kind nodes retain their typed `domain.*Def` payloads and Dependencies / Implementations / Calls are side-tabled per edge id, so projection is lossless without requiring callers to walk attribute maps.

## Out of scope

Browser wiring, diagram generation, MCP exposure, and graph-driven service paths — those are #98 and #99.

## Test plan

- [x] `TestBuildGraph_FromFixture` — reads archai's own `internal/domain/...` packages via `golang.NewReader`, asserts non-zero package / struct / function / file node counts and a non-empty edge set.
- [x] `TestProjectPackages_RoundTrip` — synthetic two-package module with every field populated; build + project yields `DeepEqual` match against the normalized input.
- [x] `TestGraphIDs_AreStable` — two builds on the same input produce identical node id / kind sequences and identical edge id sequences.
- [x] `TestContainmentEdges` — pkg→file, pkg→struct, file→struct, struct→field, struct→method.
- [x] `TestDependencyEdges` — `implements`, `uses`, and `calls` edges emitted from the corresponding `Implementations` / `Dependencies` / `Calls` inputs.
- [x] `go test ./...` — full suite green on the worktree.
- [x] `go vet ./...` — clean.
- [x] `gofmt -l internal/domain/archgraph/` — empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)